### PR TITLE
feat(queue): filter, sort and hide empty queues in the Queue Browser

### DIFF
--- a/web/src/components/QueueBrowser.tsx
+++ b/web/src/components/QueueBrowser.tsx
@@ -14,17 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Button,
   Card,
   Descriptions,
   Empty,
   Flex,
+  Input,
   Select,
   Slider,
   Space,
   Spin,
+  Switch,
   Table,
   Tag,
   Tooltip,
@@ -197,200 +199,295 @@ export const QueueBrowserControls = ({
   </Flex>
 );
 
-export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => (
-  <Card>
-    {state.loading ? (
-      <Flex justify="center" style={{ padding: 32 }}>
-        <Spin />
-      </Flex>
-    ) : state.queues.length === 0 ? (
-      <Empty
-        image={Empty.PRESENTED_IMAGE_SIMPLE}
-        description="选择 Topic 并点击「加载队列」，按队列浏览消息"
-        style={{ padding: '32px 0' }}
-      />
-    ) : (
-      <Flex gap={16} align="flex-start">
-        {/* 左侧：队列表格 */}
-        <div style={{ width: '50%', flexShrink: 0 }}>
-          <Table<QueueOffset>
-            rowKey={(r) => `${r.brokerName}-${r.queueId}`}
-            dataSource={state.queues}
-            size="small"
-            pagination={false}
-            columns={[
-              {
-                title: 'Broker',
-                dataIndex: 'brokerName',
-                width: 180,
-                ellipsis: { showTitle: false },
-                render: (v: string) => (
-                  <Tooltip title={v}>
-                    <Text strong style={{ fontSize: 14 }}>
-                      {v}
-                    </Text>
-                  </Tooltip>
-                ),
-              },
-              {
-                title: 'Queue',
-                dataIndex: 'queueId',
-                width: 50,
-                align: 'center',
-                render: (v: number) => <Text style={{ fontSize: 14 }}>{v}</Text>,
-              },
-              {
-                title: 'Offset 范围',
-                key: 'offset',
-                width: 170,
-                render: (_: unknown, record: QueueOffset) => {
-                  const key = `${record.brokerName}-${record.queueId}`;
-                  const currentOffset = state.offsets[key] ?? record.minOffset;
-                  return (
-                    <Flex align="center" gap={8}>
-                      <Text type="secondary" style={{ fontSize: 14, flexShrink: 0 }}>
-                        {record.minOffset}
-                      </Text>
-                      <Slider
-                        style={{ flex: 1, margin: 0 }}
-                        min={record.minOffset}
-                        max={
-                          record.maxOffset > record.minOffset
-                            ? record.maxOffset - 1
-                            : record.minOffset
-                        }
-                        value={currentOffset}
-                        onChange={(value) =>
-                          state.setOffsets((prev) => ({ ...prev, [key]: value }))
-                        }
-                        tooltip={{ formatter: (v) => `offset: ${v}` }}
-                      />
-                      <Text code style={{ fontSize: 14, flexShrink: 0 }}>
-                        {currentOffset}
-                      </Text>
-                    </Flex>
-                  );
-                },
-              },
-              {
-                title: '操作',
-                key: 'action',
-                width: 70,
-                align: 'center',
-                render: (_: unknown, record: QueueOffset) => {
-                  const key = `${record.brokerName}-${record.queueId}`;
-                  return (
-                    <Button
-                      size="small"
-                      type="primary"
-                      loading={state.pulling.has(key)}
-                      onClick={() => void state.handlePull(record)}
-                    >
-                      查看
-                    </Button>
-                  );
-                },
-              },
-            ]}
-          />
-          <Text type="secondary" style={{ display: 'block', marginTop: 8, fontSize: 14 }}>
-            共 {state.queues.length} 个队列，总消息量{' '}
-            {state.queues.reduce((sum, q) => sum + (q.maxOffset - q.minOffset), 0)} 条
-          </Text>
-        </div>
+export type QueueSortValue =
+  'broker-asc' | 'broker-desc' | 'queue-asc' | 'queue-desc' | 'backlog-asc' | 'backlog-desc';
 
-        {/* 右侧：消息详情（2 列，可多条并存） */}
-        <div style={{ flex: 1, minWidth: 0 }}>
-          {state.entries.length === 0 ? (
-            <Empty
-              image={Empty.PRESENTED_IMAGE_SIMPLE}
-              description="点击左侧「查看」，消息详情将显示在这里"
-              style={{ padding: '32px 0' }}
-            />
-          ) : (
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-              {state.entries.map((entry) => (
-                <Card
-                  key={entry.key}
-                  size="small"
-                  style={{ borderRadius: 8 }}
-                  title={
-                    <Space size={4}>
-                      <Tag color="blue" style={{ marginInlineEnd: 0 }}>
-                        {entry.key}
-                      </Tag>
-                      <Text type="secondary" style={{ fontSize: 14 }}>
-                        @ {entry.offset}
-                      </Text>
-                    </Space>
-                  }
-                  extra={
-                    <Button
-                      type="text"
-                      size="small"
-                      icon={<CloseOutlined />}
-                      onClick={() => state.closeEntry(entry.key)}
-                    />
-                  }
-                >
-                  {entry.message ? (
-                    <>
-                      <Descriptions column={1} size="small">
-                        <Descriptions.Item label="Message ID">
-                          <Paragraph
-                            copyable
-                            style={{ marginBottom: 0, fontFamily: 'monospace', fontSize: 14 }}
-                          >
-                            {entry.message.msgId}
-                          </Paragraph>
-                        </Descriptions.Item>
-                        <Descriptions.Item label="Tag">
-                          <Tag>{entry.message.tag || '-'}</Tag>
-                        </Descriptions.Item>
-                        <Descriptions.Item label="Key">
-                          <span style={{ fontFamily: 'monospace', fontSize: 14 }}>
-                            {entry.message.key || '-'}
-                          </span>
-                        </Descriptions.Item>
-                        <Descriptions.Item label="存储时间">
-                          <span style={{ fontFamily: 'monospace', fontSize: 14 }}>
-                            {formatTimeMs(entry.message.storeTime)}
-                          </span>
-                        </Descriptions.Item>
-                        <Descriptions.Item label="大小">
-                          {entry.message.size} bytes
-                        </Descriptions.Item>
-                        <Descriptions.Item label="Born Host">
-                          {entry.message.bornHost || '-'}
-                        </Descriptions.Item>
-                      </Descriptions>
-                      {entry.message.body && (
-                        <Card size="small" title="Body" style={{ marginTop: 12 }}>
-                          <pre
-                            style={{
-                              maxHeight: 160,
-                              overflow: 'auto',
-                              fontSize: 14,
-                              fontFamily: 'monospace',
-                              whiteSpace: 'pre-wrap',
-                              wordBreak: 'break-all',
-                              margin: 0,
-                            }}
-                          >
-                            {entry.message.body}
-                          </pre>
-                        </Card>
-                      )}
-                    </>
-                  ) : (
-                    <Text type="secondary">该 offset 处无消息</Text>
-                  )}
-                </Card>
-              ))}
-            </div>
-          )}
-        </div>
-      </Flex>
-    )}
-  </Card>
-);
+const backlogOf = (queue: QueueOffset): number => Math.max(0, queue.maxOffset - queue.minOffset);
+
+const compareQueues = (a: QueueOffset, b: QueueOffset, sort: QueueSortValue): number => {
+  switch (sort) {
+    case 'queue-asc':
+      return a.queueId - b.queueId;
+    case 'queue-desc':
+      return b.queueId - a.queueId;
+    case 'backlog-asc':
+      return backlogOf(a) - backlogOf(b);
+    case 'backlog-desc':
+      return backlogOf(b) - backlogOf(a);
+    case 'broker-desc':
+      return b.brokerName.localeCompare(a.brokerName);
+    case 'broker-asc':
+    default:
+      return a.brokerName.localeCompare(b.brokerName);
+  }
+};
+
+const QUEUE_SORT_OPTIONS = [
+  { value: 'broker-asc', label: '排序: Broker ↑' },
+  { value: 'broker-desc', label: '排序: Broker ↓' },
+  { value: 'queue-asc', label: '排序: Queue ↑' },
+  { value: 'queue-desc', label: '排序: Queue ↓' },
+  { value: 'backlog-asc', label: '排序: 积压 ↑' },
+  { value: 'backlog-desc', label: '排序: 积压 ↓' },
+];
+
+export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => {
+  const [searchText, setSearchText] = useState('');
+  const [onlyNonEmpty, setOnlyNonEmpty] = useState(false);
+  const [sortValue, setSortValue] = useState<QueueSortValue>('broker-asc');
+
+  const visibleQueues = useMemo(() => {
+    const term = searchText.trim().toLowerCase();
+    const filtered = state.queues.filter((queue) => {
+      if (onlyNonEmpty && backlogOf(queue) <= 0) return false;
+      if (!term) return true;
+      return queue.brokerName.toLowerCase().includes(term) || String(queue.queueId) === term;
+    });
+    return [...filtered].sort((a, b) => compareQueues(a, b, sortValue));
+  }, [state.queues, searchText, onlyNonEmpty, sortValue]);
+
+  const totalMessages = state.queues.reduce((sum, queue) => sum + backlogOf(queue), 0);
+
+  return (
+    <Card>
+      {state.loading ? (
+        <Flex justify="center" style={{ padding: 32 }}>
+          <Spin />
+        </Flex>
+      ) : state.queues.length === 0 ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="选择 Topic 并点击「加载队列」，按队列浏览消息"
+          style={{ padding: '32px 0' }}
+        />
+      ) : (
+        <Flex gap={16} align="flex-start">
+          {/* 左侧：队列表格 */}
+          <div style={{ width: '50%', flexShrink: 0 }}>
+            <Flex gap={8} align="center" wrap style={{ marginBottom: 12 }}>
+              <Input
+                allowClear
+                size="small"
+                prefix={<SearchOutlined />}
+                placeholder="搜索 Broker / Queue ID"
+                value={searchText}
+                onChange={(event) => setSearchText(event.target.value)}
+                style={{ width: 220 }}
+              />
+              <Select<QueueSortValue>
+                aria-label="排序"
+                size="small"
+                value={sortValue}
+                onChange={setSortValue}
+                options={QUEUE_SORT_OPTIONS}
+                style={{ width: 170 }}
+              />
+              <Switch
+                aria-label="仅显示非空队列"
+                size="small"
+                checked={onlyNonEmpty}
+                onChange={setOnlyNonEmpty}
+              />
+              <Text type="secondary" style={{ fontSize: 14 }}>
+                仅非空
+              </Text>
+            </Flex>
+            {visibleQueues.length === 0 ? (
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description="没有符合条件的队列"
+                style={{ padding: '24px 0' }}
+              />
+            ) : (
+              <Table<QueueOffset>
+                rowKey={(r) => `${r.brokerName}-${r.queueId}`}
+                dataSource={visibleQueues}
+                size="small"
+                pagination={false}
+                columns={[
+                  {
+                    title: 'Broker',
+                    dataIndex: 'brokerName',
+                    width: 180,
+                    ellipsis: { showTitle: false },
+                    render: (v: string) => (
+                      <Tooltip title={v}>
+                        <Text strong style={{ fontSize: 14 }}>
+                          {v}
+                        </Text>
+                      </Tooltip>
+                    ),
+                  },
+                  {
+                    title: 'Queue',
+                    dataIndex: 'queueId',
+                    width: 50,
+                    align: 'center',
+                    render: (v: number) => <Text style={{ fontSize: 14 }}>{v}</Text>,
+                  },
+                  {
+                    title: '积压',
+                    key: 'backlog',
+                    width: 70,
+                    align: 'right',
+                    render: (_: unknown, record: QueueOffset) => (
+                      <Text style={{ fontSize: 14 }}>{backlogOf(record)}</Text>
+                    ),
+                  },
+                  {
+                    title: 'Offset 范围',
+                    key: 'offset',
+                    width: 170,
+                    render: (_: unknown, record: QueueOffset) => {
+                      const key = `${record.brokerName}-${record.queueId}`;
+                      const currentOffset = state.offsets[key] ?? record.minOffset;
+                      return (
+                        <Flex align="center" gap={8}>
+                          <Text type="secondary" style={{ fontSize: 14, flexShrink: 0 }}>
+                            {record.minOffset}
+                          </Text>
+                          <Slider
+                            style={{ flex: 1, margin: 0 }}
+                            min={record.minOffset}
+                            max={
+                              record.maxOffset > record.minOffset
+                                ? record.maxOffset - 1
+                                : record.minOffset
+                            }
+                            value={currentOffset}
+                            onChange={(value) =>
+                              state.setOffsets((prev) => ({ ...prev, [key]: value }))
+                            }
+                            tooltip={{ formatter: (v) => `offset: ${v}` }}
+                          />
+                          <Text code style={{ fontSize: 14, flexShrink: 0 }}>
+                            {currentOffset}
+                          </Text>
+                        </Flex>
+                      );
+                    },
+                  },
+                  {
+                    title: '操作',
+                    key: 'action',
+                    width: 70,
+                    align: 'center',
+                    render: (_: unknown, record: QueueOffset) => {
+                      const key = `${record.brokerName}-${record.queueId}`;
+                      return (
+                        <Button
+                          size="small"
+                          type="primary"
+                          loading={state.pulling.has(key)}
+                          onClick={() => void state.handlePull(record)}
+                        >
+                          查看
+                        </Button>
+                      );
+                    },
+                  },
+                ]}
+              />
+            )}
+            <Text type="secondary" style={{ display: 'block', marginTop: 8, fontSize: 14 }}>
+              显示 {visibleQueues.length} / 共 {state.queues.length} 个队列，总消息量{' '}
+              {totalMessages} 条
+            </Text>
+          </div>
+
+          {/* 右侧：消息详情（2 列，可多条并存） */}
+          <div style={{ flex: 1, minWidth: 0 }}>
+            {state.entries.length === 0 ? (
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description="点击左侧「查看」，消息详情将显示在这里"
+                style={{ padding: '32px 0' }}
+              />
+            ) : (
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+                {state.entries.map((entry) => (
+                  <Card
+                    key={entry.key}
+                    size="small"
+                    style={{ borderRadius: 8 }}
+                    title={
+                      <Space size={4}>
+                        <Tag color="blue" style={{ marginInlineEnd: 0 }}>
+                          {entry.key}
+                        </Tag>
+                        <Text type="secondary" style={{ fontSize: 14 }}>
+                          @ {entry.offset}
+                        </Text>
+                      </Space>
+                    }
+                    extra={
+                      <Button
+                        type="text"
+                        size="small"
+                        icon={<CloseOutlined />}
+                        onClick={() => state.closeEntry(entry.key)}
+                      />
+                    }
+                  >
+                    {entry.message ? (
+                      <>
+                        <Descriptions column={1} size="small">
+                          <Descriptions.Item label="Message ID">
+                            <Paragraph
+                              copyable
+                              style={{ marginBottom: 0, fontFamily: 'monospace', fontSize: 14 }}
+                            >
+                              {entry.message.msgId}
+                            </Paragraph>
+                          </Descriptions.Item>
+                          <Descriptions.Item label="Tag">
+                            <Tag>{entry.message.tag || '-'}</Tag>
+                          </Descriptions.Item>
+                          <Descriptions.Item label="Key">
+                            <span style={{ fontFamily: 'monospace', fontSize: 14 }}>
+                              {entry.message.key || '-'}
+                            </span>
+                          </Descriptions.Item>
+                          <Descriptions.Item label="存储时间">
+                            <span style={{ fontFamily: 'monospace', fontSize: 14 }}>
+                              {formatTimeMs(entry.message.storeTime)}
+                            </span>
+                          </Descriptions.Item>
+                          <Descriptions.Item label="大小">
+                            {entry.message.size} bytes
+                          </Descriptions.Item>
+                          <Descriptions.Item label="Born Host">
+                            {entry.message.bornHost || '-'}
+                          </Descriptions.Item>
+                        </Descriptions>
+                        {entry.message.body && (
+                          <Card size="small" title="Body" style={{ marginTop: 12 }}>
+                            <pre
+                              style={{
+                                maxHeight: 160,
+                                overflow: 'auto',
+                                fontSize: 14,
+                                fontFamily: 'monospace',
+                                whiteSpace: 'pre-wrap',
+                                wordBreak: 'break-all',
+                                margin: 0,
+                              }}
+                            >
+                              {entry.message.body}
+                            </pre>
+                          </Card>
+                        )}
+                      </>
+                    ) : (
+                      <Text type="secondary">该 offset 处无消息</Text>
+                    )}
+                  </Card>
+                ))}
+              </div>
+            )}
+          </div>
+        </Flex>
+      )}
+    </Card>
+  );
+};

--- a/web/src/components/__tests__/QueueBrowser.test.tsx
+++ b/web/src/components/__tests__/QueueBrowser.test.tsx
@@ -20,7 +20,12 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MessageRecord, QueueOffset } from '../../api/message';
 import { getQueueOffsets, pullMessageAtOffset } from '../../api/message';
-import { formatTimeMs, useQueueBrowser } from '../QueueBrowser';
+import {
+  formatTimeMs,
+  QueueBrowserResults,
+  useQueueBrowser,
+  type QueueBrowserState,
+} from '../QueueBrowser';
 
 vi.mock('../../api/message', () => ({
   getQueueOffsets: vi.fn(),
@@ -214,5 +219,103 @@ describe('QueueBrowser request ownership', () => {
 
     expect(getQueueOffsets).toHaveBeenCalledTimes(1);
     await act(async () => queues.resolve([queue('broker-a')]));
+  });
+});
+describe('QueueBrowser results filtering', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  const browserState = (queues: QueueOffset[]): QueueBrowserState => ({
+    topic: 'topic-a',
+    setTopic: vi.fn(),
+    queues,
+    loading: false,
+    offsets: {},
+    setOffsets: vi.fn(),
+    pulling: new Set<string>(),
+    entries: [],
+    loadQueues: vi.fn(),
+    handlePull: vi.fn(),
+    closeEntry: vi.fn(),
+  });
+
+  const rows = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('tbody tr')).map((row) => row.textContent ?? '');
+
+  it('filters queues by broker name as the operator types', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <QueueBrowserResults state={browserState([queue('broker-a'), queue('broker-b')])} />,
+    );
+    expect(rows(container)).toHaveLength(2);
+
+    await user.type(screen.getByPlaceholderText('搜索 Broker / Queue ID'), 'broker-b');
+
+    expect(rows(container)).toHaveLength(1);
+    expect(rows(container)[0]).toContain('broker-b');
+  });
+
+  it('filters queues by exact queue id', async () => {
+    const user = userEvent.setup();
+    const q0 = { ...queue('broker-a'), queueId: 0, minOffset: 1, maxOffset: 5 };
+    const q1 = { ...queue('broker-a'), queueId: 1, minOffset: 1, maxOffset: 5 };
+    const { container } = render(<QueueBrowserResults state={browserState([q0, q1])} />);
+
+    await user.type(screen.getByPlaceholderText('搜索 Broker / Queue ID'), '1');
+
+    expect(rows(container)).toHaveLength(1);
+    expect(rows(container)[0]).toContain('1');
+  });
+
+  it('hides empty queues when the non-empty toggle is enabled', async () => {
+    const user = userEvent.setup();
+    const empty = { ...queue('broker-a'), minOffset: 2, maxOffset: 2 };
+    const busy = { ...queue('broker-b'), minOffset: 0, maxOffset: 10 };
+    const { container } = render(<QueueBrowserResults state={browserState([empty, busy])} />);
+    expect(rows(container)).toHaveLength(2);
+
+    await user.click(screen.getByRole('switch', { name: '仅显示非空队列' }));
+
+    expect(rows(container)).toHaveLength(1);
+    expect(rows(container)[0]).toContain('broker-b');
+  });
+
+  it('sorts queues by message backlog in descending order', async () => {
+    const user = userEvent.setup();
+    const small = { ...queue('broker-a'), minOffset: 0, maxOffset: 3 };
+    const large = { ...queue('broker-b'), minOffset: 0, maxOffset: 12 };
+    const { container } = render(<QueueBrowserResults state={browserState([small, large])} />);
+
+    await user.click(screen.getByRole('combobox', { name: '排序' }));
+    await user.click(
+      await screen.findByText('排序: 积压 ↓', { selector: '.ant-select-item-option-content' }),
+    );
+
+    expect(rows(container)[0]).toContain('broker-b');
+    expect(rows(container)[1]).toContain('broker-a');
+  });
+
+  it('reports displayed count separately from the unfiltered totals', async () => {
+    const user = userEvent.setup();
+    const empty = { ...queue('broker-a'), minOffset: 2, maxOffset: 2 };
+    const busy = { ...queue('broker-b'), minOffset: 0, maxOffset: 10 };
+    render(<QueueBrowserResults state={browserState([empty, busy])} />);
+
+    await user.click(screen.getByRole('switch', { name: '仅显示非空队列' }));
+
+    expect(screen.getByText(/显示 1 \/ 共 2 个队列，总消息量/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Add broker-name / queue-ID search, sorting (Broker / Queue / backlog, both directions), and an "only non-empty queues" toggle to the Queue Browser table.
- Show the displayed row count separately from the topic-wide totals so filtering never makes the totals misleading.
- Keep the existing pull-at-offset behavior unchanged; add a backlog column.

## Why
Fixes #3400 — for topics with many queues, operators currently scroll an unbounded table to find a broker or queue. When diagnosing uneven writes the interesting queues are the ones with the largest backlog, while empty queues add noise.

## Testing
- `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` — passes.
- `web: ./node_modules/.bin/vitest run src/components/__tests__/QueueBrowser.test.tsx` on the build server (Node 20) — **13/13 passed**, including 5 new regression tests covering broker-name search, exact queue-ID search, the empty-queue toggle, backlog descending sort, and displayed/total counts.
