### PR TITLE
test(message-properties): cover reserved property detection

### DIFF
--- a/web/src/utils/messagePayloadPreview.test.ts
+++ b/web/src/utils/messagePayloadPreview.test.ts
@@ -254,3 +254,11 @@ describe('messagePayloadPreview', () => {
     );
   });
 });
+
+describe('message reserved property detection', () => {
+  it('recognizes reserved message properties case-insensitively after trimming', () => {
+    expect(isReservedMessageProperty('tags')).toBe(true);
+    expect(isReservedMessageProperty('  UNIQ_KEY  ')).toBe(true);
+    expect(isReservedMessageProperty('tenant')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Add a focused Vitest regression case for reserved message property detection.

## Root cause
The current test suite does not cover reserved message property detection, so the behavior could regress without a failing test.

## Changes
- Add regression coverage in $(@{Slug=reserved-message-property; Focus=reserved message property detection; PrTitle=test(message-properties): cover reserved property detection; TestFile=web/src/utils/messagePayloadPreview.test.ts; Mode=existing; Append=describe('message reserved property detection', () => {
  it('recognizes reserved message properties case-insensitively after trimming', () => {
    expect(isReservedMessageProperty('tags')).toBe(true);
    expect(isReservedMessageProperty('  UNIQ_KEY  ')).toBe(true);
    expect(isReservedMessageProperty('tenant')).toBe(false);
  });
});}.TestFile).

## Testing
Commands run:
- cd web
- 
px vitest run src/utils/messagePayloadPreview.test.ts
- cd ..
- git diff --check

Actual results:
- Vitest: $testFilesLine, $testsLine.
- git diff --check: no output, exit code 0.

I did not run the full Maven/Java server suite on this Windows host because Maven is not installed and the server targets Java 21 while only Java 17 is available. This PR changes web test code only.

Fixes #4044

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100