### PR TITLE
test(data-mode): cover the runtime data-mode service

### DIFF
--- a/web/src/services/__tests__/dataMode.test.ts
+++ b/web/src/services/__tests__/dataMode.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { useDataModeStore } from '../../stores/dataModeStore';
+import { isMockMode } from '../dataMode';
+
+describe('dataMode service', () => {
+  afterEach(() => {
+    useDataModeStore.setState({ useMock: false });
+    localStorage.clear();
+  });
+
+  it('reflects the runtime mock-data store flag', () => {
+    useDataModeStore.setState({ useMock: true });
+    expect(isMockMode()).toBe(true);
+
+    useDataModeStore.setState({ useMock: false });
+    expect(isMockMode()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Add a focused Vitest regression case for runtime data-mode service.

## Root cause
The current test suite does not cover runtime data-mode service, so the behavior could regress without a failing test.

## Changes
- Add regression coverage in $(@{Slug=data-mode; Focus=runtime data-mode service; PrTitle=test(data-mode): cover the runtime data-mode service; TestFile=web/src/services/__tests__/dataMode.test.ts; Mode=new; Append=/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.
 * The ASF licenses this file to You under the Apache License, Version 2.0
 * (the "License"); you may not use this file except in compliance with
 * the License.  You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

import { afterEach, describe, expect, it } from 'vitest';
import { useDataModeStore } from '../../stores/dataModeStore';
import { isMockMode } from '../dataMode';

describe('dataMode service', () => {
  afterEach(() => {
    useDataModeStore.setState({ useMock: false });
    localStorage.clear();
  });

  it('reflects the runtime mock-data store flag', () => {
    useDataModeStore.setState({ useMock: true });
    expect(isMockMode()).toBe(true);

    useDataModeStore.setState({ useMock: false });
    expect(isMockMode()).toBe(false);
  });
});}.TestFile).

## Testing
Commands run:
- cd web
- 
px vitest run src/services/__tests__/dataMode.test.ts
- cd ..
- git diff --check

Actual results:
- Vitest: $testFilesLine, $testsLine.
- git diff --check: no output, exit code 0.

I did not run the full Maven/Java server suite on this Windows host because Maven is not installed and the server targets Java 21 while only Java 17 is available. This PR changes web test code only.

Fixes #4036

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100