### PR TITLE
test(audit): cover empty audit presentation values

### DIFF
--- a/web/src/pages/ops/__tests__/auditPresentation.test.ts
+++ b/web/src/pages/ops/__tests__/auditPresentation.test.ts
@@ -161,3 +161,11 @@ describe('audit presentation helpers', () => {
     expect(isControlPlaneAuditRecord({ operationType: 'SEND_MESSAGE' })).toBe(false);
   });
 });
+
+describe('audit presentation empty values', () => {
+  it('treats blank codes and details as empty presentation values', () => {
+    expect(normalizeAuditCode('  ')).toBe('');
+    expect(formatAuditCode(undefined)).toBe('-');
+    expect(parseAuditDetail('  ')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Add a focused Vitest regression case for empty audit presentation values.

## Root cause
The current test suite does not cover empty audit presentation values, so the behavior could regress without a failing test.

## Changes
- Add regression coverage in $(@{Slug=audit-empty-values; Focus=empty audit presentation values; PrTitle=test(audit): cover empty audit presentation values; TestFile=web/src/pages/ops/__tests__/auditPresentation.test.ts; Mode=existing; Append=describe('audit presentation empty values', () => {
  it('treats blank codes and details as empty presentation values', () => {
    expect(normalizeAuditCode('  ')).toBe('');
    expect(formatAuditCode(undefined)).toBe('-');
    expect(parseAuditDetail('  ')).toEqual([]);
  });
});}.TestFile).

## Testing
Commands run:
- cd web
- 
px vitest run src/pages/ops/__tests__/auditPresentation.test.ts
- cd ..
- git diff --check

Actual results:
- Vitest: $testFilesLine, $testsLine.
- git diff --check: no output, exit code 0.

I did not run the full Maven/Java server suite on this Windows host because Maven is not installed and the server targets Java 21 while only Java 17 is available. This PR changes web test code only.

Fixes #4020

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100