### PR TITLE
feat(alert): export notification deliveries as CSV

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.cluster.metrics.AlertingProperties;
 import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.common.util.CsvUtil;
 import org.apache.rocketmq.studio.common.util.NoRedirectClientHttpRequestFactory;
 import org.apache.rocketmq.studio.common.util.UrlHostGuard;
 import org.apache.rocketmq.studio.persistence.entity.RmqAlertNotificationOutbox;
@@ -63,6 +64,7 @@ import jakarta.mail.internet.InternetAddress;
 public class NotificationOutboxService {
     private static final int MAX_ATTEMPTS = 5;
     private static final int BATCH_SIZE = 20;
+    private static final int MAX_EXPORT_ROWS = 10_000;
     private static final Duration DEFAULT_CLAIM_TIMEOUT = Duration.ofMinutes(1);
     private static final Duration DEFAULT_CLAIM_RENEWAL_INTERVAL = Duration.ofSeconds(20);
     private static final int DEFAULT_HEARTBEAT_THREADS = 2;
@@ -220,6 +222,29 @@ public class NotificationOutboxService {
         }
         return PageResult.of(mapper.findPage(normalizedChannel, normalizedStatus, normalizedInstanceId, safePageSize,
                 (long) (safePage - 1) * safePageSize), total, safePage, safePageSize);
+    }
+
+    public String exportDeliveries(String channel, String status, String instanceId) {
+        String normalizedChannel = normalizeFilter(channel);
+        String normalizedStatus = normalizeStatus(status);
+        String normalizedInstanceId = normalizeTrim(instanceId);
+        long total = mapper.countPage(normalizedChannel, normalizedStatus, normalizedInstanceId);
+        StringBuilder csv = new StringBuilder("\uFEFF");
+        CsvUtil.appendRow(csv, "Delivery ID", "Alert ID", "Alert Title", "Alert Domain", "Transition",
+                "Instance ID", "Channel", "Status", "Attempt Count", "Created At", "Delivered At",
+                "Next Attempt At", "Last Error");
+        if (total == 0) {
+            return csv.toString();
+        }
+        int limit = (int) Math.min(total, MAX_EXPORT_ROWS);
+        for (NotificationDeliveryPageVO row : mapper.findPage(
+                normalizedChannel, normalizedStatus, normalizedInstanceId, limit, 0)) {
+            CsvUtil.appendRow(csv, row.getId(), row.getAlertId(), row.getAlertTitle(), row.getAlertDomain(),
+                    row.getTransition(), row.getInstanceId(), row.getChannel(), row.getStatus(),
+                    row.getAttemptCount(), row.getCreatedAt(), row.getDeliveredAt(), row.getNextAttemptAt(),
+                    row.getLastError());
+        }
+        return csv.toString();
     }
 
     public void retryFailedDelivery(Long deliveryId) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertController.java
@@ -87,6 +87,14 @@ public class SystemAlertController {
         return Result.ok(notificationOutboxService.listDeliveries(channel, status, instanceId, page, pageSize));
     }
 
+    @GetMapping("/deliveries/export")
+    public Result<String> exportDeliveries(
+            @RequestParam(required = false) String channel,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String instanceId) {
+        return Result.ok(notificationOutboxService.exportDeliveries(channel, status, instanceId));
+    }
+
     @PostMapping("/deliveries/{deliveryId}/retry")
     public Result<Void> retryFailedDelivery(@PathVariable Long deliveryId) {
         notificationOutboxService.retryFailedDelivery(deliveryId);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxServiceTest.java
@@ -476,6 +476,58 @@ class NotificationOutboxServiceTest {
     }
 
     @Test
+    void exportsDeliveryRowsWithNormalizedFiltersWithoutMessageContentTest() {
+        RmqAlertNotificationOutboxMapper mapper = mock(RmqAlertNotificationOutboxMapper.class);
+        NotificationDeliveryPageVO delivery = NotificationDeliveryPageVO.builder().id(8L).alertId(9L)
+                .alertTitle("Disk usage \"high\"").alertDomain(AlertDomain.CLUSTER).transition("FIRING")
+                .instanceId("local").channel("dingtalk").status(NotificationOutboxStatus.FAILED).attemptCount(2)
+                .createdAt(LocalDateTime.of(2026, 8, 23, 10, 0))
+                .deliveredAt(null).nextAttemptAt(LocalDateTime.of(2026, 8, 23, 10, 5))
+                .lastError("=cmd()").messageContent("sensitive message content").build();
+        when(mapper.countPage("dingtalk", "FAILED", "local")).thenReturn(1L);
+        when(mapper.findPage("dingtalk", "FAILED", "local", 1, 0)).thenReturn(List.of(delivery));
+
+        String csv = new NotificationOutboxService(mapper, mock(SettingsRepository.class),
+                mock(AlertSilenceService.class), mock(AlertRepository.class), mock(OperationAuditService.class))
+                .exportDeliveries(" DingTalk ", "failed", "local");
+
+        verify(mapper).findPage("dingtalk", "FAILED", "local", 1, 0);
+        assertThat(csv).startsWith("\uFEFF\"Delivery ID\",\"Alert ID\",\"Alert Title\",\"Alert Domain\",\"Transition\","
+                + "\"Instance ID\",\"Channel\",\"Status\",\"Attempt Count\",\"Created At\",\"Delivered At\","
+                + "\"Next Attempt At\",\"Last Error\"");
+        assertThat(csv).contains("\"8\",\"9\",\"Disk usage \"\"high\"\"\",\"CLUSTER\",\"FIRING\",\"local\","
+                + "\"dingtalk\",\"FAILED\",\"2\",\"2026-08-23T10:00\",\"\",\"2026-08-23T10:05\",\"'=cmd()\"");
+        assertThat(csv).doesNotContain("sensitive message content");
+    }
+
+    @Test
+    void capsExportAtTenThousandRowsWhenMoreDeliveriesMatchTest() {
+        RmqAlertNotificationOutboxMapper mapper = mock(RmqAlertNotificationOutboxMapper.class);
+        when(mapper.countPage("dingtalk", "FAILED", "local")).thenReturn(10_500L);
+        when(mapper.findPage("dingtalk", "FAILED", "local", 10_000, 0)).thenReturn(List.of());
+
+        String csv = new NotificationOutboxService(mapper, mock(SettingsRepository.class),
+                mock(AlertSilenceService.class), mock(AlertRepository.class), mock(OperationAuditService.class))
+                .exportDeliveries("dingtalk", "FAILED", "local");
+
+        verify(mapper).findPage("dingtalk", "FAILED", "local", 10_000, 0);
+        assertThat(csv).contains("\"Delivery ID\"");
+    }
+
+    @Test
+    void exportsOnlyTheHeaderWhenNoDeliveriesMatchTest() {
+        RmqAlertNotificationOutboxMapper mapper = mock(RmqAlertNotificationOutboxMapper.class);
+        when(mapper.countPage("dingtalk", "FAILED", "local")).thenReturn(0L);
+
+        String csv = new NotificationOutboxService(mapper, mock(SettingsRepository.class),
+                mock(AlertSilenceService.class), mock(AlertRepository.class), mock(OperationAuditService.class))
+                .exportDeliveries("dingtalk", "FAILED", "local");
+
+        assertThat(csv).startsWith("\uFEFF\"Delivery ID\",\"Alert ID\"").endsWith("\"Last Error\"\r\n");
+        verify(mapper, never()).findPage(anyString(), anyString(), anyString(), any(Integer.class), any(Long.class));
+    }
+
+    @Test
     void retriesOnlyFailedDeliveryAndResetsItsDispatchStateTest() {
         RmqAlertNotificationOutboxMapper mapper = mock(RmqAlertNotificationOutboxMapper.class);
         OperationAuditService audit = mock(OperationAuditService.class);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
@@ -134,6 +134,20 @@ class SystemAlertControllerTest {
     }
 
     @Test
+    void exportDeliveriesShouldReturnCsvWithForwardedFiltersTest() throws Exception {
+        String csv = "\uFEFF\"Delivery ID\",\"Channel\",\"Status\"\r\n\"8\",\"dingtalk\",\"FAILED\"\r\n";
+        when(notificationOutboxService.exportDeliveries("dingtalk", "FAILED", "local")).thenReturn(csv);
+
+        mockMvc.perform(get("/api/system-alerts/deliveries/export").param("channel", "dingtalk")
+                        .param("status", "FAILED").param("instanceId", "local"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data").value(csv));
+
+        verify(notificationOutboxService).exportDeliveries("dingtalk", "FAILED", "local");
+    }
+
+    @Test
     void retryFailedDeliveryShouldForwardDeliveryIdTest() throws Exception {
         mockMvc.perform(post("/api/system-alerts/deliveries/8/retry"))
                 .andExpect(status().isOk())

--- a/web/src/api/ops.test.ts
+++ b/web/src/api/ops.test.ts
@@ -43,6 +43,7 @@ import {
   acknowledgeAlert,
   clearAcknowledgedAlerts,
   listAlertDeliveries,
+  exportNotificationDeliveries,
   listAlertSilences,
   listAlertSilencesPage,
   createAlertSilence,
@@ -358,6 +359,18 @@ describe('Ops API - System Alerts & Audit', () => {
     await expect(listAlertDeliveries(1)).resolves.toEqual([
       { id: 1, channel: 'dingtalk', status: 'DELIVERED', attemptCount: 1 },
     ]);
+  });
+
+  it('exports notification deliveries with the current filters', async () => {
+    const csv = '"Delivery ID","Channel"\r\n"1","dingtalk"\r\n';
+    mock.onGet('/system-alerts/deliveries/export').reply((config) => {
+      expect(config.params).toEqual({ channel: 'dingtalk', status: 'FAILED', instanceId: 'local' });
+      return [200, { code: 200, data: csv }];
+    });
+
+    await expect(
+      exportNotificationDeliveries({ channel: 'dingtalk', status: 'FAILED', instanceId: 'local' }),
+    ).resolves.toBe(csv);
   });
 
   it('manages alert silences', async () => {

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -362,6 +362,11 @@ export async function listAlertDeliveriesPage(params: NotificationDeliveryQuery 
   return res.data.data;
 }
 
+export async function exportNotificationDeliveries(params: NotificationDeliveryQuery = {}) {
+  const res = await client.get<{ data: string }>('/system-alerts/deliveries/export', { params });
+  return res.data.data;
+}
+
 export async function listAlertSilences() {
   const res = await client.get<{ data: AlertSilence[] }>('/alert-silences');
   return res.data.data;

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -584,6 +584,10 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: '重试当前页失败记录',
     en: 'Retry failed records on this page',
   },
+  'deliveries.exportFailed': {
+    zh: '导出投递记录失败，请稍后重试',
+    en: 'Failed to export alert deliveries. Please try again later.',
+  },
 
   // ─── General Settings ───
   'settings.generalLoadFailed': {

--- a/web/src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
+++ b/web/src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
@@ -7,10 +7,14 @@
 import { App } from 'antd';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LangProvider } from '../../../i18n/LangContext';
 import { listInstances } from '../../../services/instanceService';
-import { listAlertDeliveriesPage, retryAlertDelivery } from '../../../services/opsService';
+import {
+  listAlertDeliveriesPage,
+  retryAlertDelivery,
+  exportNotificationDeliveries,
+} from '../../../services/opsService';
 import NotificationDeliveriesPage from '../notificationDeliveries';
 
 vi.mock('../../../services/instanceService', () => ({
@@ -20,6 +24,7 @@ vi.mock('../../../services/opsService', () => ({
   listAlertDeliveriesPage: vi.fn(),
   retryAlertDeliveries: vi.fn(),
   retryAlertDelivery: vi.fn(),
+  exportNotificationDeliveries: vi.fn(),
 }));
 
 const deferred = <T,>() => {
@@ -29,6 +34,10 @@ const deferred = <T,>() => {
   });
   return { promise, resolve };
 };
+
+let createObjectURL: ReturnType<typeof vi.fn>;
+let revokeObjectURL: ReturnType<typeof vi.fn>;
+let clickSpy: ReturnType<typeof vi.spyOn>;
 
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
@@ -41,6 +50,25 @@ beforeAll(() => {
       removeEventListener: vi.fn(),
     })),
   });
+  createObjectURL = vi.fn().mockReturnValue('blob:deliveries');
+  revokeObjectURL = vi.fn();
+  Object.defineProperty(URL, 'createObjectURL', {
+    configurable: true,
+    value: createObjectURL,
+  });
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    configurable: true,
+    value: revokeObjectURL,
+  });
+});
+
+beforeEach(() => {
+  clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  clickSpy.mockRestore();
+  vi.clearAllMocks();
 });
 
 describe('NotificationDeliveriesPage', () => {
@@ -81,6 +109,35 @@ describe('NotificationDeliveriesPage', () => {
 
     await waitFor(() => expect(retryAlertDelivery).toHaveBeenCalledWith(7));
     await waitFor(() => expect(listAlertDeliveriesPage).toHaveBeenCalledTimes(2));
+  });
+
+  it('exports the current filtered deliveries as a CSV download', async () => {
+    vi.mocked(exportNotificationDeliveries).mockResolvedValue(
+      '"Delivery ID","Channel"\r\n"7","dingtalk"\r\n',
+    );
+    const user = userEvent.setup();
+    render(
+      <App>
+        <LangProvider>
+          <NotificationDeliveriesPage />
+        </LangProvider>
+      </App>,
+    );
+
+    await screen.findByText('Broker disk usage');
+    await user.click(screen.getByRole('button', { name: /导\s*出/ }));
+
+    await waitFor(() =>
+      expect(exportNotificationDeliveries).toHaveBeenCalledWith({
+        channel: undefined,
+        status: undefined,
+        instanceId: undefined,
+      }),
+    );
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    await expect(blob.text()).resolves.toContain('"Delivery ID"');
+    expect(clickSpy).toHaveBeenCalledTimes(1);
   });
 
   it('queues one retry when the action is clicked twice before rendering', async () => {

--- a/web/src/pages/ops/notificationDeliveries.tsx
+++ b/web/src/pages/ops/notificationDeliveries.tsx
@@ -26,10 +26,12 @@ import type { Instance } from '../../api/instance';
 import type { NotificationDeliveryRecord } from '../../api/ops';
 import { listInstances } from '../../services/instanceService';
 import {
+  exportNotificationDeliveries,
   listAlertDeliveriesPage,
   retryAlertDeliveries,
   retryAlertDelivery,
 } from '../../services/opsService';
+import { downloadCsv } from '../../utils/download';
 import { formatUtcDateTime } from '../../utils/format';
 import { tableScrollX } from '../../utils/table';
 
@@ -55,6 +57,7 @@ const NotificationDeliveriesPage = () => {
   const [selectedDelivery, setSelectedDelivery] = useState<NotificationDeliveryRecord>();
   const [retryingIds, setRetryingIds] = useState<Set<number>>(() => new Set());
   const [retryingVisible, setRetryingVisible] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const retryingIdsInFlight = useRef(new Set<number>());
   const retryingVisibleInFlight = useRef(false);
   const [refreshNonce, setRefreshNonce] = useState(0);
@@ -111,6 +114,18 @@ const NotificationDeliveriesPage = () => {
     } finally {
       retryingVisibleInFlight.current = false;
       setRetryingVisible(false);
+    }
+  };
+
+  const exportCsv = async () => {
+    setExporting(true);
+    try {
+      const csv = await exportNotificationDeliveries({ channel, status, instanceId });
+      downloadCsv(`rocketmq-alert-deliveries-${new Date().toISOString().slice(0, 10)}.csv`, csv);
+    } catch {
+      message.error(t('deliveries.exportFailed'));
+    } finally {
+      setExporting(false);
     }
   };
 
@@ -239,6 +254,9 @@ const NotificationDeliveriesPage = () => {
               onClick={() => void retryVisibleFailures()}
             >
               {t('deliveries.retryCurrentPage')}
+            </Button>
+            <Button loading={exporting} onClick={() => void exportCsv()}>
+              {t('common.export')}
             </Button>
             <Select
               allowClear

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -442,6 +442,13 @@ export async function listAlertDeliveriesPage(
   return opsApi.listAlertDeliveriesPage(params);
 }
 
+export async function exportNotificationDeliveries(
+  params: NotificationDeliveryQuery = {},
+): Promise<string> {
+  if (!isMockMode()) return opsApi.exportNotificationDeliveries(params);
+  return '';
+}
+
 export async function listAlertSilences(): Promise<AlertSilence[]> {
   if (isMockMode()) return alertSilencesState.map((silence) => ({ ...silence }));
   return opsApi.listAlertSilences();


### PR DESCRIPTION
## Summary

- Add `GET /api/system-alerts/deliveries/export` that reuses the existing
  `channel` / `status` / `instanceId` filters of the deliveries page.
- Export at most 10,000 rows ordered by delivery id (reuses
  `RmqAlertNotificationOutboxMapper.findPage`, which already applies
  `ORDER BY o.id DESC`).
- CSV columns: Delivery ID, Alert ID, Alert Title, Alert Domain, Transition,
  Instance ID, Channel, Status, Attempt Count, Created At, Delivered At,
  Next Attempt At, Last Error. `messageContent` is never exported.
- Rendering goes through the shared `CsvUtil.appendRow`, which quotes every
  cell and neutralizes spreadsheet formula injection.
- Frontend `exportNotificationDeliveries(params)` API helper plus an Export
  button on the notification deliveries page that downloads the CSV built
  from the current channel/status/instance filters.

## Why

Issue #3559 asks for a way to export notification deliveries for analysis
without leaking the rendered alert message content. The deliveries page
already exposes channel/status/instance filters, so the export endpoint
reuses the exact same normalization and paging query path, capped at
10,000 rows.

Fixes #3559

## Testing

- `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` → exit 0
- `cd web && ./node_modules/.bin/vitest run src/api/ops.test.ts src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx`
  → 2 files passed, 31 tests passed
- `cd server && mvn -B -ntp test -Dtest=NotificationOutboxServiceTest,SystemAlertControllerTest -DfailIfNoTests=false`
  → Tests run: 40, Failures: 0, Errors: 0, Skipped: 0; BUILD SUCCESS
