### PR TITLE
test(llm): cover fallback model option resolution

### DIFF
--- a/web/src/pages/studio/__tests__/llmModelOptions.test.ts
+++ b/web/src/pages/studio/__tests__/llmModelOptions.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { FALLBACK_MODELS, fallbackModelOptions } from '../llmModelOptions';
+
+describe('fallbackModelOptions', () => {
+  it('returns provider fallbacks as value/label options', () => {
+    expect(fallbackModelOptions('openai')).toEqual(
+      FALLBACK_MODELS.openai.map((item) => ({ value: item, label: item })),
+    );
+  });
+
+  it('uses the current model for unknown providers when one is supplied', () => {
+    expect(fallbackModelOptions('custom', 'gpt-5.6-sol')).toEqual([
+      { value: 'gpt-5.6-sol', label: 'gpt-5.6-sol' },
+    ]);
+  });
+
+  it('returns an empty list for an unknown provider without a current model', () => {
+    expect(fallbackModelOptions('custom')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Add a focused Vitest regression case for LLM fallback model option resolution.

## Root cause
The current test suite does not cover LLM fallback model option resolution, so the behavior could regress without a failing test.

## Changes
- Add regression coverage in $(@{Slug=llm-model-options; Focus=LLM fallback model option resolution; PrTitle=test(llm): cover fallback model option resolution; TestFile=web/src/pages/studio/__tests__/llmModelOptions.test.ts; Mode=new; Append=/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.
 * The ASF licenses this file to You under the Apache License, Version 2.0
 * (the "License"); you may not use this file except in compliance with
 * the License.  You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

import { describe, expect, it } from 'vitest';
import { FALLBACK_MODELS, fallbackModelOptions } from '../llmModelOptions';

describe('fallbackModelOptions', () => {
  it('returns provider fallbacks as value/label options', () => {
    expect(fallbackModelOptions('openai')).toEqual(
      FALLBACK_MODELS.openai.map((item) => ({ value: item, label: item })),
    );
  });

  it('uses the current model for unknown providers when one is supplied', () => {
    expect(fallbackModelOptions('custom', 'gpt-5.6-sol')).toEqual([
      { value: 'gpt-5.6-sol', label: 'gpt-5.6-sol' },
    ]);
  });

  it('returns an empty list for an unknown provider without a current model', () => {
    expect(fallbackModelOptions('custom')).toEqual([]);
  });
});}.TestFile).

## Testing
Commands run:
- cd web
- 
px vitest run src/pages/studio/__tests__/llmModelOptions.test.ts
- cd ..
- git diff --check

Actual results:
- Vitest: $testFilesLine, $testsLine.
- git diff --check: no output, exit code 0.

I did not run the full Maven/Java server suite on this Windows host because Maven is not installed and the server targets Java 21 while only Java 17 is available. This PR changes web test code only.

Fixes #4032

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100