### PR TITLE
test(metrics): cover optional data-source query credentials

### DIFF
--- a/web/src/api/metrics.test.ts
+++ b/web/src/api/metrics.test.ts
@@ -205,3 +205,22 @@ describe('metrics API', () => {
     await expect(result.text()).resolves.toContain('zip-content');
   });
 });
+
+describe('metrics data-source query optional credentials', () => {
+  it('omits optional credential fields when none are supplied', async () => {
+    const result = { resultType: 'matrix', series: [], warnings: [] };
+    const query = { metric: 'up', start: 1, end: 2, step: '1m' };
+
+    mock.onPost('/metrics/query/datasource').reply((config) => {
+      const body = JSON.parse(config.data);
+
+      expect(body.query).toEqual(query);
+      expect(body.username).toBeUndefined();
+      expect(body.password).toBeUndefined();
+      expect(body.bearerToken).toBeUndefined();
+      return [200, { code: 200, data: result }];
+    });
+
+    await expect(queryByDataSource({ key: 'ds-prom-1', query })).resolves.toEqual(result);
+  });
+});


### PR DESCRIPTION
## Summary
Add a focused Vitest regression case for optional credentials on metrics data-source queries.

## Root cause
The current test suite does not cover optional credentials on metrics data-source queries, so the behavior could regress without a failing test.

## Changes
- Add regression coverage in $(@{Slug=metrics-datasource-credentials; Focus=optional credentials on metrics data-source queries; PrTitle=test(metrics): cover optional data-source query credentials; TestFile=web/src/api/metrics.test.ts; Mode=existing; Append=describe('metrics data-source query optional credentials', () => {
  it('omits optional credential fields when none are supplied', async () => {
    const result = { resultType: 'matrix', series: [], warnings: [] };
    const query = { metric: 'up', start: 1, end: 2, step: '1m' };

    mock.onPost('/metrics/query/datasource').reply((config) => {
      const body = JSON.parse(config.data);

      expect(body.query).toEqual(query);
      expect(body.username).toBeUndefined();
      expect(body.password).toBeUndefined();
      expect(body.bearerToken).toBeUndefined();
      return [200, { code: 200, data: result }];
    });

    await expect(
      queryByDataSource({ key: 'ds-prom-1', query }),
    ).resolves.toEqual(result);
  });
});}.TestFile).

## Testing
Commands run:
- cd web
- 
px vitest run src/api/metrics.test.ts
- cd ..
- git diff --check

Actual results:
- Vitest: $testFilesLine, $testsLine.
- git diff --check: no output, exit code 0.

I did not run the full Maven/Java server suite on this Windows host because Maven is not installed and the server targets Java 21 while only Java 17 is available. This PR changes web test code only.

Fixes #4046

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100