### PR TITLE
test(llm): cover failure result fallbacks

### DIFF
--- a/web/src/pages/studio/__tests__/llmFailureResult.test.ts
+++ b/web/src/pages/studio/__tests__/llmFailureResult.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildLlmFailureResult } from '../llmFailureResult';
+
+describe('buildLlmFailureResult', () => {
+  it('falls back to the caller message when the API result is missing', () => {
+    expect(buildLlmFailureResult(null, '连接失败')).toEqual({
+      success: false,
+      msg: '连接失败',
+      code: undefined,
+      hint: undefined,
+    });
+  });
+
+  it('prefers the API error message and preserves optional diagnostics', () => {
+    expect(
+      buildLlmFailureResult(
+        { status: 0, errMsg: 'invalid key', code: 'INVALID_KEY', hint: '检查密钥' },
+        '连接失败',
+      ),
+    ).toEqual({
+      success: false,
+      msg: 'invalid key',
+      code: 'INVALID_KEY',
+      hint: '检查密钥',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Add a focused Vitest regression case for LLM test failure result fallbacks.

## Root cause
The current test suite does not cover LLM test failure result fallbacks, so the behavior could regress without a failing test.

## Changes
- Add regression coverage in $(@{Slug=llm-failure-result; Focus=LLM test failure result fallbacks; PrTitle=test(llm): cover failure result fallbacks; TestFile=web/src/pages/studio/__tests__/llmFailureResult.test.ts; Mode=new; Append=/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.
 * The ASF licenses this file to You under the Apache License, Version 2.0
 * (the "License"); you may not use this file except in compliance with
 * the License.  You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

import { describe, expect, it } from 'vitest';
import { buildLlmFailureResult } from '../llmFailureResult';

describe('buildLlmFailureResult', () => {
  it('falls back to the caller message when the API result is missing', () => {
    expect(buildLlmFailureResult(null, '连接失败')).toEqual({
      success: false,
      msg: '连接失败',
      code: undefined,
      hint: undefined,
    });
  });

  it('prefers the API error message and preserves optional diagnostics', () => {
    expect(
      buildLlmFailureResult(
        { status: 0, errMsg: 'invalid key', code: 'INVALID_KEY', hint: '检查密钥' },
        '连接失败',
      ),
    ).toEqual({
      success: false,
      msg: 'invalid key',
      code: 'INVALID_KEY',
      hint: '检查密钥',
    });
  });
});}.TestFile).

## Testing
Commands run:
- cd web
- 
px vitest run src/pages/studio/__tests__/llmFailureResult.test.ts
- cd ..
- git diff --check

Actual results:
- Vitest: $testFilesLine, $testsLine.
- git diff --check: no output, exit code 0.

I did not run the full Maven/Java server suite on this Windows host because Maven is not installed and the server targets Java 21 while only Java 17 is available. This PR changes web test code only.

Fixes #4030

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100