### PR TITLE
[studio][ISSUE #4048] Avoid data-source cache key collisions

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -218,7 +218,7 @@ public class SettingsService {
         return settingsRepository.findAllDataSources();
     }
 
-    @Cacheable(value = "data-sources", key = "'page:' + #search + ':' + #type + ':' + #page + ':' + #pageSize")
+    @Cacheable("data-sources")
     public PageResult<DataSourceVO> listDataSources(String search, String type, int page, int pageSize) {
         if (page < 1) {
             throw new BusinessException(400, "page must be greater than zero");

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceCachingTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceCachingTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.settings;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = SettingsServiceCachingTest.Config.class)
+class SettingsServiceCachingTest {
+
+    @Autowired
+    private SettingsService settingsService;
+
+    @Autowired
+    private SettingsRepository settingsRepository;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void resetState() {
+        reset(settingsRepository);
+        cacheManager.getCache("data-sources").clear();
+    }
+
+    @Test
+    void pagedInventoryShouldDistinguishNullFromLiteralNullSearchTest() {
+        PageResult<DataSourceVO> unfiltered = PageResult.of(
+                List.of(DataSourceVO.builder().key("all").name("All").build()), 1, 1, 20);
+        PageResult<DataSourceVO> literalNull = PageResult.of(
+                List.of(DataSourceVO.builder().key("literal-null").name("Literal null").build()),
+                1, 1, 20);
+        when(settingsRepository.findDataSources(null, null, 1, 20)).thenReturn(unfiltered);
+        when(settingsRepository.findDataSources("null", null, 1, 20)).thenReturn(literalNull);
+
+        assertThat(settingsService.listDataSources(null, null, 1, 20)).isSameAs(unfiltered);
+        assertThat(settingsService.listDataSources("null", null, 1, 20)).isSameAs(literalNull);
+        verify(settingsRepository).findDataSources(null, null, 1, 20);
+        verify(settingsRepository).findDataSources("null", null, 1, 20);
+    }
+
+    @Configuration
+    @EnableCaching
+    static class Config {
+
+        @Bean
+        CacheManager cacheManager() {
+            return new ConcurrentMapCacheManager("data-sources");
+        }
+
+        @Bean
+        SettingsRepository settingsRepository() {
+            return mock(SettingsRepository.class);
+        }
+
+        @Bean
+        SettingsService settingsService(SettingsRepository settingsRepository) {
+            return new SettingsService(settingsRepository, RestClient.create(), new ObjectMapper(),
+                    mock(OperationAuditService.class));
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- let Spring's default multi-argument key generator identify paged data-source queries
- add a Spring caching regression test that distinguishes an absent search filter from the literal text `null`

## Why

The previous delimiter-based key rendered Java `null` as the text `null`. An unfiltered request and a request searching for that literal value therefore shared one cache entry, so the latter could receive stale unfiltered results without reaching the repository. The default `SimpleKey` preserves argument boundaries and null values.

Fixes #4048

## Verification

- Before the production change: `SettingsServiceCachingTest` failed because the second query returned the first cached page.
- `mvn '-Dtest=SettingsServiceCachingTest,SettingsServiceTest' test`
  - 44 tests, 0 failures, 0 errors, 0 skipped
  - Checkstyle: 0 violations

## Scope

2 files changed; no API or persistence schema changes.