### PR TITLE
test(alert-rules): cover legacy payload normalization

### DIFF
--- a/web/src/pages/ops/__tests__/alertRulePayload.test.ts
+++ b/web/src/pages/ops/__tests__/alertRulePayload.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  attachThresholdUnit,
+  normalizeDuration,
+  normalizeMetric,
+  thresholdUnits,
+} from '../alertRulePayload';
+
+describe('alert rule payload normalization', () => {
+  it('maps legacy Chinese metric labels to Prometheus metric names', () => {
+    expect(normalizeMetric('磁盘使用率')).toBe('rocketmq_disk_use_ratio');
+    expect(normalizeMetric('rocketmq_tps')).toBe('rocketmq_tps');
+  });
+
+  it('maps legacy Chinese duration labels to Prometheus durations', () => {
+    expect(normalizeDuration('1分钟')).toBe('1m');
+    expect(normalizeDuration('30分钟')).toBe('30m');
+    expect(normalizeDuration('45分钟')).toBe('45分钟');
+  });
+
+  it('attaches the metric threshold unit after normalization', () => {
+    expect(attachThresholdUnit({ metric: '磁盘使用率', duration: '1分钟', threshold: 80 })).toEqual(
+      {
+        metric: 'rocketmq_disk_use_ratio',
+        duration: '1m',
+        threshold: 80,
+        thresholdUnit: '%',
+      },
+    );
+    expect(thresholdUnits['rocketmq_consumer_lag_messages']).toBe('条');
+  });
+});


### PR DESCRIPTION
## Summary
Add a focused Vitest regression case for legacy alert rule payload normalization.

## Root cause
The current test suite does not cover legacy alert rule payload normalization, so the behavior could regress without a failing test.

## Changes
- Add regression coverage in $(@{Slug=alert-rule-payload; Focus=legacy alert rule payload normalization; PrTitle=test(alert-rules): cover legacy payload normalization; TestFile=web/src/pages/ops/__tests__/alertRulePayload.test.ts; Mode=new; Append=/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.
 * The ASF licenses this file to You under the Apache License, Version 2.0
 * (the "License"); you may not use this file except in compliance with
 * the License.  You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

import { describe, expect, it } from 'vitest';
import {
  attachThresholdUnit,
  normalizeDuration,
  normalizeMetric,
  thresholdUnits,
} from '../alertRulePayload';

describe('alert rule payload normalization', () => {
  it('maps legacy Chinese metric labels to Prometheus metric names', () => {
    expect(normalizeMetric('磁盘使用率')).toBe('rocketmq_disk_use_ratio');
    expect(normalizeMetric('rocketmq_tps')).toBe('rocketmq_tps');
  });

  it('maps legacy Chinese duration labels to Prometheus durations', () => {
    expect(normalizeDuration('1分钟')).toBe('1m');
    expect(normalizeDuration('30分钟')).toBe('30m');
    expect(normalizeDuration('45分钟')).toBe('45分钟');
  });

  it('attaches the metric threshold unit after normalization', () => {
    expect(
      attachThresholdUnit({ metric: '磁盘使用率', duration: '1分钟', threshold: 80 }),
    ).toEqual({
      metric: 'rocketmq_disk_use_ratio',
      duration: '1m',
      threshold: 80,
      thresholdUnit: '%',
    });
    expect(thresholdUnits['rocketmq_consumer_lag_messages']).toBe('条');
  });
});}.TestFile).

## Testing
Commands run:
- cd web
- 
px vitest run src/pages/ops/__tests__/alertRulePayload.test.ts
- cd ..
- git diff --check

Actual results:
- Vitest: $testFilesLine, $testsLine.
- git diff --check: no output, exit code 0.

I did not run the full Maven/Java server suite on this Windows host because Maven is not installed and the server targets Java 21 while only Java 17 is available. This PR changes web test code only.

Fixes #4028

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100