### PR TITLE
test(consumer-group): cover an empty queue inventory

### DIFF
--- a/web/src/utils/consumerGroupDiagnostics.test.ts
+++ b/web/src/utils/consumerGroupDiagnostics.test.ts
@@ -155,3 +155,13 @@ describe('consumer group diagnostics', () => {
     );
   });
 });
+
+describe('consumer group diagnostics empty queue inventory', () => {
+  it('reports zero queue count when no queue progress is supplied', () => {
+    const diagnostics = analyzeConsumerGroupHealth(group(), [], [], {
+      now: '2026-08-31T12:01:00Z',
+    });
+
+    expect(diagnostics.summary.queueCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Add a focused Vitest regression case for empty consumer group queue inventory.

## Root cause
The current test suite does not cover empty consumer group queue inventory, so the behavior could regress without a failing test.

## Changes
- Add regression coverage in $(@{Slug=consumer-group-no-queues; Focus=empty consumer group queue inventory; PrTitle=test(consumer-group): cover an empty queue inventory; TestFile=web/src/utils/consumerGroupDiagnostics.test.ts; Mode=existing; Append=describe('consumer group diagnostics empty queue inventory', () => {
  it('reports zero queue count when no queue progress is supplied', () => {
    const diagnostics = analyzeConsumerGroupHealth(
      group(),
      [],
      [],
      { now: '2026-08-31T12:01:00Z' },
    );

    expect(diagnostics.summary.queueCount).toBe(0);
  });
});}.TestFile).

## Testing
Commands run:
- cd web
- 
px vitest run src/utils/consumerGroupDiagnostics.test.ts
- cd ..
- git diff --check

Actual results:
- Vitest: $testFilesLine, $testsLine.
- git diff --check: no output, exit code 0.

I did not run the full Maven/Java server suite on this Windows host because Maven is not installed and the server targets Java 21 while only Java 17 is available. This PR changes web test code only.

Fixes #4024

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100