### PR TITLE
test(auth-store): cover auth session persistence

### DIFF
--- a/web/src/stores/__tests__/authStore.test.ts
+++ b/web/src/stores/__tests__/authStore.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import useAuthStore from '../authStore';
+
+describe('authStore', () => {
+  afterEach(() => {
+    useAuthStore.getState().logout();
+    localStorage.clear();
+  });
+
+  it('updates the in-memory session through login and logout', () => {
+    useAuthStore.getState().login('studio-admin', 7, true);
+    expect(useAuthStore.getState()).toMatchObject({
+      user: 'studio-admin',
+      userId: 7,
+      admin: true,
+    });
+
+    useAuthStore.getState().logout();
+    expect(useAuthStore.getState()).toMatchObject({
+      user: null,
+      userId: null,
+      admin: null,
+    });
+  });
+
+  it('persists display identity without a bearer token', () => {
+    useAuthStore.getState().login('studio-admin', 7, true);
+
+    expect(localStorage.getItem('rocketmq-studio-user')).toBe('studio-admin');
+    expect(localStorage.getItem('rocketmq-studio-user-id')).toBe('7');
+    expect(localStorage.getItem('rocketmq-studio-user-admin')).toBe('true');
+    expect(localStorage.getItem('token')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Add a focused Vitest regression case for auth store session persistence.

## Root cause
The current test suite does not cover auth store session persistence, so the behavior could regress without a failing test.

## Changes
- Add regression coverage in $(@{Slug=auth-store; Focus=auth store session persistence; PrTitle=test(auth-store): cover auth session persistence; TestFile=web/src/stores/__tests__/authStore.test.ts; Mode=new; Append=/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.
 * The ASF licenses this file to You under the Apache License, Version 2.0
 * (the "License"); you may not use this file except in compliance with
 * the License.  You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

import { afterEach, describe, expect, it } from 'vitest';
import useAuthStore from '../authStore';

describe('authStore', () => {
  afterEach(() => {
    useAuthStore.getState().logout();
    localStorage.clear();
  });

  it('updates the in-memory session through login and logout', () => {
    useAuthStore.getState().login('studio-admin', 7, true);
    expect(useAuthStore.getState()).toMatchObject({
      user: 'studio-admin',
      userId: 7,
      admin: true,
    });

    useAuthStore.getState().logout();
    expect(useAuthStore.getState()).toMatchObject({
      user: null,
      userId: null,
      admin: null,
    });
  });

  it('persists display identity without a bearer token', () => {
    useAuthStore.getState().login('studio-admin', 7, true);

    expect(localStorage.getItem('rocketmq-studio-user')).toBe('studio-admin');
    expect(localStorage.getItem('rocketmq-studio-user-id')).toBe('7');
    expect(localStorage.getItem('rocketmq-studio-user-admin')).toBe('true');
    expect(localStorage.getItem('token')).toBeNull();
  });
});}.TestFile).

## Testing
Commands run:
- cd web
- 
px vitest run src/stores/__tests__/authStore.test.ts
- cd ..
- git diff --check

Actual results:
- Vitest: $testFilesLine, $testsLine.
- git diff --check: no output, exit code 0.

I did not run the full Maven/Java server suite on this Windows host because Maven is not installed and the server targets Java 21 while only Java 17 is available. This PR changes web test code only.

Fixes #4038

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100