### PR TITLE
test(acl): cover enabled ACL with no plain access accounts

### DIFF
--- a/web/src/utils/aclRiskDiagnostics.test.ts
+++ b/web/src/utils/aclRiskDiagnostics.test.ts
@@ -170,3 +170,12 @@ describe('ACL risk diagnostics', () => {
     );
   });
 });
+
+describe('ACL risk diagnostics missing accounts', () => {
+  it('flags an enabled ACL with no plain access accounts as critical', () => {
+    const diagnostics = analyzeAclRisk(config({ accounts: [], accountCount: 0 }));
+
+    expect(diagnostics.summary.accountCount).toBe(0);
+    expect(diagnostics.issues.map((issue) => issue.code)).toContain('NO_PLAIN_ACCESS_ACCOUNTS');
+  });
+});


### PR DESCRIPTION
## Summary
Add a focused Vitest regression case for ACL diagnostics for enabled clusters without accounts.

## Root cause
The current test suite does not cover ACL diagnostics for enabled clusters without accounts, so the behavior could regress without a failing test.

## Changes
- Add regression coverage in $(@{Slug=acl-no-accounts; Focus=ACL diagnostics for enabled clusters without accounts; PrTitle=test(acl): cover enabled ACL with no plain access accounts; TestFile=web/src/utils/aclRiskDiagnostics.test.ts; Mode=existing; Append=describe('ACL risk diagnostics missing accounts', () => {
  it('flags an enabled ACL with no plain access accounts as critical', () => {
    const diagnostics = analyzeAclRisk(config({ accounts: [], accountCount: 0 }));

    expect(diagnostics.summary.accountCount).toBe(0);
    expect(diagnostics.issues.map((issue) => issue.code)).toContain('NO_PLAIN_ACCESS_ACCOUNTS');
  });
});}.TestFile).

## Testing
Commands run:
- cd web
- 
px vitest run src/utils/aclRiskDiagnostics.test.ts
- cd ..
- git diff --check

Actual results:
- Vitest: $testFilesLine, $testsLine.
- git diff --check: no output, exit code 0.

I did not run the full Maven/Java server suite on this Windows host because Maven is not installed and the server targets Java 21 while only Java 17 is available. This PR changes web test code only.

Fixes #4042

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100