### PR TITLE
feat(alert): allow editing maintenance windows after creation

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceController.java
@@ -53,6 +53,11 @@ public class AlertSilenceController {
         return Result.ok(silenceService.create(request));
     }
 
+    @PostMapping("/update")
+    public Result<AlertSilenceVO> update(@Valid @RequestBody UpdateAlertSilenceDTO request) {
+        return Result.ok(silenceService.update(request));
+    }
+
     @DeleteMapping("/{id}")
     public Result<Void> delete(@PathVariable Long id) {
         silenceService.delete(id);

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceService.java
@@ -52,30 +52,27 @@ public class AlertSilenceService {
     }
 
     public AlertSilenceVO create(CreateAlertSilenceDTO request) {
-        if (request == null || request.getStartsAt() == null || request.getEndsAt() == null) {
-            throw new BusinessException(400, "Silence start and end times are required");
-        }
-        if (!request.getEndsAt().toInstant().isAfter(request.getStartsAt().toInstant())) {
-            throw new BusinessException(400, "Silence end time must be after start time");
-        }
-        if (request.getReason() != null && request.getReason().length() > 512) {
-            throw new BusinessException(400, "Silence reason must not exceed 512 characters");
-        }
+        validateSilence(request);
         RecurrenceConfiguration recurrence = validateRecurrence(request);
-        AlertSilenceVO silence = AlertSilenceVO.builder().domain(request.getDomain())
-                .ruleId(request.getRuleId()).instanceId(trimToNull(request.getInstanceId()))
-                .labels(normalizeLabels(request.getLabels()))
-                .startsAt(LocalDateTime.ofInstant(request.getStartsAt().toInstant(), ZoneOffset.UTC))
-                .endsAt(LocalDateTime.ofInstant(request.getEndsAt().toInstant(), ZoneOffset.UTC))
-                .recurrence(recurrence.type()).timeZone(recurrence.timeZone())
-                .recurrenceDays(recurrence.days()).recurrenceUntil(recurrence.until())
-                .reason(trimToNull(request.getReason()))
-                .createdBy(AuthenticatedUserContext.currentUsernameOrSystem()).build();
+        AlertSilenceVO silence = buildSilence(request, null,
+                AuthenticatedUserContext.currentUsernameOrSystem(), recurrence);
         AlertSilenceVO saved = repository.save(silence);
-        operationAuditService.record("CREATE_ALERT_SILENCE", "ALERT_SILENCE", String.valueOf(saved.getId()),
-                saved.getInstanceId(), "ruleId=" + saved.getRuleId() + ", recurrence=" + saved.getRecurrence(),
-                "SUCCESS", null);
+        recordAudit("CREATE_ALERT_SILENCE", saved);
         return saved;
+    }
+
+    public AlertSilenceVO update(UpdateAlertSilenceDTO request) {
+        if (request == null || request.getId() == null) {
+            throw new BusinessException(400, "Silence ID is required");
+        }
+        AlertSilenceVO existing = repository.findById(request.getId())
+                .orElseThrow(() -> new BusinessException(404, "Alert silence not found: " + request.getId()));
+        validateSilence(request);
+        RecurrenceConfiguration recurrence = validateRecurrence(request);
+        AlertSilenceVO silence = buildSilence(request, existing.getId(), existing.getCreatedBy(), recurrence);
+        AlertSilenceVO updated = repository.update(silence);
+        recordAudit("UPDATE_ALERT_SILENCE", updated);
+        return updated;
     }
 
     public void delete(Long id) {
@@ -86,6 +83,37 @@ public class AlertSilenceService {
             throw new BusinessException(404, "Alert silence not found: " + id);
         }
         operationAuditService.record("DELETE_ALERT_SILENCE", "ALERT_SILENCE", String.valueOf(id), null, null,
+                "SUCCESS", null);
+    }
+
+    private static void validateSilence(CreateAlertSilenceDTO request) {
+        if (request == null || request.getStartsAt() == null || request.getEndsAt() == null) {
+            throw new BusinessException(400, "Silence start and end times are required");
+        }
+        if (!request.getEndsAt().toInstant().isAfter(request.getStartsAt().toInstant())) {
+            throw new BusinessException(400, "Silence end time must be after start time");
+        }
+        if (request.getReason() != null && request.getReason().length() > 512) {
+            throw new BusinessException(400, "Silence reason must not exceed 512 characters");
+        }
+    }
+
+    private static AlertSilenceVO buildSilence(CreateAlertSilenceDTO request, Long id, String createdBy,
+            RecurrenceConfiguration recurrence) {
+        return AlertSilenceVO.builder().id(id).domain(request.getDomain())
+                .ruleId(request.getRuleId()).instanceId(trimToNull(request.getInstanceId()))
+                .labels(normalizeLabels(request.getLabels()))
+                .startsAt(LocalDateTime.ofInstant(request.getStartsAt().toInstant(), ZoneOffset.UTC))
+                .endsAt(LocalDateTime.ofInstant(request.getEndsAt().toInstant(), ZoneOffset.UTC))
+                .recurrence(recurrence.type()).timeZone(recurrence.timeZone())
+                .recurrenceDays(recurrence.days()).recurrenceUntil(recurrence.until())
+                .reason(trimToNull(request.getReason()))
+                .createdBy(createdBy).build();
+    }
+
+    private void recordAudit(String operation, AlertSilenceVO silence) {
+        operationAuditService.record(operation, "ALERT_SILENCE", String.valueOf(silence.getId()),
+                silence.getInstanceId(), "ruleId=" + silence.getRuleId() + ", recurrence=" + silence.getRecurrence(),
                 "SUCCESS", null);
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepository.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -30,6 +31,7 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -45,6 +47,32 @@ public class MybatisPlusAlertSilenceRepository implements AlertSilenceRepository
         RmqAlertSilence entity = toEntity(silence);
         mapper.insert(entity);
         silence.setId(entity.getId());
+        return silence;
+    }
+
+    @Override
+    public Optional<AlertSilenceVO> findById(Long id) {
+        return Optional.ofNullable(mapper.selectById(id)).map(this::toVo);
+    }
+
+    @Override
+    public AlertSilenceVO update(AlertSilenceVO silence) {
+        RmqAlertSilence entity = toEntity(silence);
+        // Set every editable column explicitly so that clearing a scope field (null in the VO)
+        // is persisted as SQL NULL instead of being skipped by MyBatis-Plus updateById.
+        mapper.update(null, new UpdateWrapper<RmqAlertSilence>()
+                .eq("id", silence.getId())
+                .set("domain", entity.getDomain())
+                .set("rule_id", entity.getRuleId())
+                .set("instance_id", entity.getInstanceId())
+                .set("labels_json", entity.getLabelsJson())
+                .set("starts_at", entity.getStartsAt())
+                .set("ends_at", entity.getEndsAt())
+                .set("recurrence", entity.getRecurrence())
+                .set("time_zone", entity.getTimeZone())
+                .set("recurrence_days_json", entity.getRecurrenceDaysJson())
+                .set("recurrence_until", entity.getRecurrenceUntil())
+                .set("reason", entity.getReason()));
         return silence;
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/UpdateAlertSilenceDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/UpdateAlertSilenceDTO.java
@@ -16,24 +16,13 @@
  */
 package org.apache.rocketmq.studio.ops.alert;
 
-import org.apache.rocketmq.studio.common.domain.PageResult;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
-public interface AlertSilenceRepository {
-    AlertSilenceVO save(AlertSilenceVO silence);
-
-    Optional<AlertSilenceVO> findById(Long id);
-
-    AlertSilenceVO update(AlertSilenceVO silence);
-
-    List<AlertSilenceVO> findAll();
-
-    PageResult<AlertSilenceVO> findPage(int page, int pageSize);
-
-    List<AlertSilenceVO> findActiveCandidates(AlertDomain domain, Long ruleId, String instanceId, LocalDateTime now);
-
-    boolean deleteById(Long id);
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class UpdateAlertSilenceDTO extends CreateAlertSilenceDTO {
+    @NotNull(message = "id is required")
+    private Long id;
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceControllerTest.java
@@ -108,4 +108,56 @@ class AlertSilenceControllerTest {
                         && request.getRecurrenceDays().equals(Set.of(1, 3, 5))
                         && "Asia/Shanghai".equals(request.getTimeZone())));
     }
+
+    @Test
+    void updateShouldBindAndReturnUpdatedScheduleTest() throws Exception {
+        AlertSilenceVO silence = AlertSilenceVO.builder().id(13L)
+                .startsAt(LocalDateTime.of(2026, 9, 7, 1, 0))
+                .endsAt(LocalDateTime.of(2026, 9, 7, 2, 0))
+                .recurrence(AlertSilenceRecurrence.WEEKLY).timeZone("Asia/Shanghai")
+                .recurrenceDays(Set.of(1, 3, 5))
+                .recurrenceUntil(LocalDateTime.of(2026, 10, 1, 0, 0)).createdBy("admin").build();
+        when(silenceService.update(any(UpdateAlertSilenceDTO.class))).thenReturn(silence);
+
+        mockMvc.perform(post("/api/alert-silences/update")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "id": 13,
+                                  "startsAt": "2026-09-07T09:00:00+08:00",
+                                  "endsAt": "2026-09-07T10:00:00+08:00",
+                                  "recurrence": "WEEKLY",
+                                  "timeZone": "Asia/Shanghai",
+                                  "recurrenceDays": [1, 3, 5],
+                                  "recurrenceUntil": "2026-10-01T08:00:00+08:00"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/json"))
+                .andExpect(jsonPath("$.data.id").value(13))
+                .andExpect(jsonPath("$.data.recurrence").value("WEEKLY"))
+                .andExpect(jsonPath("$.data.createdBy").value("admin"));
+
+        verify(silenceService).update(org.mockito.ArgumentMatchers.argThat(request ->
+                request.getId() == 13L
+                        && request.getRecurrence() == AlertSilenceRecurrence.WEEKLY
+                        && request.getRecurrenceDays().equals(Set.of(1, 3, 5))
+                        && "Asia/Shanghai".equals(request.getTimeZone())));
+    }
+
+    @Test
+    void updateShouldRejectMissingIdTest() throws Exception {
+        mockMvc.perform(post("/api/alert-silences/update")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "startsAt": "2026-09-07T09:00:00+08:00",
+                                  "endsAt": "2026-09-07T10:00:00+08:00"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400));
+
+        verify(silenceService, org.mockito.Mockito.never()).update(any());
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceServiceTest.java
@@ -262,6 +262,82 @@ class AlertSilenceServiceTest {
                 .hasMessage("Weekly silence windows must not exceed 7 days");
     }
 
+    @Test
+    void updatesExistingSilencePreservingIdAndCreatorAndAuditsTest() {
+        AlertSilenceService service = new AlertSilenceService(repository, operationAuditService);
+        AlertSilenceVO existing = AlertSilenceVO.builder().id(9L)
+                .startsAt(LocalDateTime.of(2026, 9, 1, 10, 0)).endsAt(LocalDateTime.of(2026, 9, 1, 11, 0))
+                .createdBy("alice").build();
+        when(repository.findById(9L)).thenReturn(java.util.Optional.of(existing));
+        when(repository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        UpdateAlertSilenceDTO request = updateRequest(9L);
+        request.setDomain(AlertDomain.CLUSTER);
+        request.setInstanceId(" local ");
+        request.setReason("rescheduled maintenance");
+
+        AlertSilenceVO updated = service.update(request);
+
+        assertThat(updated.getId()).isEqualTo(9L);
+        assertThat(updated.getCreatedBy()).isEqualTo("alice");
+        assertThat(updated.getInstanceId()).isEqualTo("local");
+        assertThat(updated.getReason()).isEqualTo("rescheduled maintenance");
+        org.mockito.Mockito.verify(operationAuditService).record("UPDATE_ALERT_SILENCE", "ALERT_SILENCE", "9",
+                "local", "ruleId=null, recurrence=ONCE", "SUCCESS", null);
+    }
+
+    @Test
+    void updateRejectsMissingSilenceWithNotFoundTest() {
+        AlertSilenceService service = new AlertSilenceService(repository, operationAuditService);
+        when(repository.findById(9L)).thenReturn(java.util.Optional.empty());
+
+        assertThatThrownBy(() -> service.update(updateRequest(9L)))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Alert silence not found: 9");
+        org.mockito.Mockito.verify(repository, org.mockito.Mockito.never()).update(any());
+    }
+
+    @Test
+    void updateReusesCreateValidationAndNeverPersistsInvalidScheduleTest() {
+        AlertSilenceService service = new AlertSilenceService(repository, operationAuditService);
+        AlertSilenceVO existing = AlertSilenceVO.builder().id(9L)
+                .startsAt(LocalDateTime.of(2026, 9, 1, 10, 0)).endsAt(LocalDateTime.of(2026, 9, 1, 11, 0))
+                .createdBy("alice").build();
+        when(repository.findById(9L)).thenReturn(java.util.Optional.of(existing));
+        UpdateAlertSilenceDTO invalid = updateRequest(9L);
+        invalid.setRecurrence(AlertSilenceRecurrence.WEEKLY);
+        invalid.setTimeZone("UTC");
+        invalid.setRecurrenceUntil(java.time.OffsetDateTime.parse("2026-09-30T00:00:00Z"));
+
+        assertThatThrownBy(() -> service.update(invalid))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("At least one weekday is required for weekly silences");
+        org.mockito.Mockito.verify(repository, org.mockito.Mockito.never()).update(any());
+        org.mockito.Mockito.verify(operationAuditService, org.mockito.Mockito.never())
+                .record(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.isNull(),
+                        org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.isNull());
+    }
+
+    @Test
+    void updateRejectsMissingIdTest() {
+        AlertSilenceService service = new AlertSilenceService(repository, operationAuditService);
+        UpdateAlertSilenceDTO request = updateRequest(9L);
+        request.setId(null);
+
+        assertThatThrownBy(() -> service.update(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Silence ID is required");
+    }
+
+    private static UpdateAlertSilenceDTO updateRequest(Long id) {
+        UpdateAlertSilenceDTO request = new UpdateAlertSilenceDTO();
+        request.setId(id);
+        request.setStartsAt(java.time.OffsetDateTime.parse("2026-09-02T10:00:00Z"));
+        request.setEndsAt(java.time.OffsetDateTime.parse("2026-09-02T11:00:00Z"));
+        return request;
+    }
+
     private static CreateAlertSilenceDTO recurringRequest(AlertSilenceRecurrence recurrence) {
         CreateAlertSilenceDTO request = new CreateAlertSilenceDTO();
         request.setStartsAt(java.time.OffsetDateTime.parse("2026-09-01T10:00:00Z"));

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepositoryTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.ops.alert;
 
 import com.baomidou.mybatisplus.core.conditions.Wrapper;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -107,6 +108,57 @@ class MybatisPlusAlertSilenceRepositoryTest {
                 .containsValue(AlertDomain.CLUSTER.name())
                 .containsValue(5L)
                 .containsValue("local");
+    }
+
+    @Test
+    void findByIdShouldRestoreEntityToVoTest() {
+        MybatisPlusAlertSilenceRepository repository = new MybatisPlusAlertSilenceRepository(
+                mapper, new ObjectMapper());
+        RmqAlertSilence entity = new RmqAlertSilence();
+        entity.setId(9L);
+        entity.setDomain("BUSINESS");
+        entity.setInstanceId("local");
+        entity.setLabelsJson("{\"brokerName\":\"broker-a\"}");
+        entity.setStartsAt(LocalDateTime.of(2026, 9, 1, 10, 0));
+        entity.setEndsAt(LocalDateTime.of(2026, 9, 1, 11, 0));
+        entity.setRecurrence("ONCE");
+        entity.setCreatedBy("alice");
+        when(mapper.selectById(9L)).thenReturn(entity);
+
+        java.util.Optional<AlertSilenceVO> found = repository.findById(9L);
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(9L);
+        assertThat(found.get().getDomain()).isEqualTo(AlertDomain.BUSINESS);
+        assertThat(found.get().getLabels()).containsEntry("brokerName", "broker-a");
+        assertThat(found.get().getCreatedBy()).isEqualTo("alice");
+    }
+
+    @Test
+    void updateShouldExplicitlySetEditableColumnsAndKeepCreatorUntouchedTest() {
+        MybatisPlusAlertSilenceRepository repository = new MybatisPlusAlertSilenceRepository(
+                mapper, new ObjectMapper());
+        AlertSilenceVO silence = AlertSilenceVO.builder().id(9L)
+                .domain(null).startsAt(LocalDateTime.of(2026, 9, 2, 10, 0))
+                .endsAt(LocalDateTime.of(2026, 9, 2, 11, 0)).recurrence(AlertSilenceRecurrence.ONCE)
+                .createdBy("alice").build();
+        when(mapper.update(org.mockito.ArgumentMatchers.isNull(), any(UpdateWrapper.class))).thenReturn(1);
+
+        AlertSilenceVO updated = repository.update(silence);
+
+        ArgumentCaptor<UpdateWrapper<RmqAlertSilence>> captor = ArgumentCaptor.forClass(UpdateWrapper.class);
+        verify(mapper).update(org.mockito.ArgumentMatchers.isNull(), captor.capture());
+        assertThat(updated.getId()).isEqualTo(9L);
+        assertThat(captor.getValue().getSqlSet())
+                .contains("domain")
+                .contains("labels_json")
+                .contains("time_zone")
+                .contains("recurrence_days_json")
+                .contains("recurrence_until")
+                .contains("reason")
+                .doesNotContain("created_by")
+                .doesNotContain("gmt_create");
+        assertThat(captor.getValue().getTargetSql()).contains("id");
     }
 
     @Test

--- a/web/src/api/ops.test.ts
+++ b/web/src/api/ops.test.ts
@@ -46,6 +46,7 @@ import {
   listAlertSilences,
   listAlertSilencesPage,
   createAlertSilence,
+  updateAlertSilence,
   deleteAlertSilence,
   listAuditRecords,
   cleanupAuditLogs,
@@ -373,6 +374,7 @@ describe('Ops API - System Alerts & Audit', () => {
       return [200, { code: 200, data: { items: [silence], total: 21, page: 2, size: 10 } }];
     });
     mock.onPost('/alert-silences').reply(200, { code: 200, data: silence });
+    mock.onPost('/alert-silences/update').reply(200, { code: 200, data: silence });
     mock.onDelete('/alert-silences/2').reply(200, { code: 200 });
     await expect(listAlertSilences()).resolves.toEqual([silence]);
     await expect(listAlertSilencesPage({ page: 2, pageSize: 10 })).resolves.toEqual({
@@ -382,6 +384,7 @@ describe('Ops API - System Alerts & Audit', () => {
       size: 10,
     });
     await expect(createAlertSilence(silence)).resolves.toEqual(silence);
+    await expect(updateAlertSilence({ ...silence, instanceId: 'local' })).resolves.toEqual(silence);
     await expect(deleteAlertSilence(2)).resolves.toBeUndefined();
   });
 

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -168,6 +168,10 @@ export interface AlertSilence {
 
 export type CreateAlertSilence = Omit<AlertSilence, 'id' | 'createdBy'>;
 
+export interface UpdateAlertSilence extends CreateAlertSilence {
+  id: number;
+}
+
 // Matches mock/audit.ts (inferred from data)
 export interface AuditRecord {
   id: number;
@@ -376,6 +380,11 @@ export async function listAlertSilencesPage(params: AlertSilenceQuery = {}) {
 
 export async function createAlertSilence(data: CreateAlertSilence) {
   const res = await client.post<{ data: AlertSilence }>('/alert-silences', data);
+  return res.data.data;
+}
+
+export async function updateAlertSilence(data: UpdateAlertSilence) {
+  const res = await client.post<{ data: AlertSilence }>('/alert-silences/update', data);
   return res.data.data;
 }
 

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -759,6 +759,13 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: '维护窗口结束失败，请稍后重试',
     en: 'Failed to end maintenance window. Please try again later.',
   },
+  'sysAlerts.edit': { zh: '编辑', en: 'Edit' },
+  'sysAlerts.update': { zh: '更新', en: 'Update' },
+  'sysAlerts.silenceUpdated': { zh: '维护窗口已更新', en: 'Maintenance window updated.' },
+  'sysAlerts.silenceUpdateFailed': {
+    zh: '维护窗口更新失败，请检查时间范围',
+    en: 'Failed to update maintenance window. Check the time range.',
+  },
   'sysAlerts.exportCsv': { zh: '导出 CSV', en: 'Export CSV' },
   'sysAlerts.maintenanceWindows': { zh: '维护窗口', en: 'Maintenance windows' },
   'sysAlerts.business': { zh: '业务告警', en: 'Business alerts' },

--- a/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
@@ -23,6 +23,7 @@ import {
   listAlertSilences,
   listAlertSilencesPage,
   listSystemAlertsPage,
+  updateAlertSilence,
 } from '../../../services/opsService';
 import SystemAlertsPage from '../systemAlerts';
 
@@ -37,6 +38,7 @@ vi.mock('../../../services/opsService', () => ({
   listAlertSilences: vi.fn(),
   listAlertSilencesPage: vi.fn(),
   createAlertSilence: vi.fn(),
+  updateAlertSilence: vi.fn(),
   deleteAlertSilence: vi.fn(),
 }));
 
@@ -608,5 +610,82 @@ describe('SystemAlertsPage', () => {
       expect(deleteAlertSilence).toHaveBeenCalledWith(10);
       expect(listAlertSilencesPage).toHaveBeenLastCalledWith({ page: 1, pageSize: 10 });
     });
+  });
+
+  it('edits an existing maintenance window with a prefilled form', async () => {
+    vi.mocked(listAlertSilencesPage).mockResolvedValue({
+      items: [
+        {
+          id: 9,
+          domain: 'CLUSTER',
+          instanceId: 'local',
+          labels: { brokerName: 'broker-a' },
+          startsAt: '2026-09-07T01:00',
+          endsAt: '2026-09-07T02:00',
+          recurrence: 'WEEKLY',
+          timeZone: 'Asia/Shanghai',
+          recurrenceDays: [1, 3],
+          recurrenceUntil: '2026-10-01T00:00',
+          reason: 'planned upgrade',
+          createdBy: 'alice',
+        },
+      ],
+      total: 1,
+      page: 1,
+      size: 10,
+    });
+    vi.mocked(updateAlertSilence).mockResolvedValue({
+      id: 9,
+      domain: 'CLUSTER',
+      instanceId: 'remote',
+      startsAt: '2026-09-07T01:00',
+      endsAt: '2026-09-07T02:00',
+      recurrence: 'WEEKLY',
+      timeZone: 'Asia/Shanghai',
+      recurrenceDays: [1, 3],
+      recurrenceUntil: '2026-10-01T00:00',
+      reason: 'updated reason',
+      createdBy: 'alice',
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole('button', { name: '维护窗口' }));
+    await user.click(await screen.findByRole('button', { name: /编\s*辑/ }));
+
+    // The form is prefilled with the window converted into its configured time zone.
+    expect(screen.getByLabelText('开始时间')).toHaveValue('2026-09-07T09:00');
+    expect(screen.getByLabelText('结束时间')).toHaveValue('2026-09-07T10:00');
+    expect(screen.getByLabelText('重复至')).toHaveValue('2026-10-01T08:00');
+    expect(screen.getByLabelText('时区')).toHaveValue('Asia/Shanghai');
+    expect(screen.getByLabelText('标签范围')).toHaveValue('brokerName=broker-a');
+    expect(screen.getByLabelText('原因')).toHaveValue('planned upgrade');
+
+    await user.clear(screen.getByLabelText('实例 ID'));
+    await user.type(screen.getByLabelText('实例 ID'), 'remote');
+    await user.clear(screen.getByLabelText('原因'));
+    await user.type(screen.getByLabelText('原因'), 'updated reason');
+    await user.click(screen.getByRole('button', { name: /更\s*新/ }));
+
+    await waitFor(() => {
+      expect(updateAlertSilence).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 9,
+          domain: 'CLUSTER',
+          instanceId: 'remote',
+          labels: { brokerName: 'broker-a' },
+          recurrence: 'WEEKLY',
+          timeZone: 'Asia/Shanghai',
+          recurrenceDays: [1, 3],
+          startsAt: '2026-09-07T01:00:00.000Z',
+          endsAt: '2026-09-07T02:00:00.000Z',
+          recurrenceUntil: '2026-10-01T00:00:00.000Z',
+          reason: 'updated reason',
+        }),
+      );
+      expect(createAlertSilence).not.toHaveBeenCalled();
+      expect(listAlertSilencesPage).toHaveBeenLastCalledWith({ page: 1, pageSize: 10 });
+    });
+    expect(await screen.findByText('维护窗口已更新')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -44,6 +44,7 @@ import {
   retryAlertDelivery,
   listSystemAlertsPage,
   createAlertSilence,
+  updateAlertSilence,
   deleteAlertSilence,
   listAlertSilencesPage,
 } from '../../services/opsService';
@@ -104,6 +105,23 @@ const parseSilenceLabels = (
 const localDateTimeToUtc = (value: string) => new Date(`${value}:00`).toISOString();
 const localDateTimeToUtcDatabaseValue = (value: string) =>
   new Date(`${value}:00`).toISOString().replace('Z', '');
+
+const utcLocalDateTimeToInputValue = (value: string, timeZone: string) => {
+  const timestamp = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(value.trim()) ? new Date(value) : new Date(`${value}Z`);
+  if (Number.isNaN(timestamp.getTime())) return '';
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  }).formatToParts(timestamp);
+  const part = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((candidate) => candidate.type === type)?.value ?? '00';
+  return `${part('year')}-${part('month')}-${part('day')}T${part('hour')}:${part('minute')}`;
+};
 
 const ALERT_EXPORT_COLUMNS: CsvColumn<SystemAlert>[] = [
   { header: 'ID', value: (alert) => alert.id },
@@ -173,6 +191,7 @@ const SystemAlertsPage = () => {
   const [silenceTotal, setSilenceTotal] = useState(0);
   const [savingSilence, setSavingSilence] = useState(false);
   const [deletingSilenceId, setDeletingSilenceId] = useState<number | null>(null);
+  const [editingSilenceId, setEditingSilenceId] = useState<number | null>(null);
   const silencePageSize = 10;
   const [silenceForm] = Form.useForm();
   const silenceRecurrence = Form.useWatch('recurrence', silenceForm) ?? 'ONCE';
@@ -375,11 +394,38 @@ const SystemAlertsPage = () => {
 
   const openSilences = () => {
     setSilencePage(1);
+    setEditingSilenceId(null);
+    silenceForm.resetFields();
     setSilencesVisible(true);
     void loadSilences(1);
   };
 
-  const createSilence = async () => {
+  const openEditSilence = (silence: AlertSilence) => {
+    const recurrence = silence.recurrence ?? 'ONCE';
+    const timeZone = recurrence === 'ONCE' ? DEFAULT_TIME_ZONE : (silence.timeZone ?? DEFAULT_TIME_ZONE);
+    const convertTime = (value: string) => utcLocalDateTimeToInputValue(value, timeZone);
+    setEditingSilenceId(silence.id);
+    silenceForm.setFieldsValue({
+      domain: silence.domain ?? undefined,
+      ruleId: silence.ruleId != null ? String(silence.ruleId) : undefined,
+      instanceId: silence.instanceId ?? undefined,
+      labelsText:
+        silence.labels && Object.keys(silence.labels).length > 0
+          ? Object.entries(silence.labels)
+              .map(([key, value]) => `${key}=${value}`)
+              .join(', ')
+          : undefined,
+      recurrence,
+      timeZone,
+      recurrenceDays: silence.recurrenceDays ?? undefined,
+      recurrenceUntil: silence.recurrenceUntil ? convertTime(silence.recurrenceUntil) : undefined,
+      startsAt: convertTime(silence.startsAt),
+      endsAt: convertTime(silence.endsAt),
+      reason: silence.reason ?? undefined,
+    });
+  };
+
+  const submitSilence = async () => {
     let values: {
       domain?: 'BUSINESS' | 'CLUSTER';
       ruleId?: string;
@@ -399,6 +445,7 @@ const SystemAlertsPage = () => {
       return;
     }
     setSavingSilence(true);
+    const editing = editingSilenceId != null;
     try {
       const recurrence = values.recurrence ?? 'ONCE';
       const convertTime = (value: string) =>
@@ -421,13 +468,18 @@ const SystemAlertsPage = () => {
             ? convertTime(values.recurrenceUntil)
             : undefined,
       };
-      await createAlertSilence(request);
+      if (editing && editingSilenceId != null) {
+        await updateAlertSilence({ ...request, id: editingSilenceId });
+      } else {
+        await createAlertSilence(request);
+      }
       silenceForm.resetFields();
+      setEditingSilenceId(null);
       setSilencePage(1);
       await loadSilences(1);
-      message.success(t('sysAlerts.silenceCreated'));
+      message.success(editing ? t('sysAlerts.silenceUpdated') : t('sysAlerts.silenceCreated'));
     } catch {
-      message.error(t('sysAlerts.silenceCreateFailed'));
+      message.error(editing ? t('sysAlerts.silenceUpdateFailed') : t('sysAlerts.silenceCreateFailed'));
     } finally {
       setSavingSilence(false);
     }
@@ -824,9 +876,12 @@ const SystemAlertsPage = () => {
       <Modal
         title={t('sysAlerts.maintenanceWindows')}
         open={silencesVisible}
-        onCancel={() => setSilencesVisible(false)}
-        onOk={() => void createSilence()}
-        okText={t('sysAlerts.create')}
+        onCancel={() => {
+          setSilencesVisible(false);
+          setEditingSilenceId(null);
+        }}
+        onOk={() => void submitSilence()}
+        okText={editingSilenceId != null ? t('sysAlerts.update') : t('sysAlerts.create')}
         okButtonProps={{ style: { display: canManageSilences ? undefined : 'none' } }}
         confirmLoading={savingSilence}
         width={680}
@@ -969,14 +1024,23 @@ const SystemAlertsPage = () => {
                     : ''}
                 </Text>
                 {canManageSilences && (
-                  <Button
-                    size="small"
-                    danger
-                    loading={deletingSilenceId === silence.id}
-                    onClick={() => void deleteSilence(silence.id)}
-                  >
-                    {t('sysAlerts.end')}
-                  </Button>
+                  <Flex gap={4} align="center" style={{ flexShrink: 0 }}>
+                    <Button
+                      size="small"
+                      type="link"
+                      onClick={() => openEditSilence(silence)}
+                    >
+                      {t('sysAlerts.edit')}
+                    </Button>
+                    <Button
+                      size="small"
+                      danger
+                      loading={deletingSilenceId === silence.id}
+                      onClick={() => void deleteSilence(silence.id)}
+                    >
+                      {t('sysAlerts.end')}
+                    </Button>
+                  </Flex>
                 )}
               </Flex>
             ))}

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -28,6 +28,7 @@ import type {
   AlertSilenceQuery,
   AlertSilence,
   CreateAlertSilence,
+  UpdateAlertSilence,
 } from '../api/ops';
 import { mockAlertRules } from '../mock/alerts';
 import { mockAuditRecords } from '../mock/audit';
@@ -465,6 +466,14 @@ export async function createAlertSilence(data: CreateAlertSilence): Promise<Aler
   const silence = { ...data, id: Date.now(), createdBy: 'admin' } as AlertSilence;
   alertSilencesState = [silence, ...alertSilencesState];
   return silence;
+}
+
+export async function updateAlertSilence(data: UpdateAlertSilence): Promise<AlertSilence> {
+  if (!isMockMode()) return opsApi.updateAlertSilence(data);
+  const existing = alertSilencesState.find((silence) => silence.id === data.id);
+  const updated = { ...data, createdBy: existing?.createdBy ?? 'admin' } as AlertSilence;
+  alertSilencesState = alertSilencesState.map((silence) => (silence.id === data.id ? updated : silence));
+  return updated;
 }
 
 export async function deleteAlertSilence(id: number): Promise<void> {


### PR DESCRIPTION
Fixes #3165

## Summary

Maintenance windows (alert silences) can now be edited after creation instead of
only being ended. The silence form in the System Alerts page gains an **Edit**
action per window; opening it prefills the existing window (times converted from
stored UTC into the window's time zone, scope fields, recurrence settings and
reason) and submits an update.

Backend:

- `UpdateAlertSilenceDTO` carries the window `id` plus the same editable fields
  as `CreateAlertSilenceDTO`.
- `POST /api/alert-silences/update` updates an existing window.
- `AlertSilenceService.update` loads the current record (404 when missing),
  reuses the exact create-time validation (end after start, valid IANA time
  zone, recurrence end required and after the first window, daily/weekly window
  duration caps, ISO weekdays 1-7, bounded labels/reason), and preserves the
  original `id`, `creator` and `gmt_create`.
- Updates are written to the operation audit log as `UPDATE_ALERT_SILENCE` /
  `ALERT_SILENCE`, mirroring the existing create/delete audit entries.
- `MybatisPlusAlertSilenceRepository.update` sets every editable column
  explicitly via `UpdateWrapper`, so clearing a scope (e.g. empty labels,
  `ONCE` recurrence) is persisted as SQL `NULL` instead of being skipped by
  MyBatis-Plus `updateById`'s null-field strategy; `created_by` is never
  touched.

Frontend:

- `updateAlertSilence` API function and mock-mode service support.
- Edit button next to the existing End action; the create/update form is
  prefilled and the modal switches to Update mode, then refreshes the list.

## Why

Maintenance windows are used to suppress notifications during planned work.
Today an admin who mistypes a time, needs a different scope, or wants to
reschedule a recurring window must delete the window and recreate it, losing
the original record id and creator and requiring the whole form to be filled
again. Editing reuses all create-time validation so an invalid edit can never
produce an invalid window.

## Testing

- Backend (`mvn test -Dtest=AlertSilenceServiceTest,AlertSilenceControllerTest,MybatisPlusAlertSilenceRepositoryTest`):
  - update succeeds and keeps the original id/creator; audit records
    `UPDATE_ALERT_SILENCE`.
  - update of an unknown id returns 404; missing id is rejected.
  - invalid recurrence (weekly without weekdays) is rejected by the shared
    validation and nothing is persisted.
  - repository update sets every editable column explicitly (including null
    clears) and never sets `created_by`/`gmt_create`; `findById` restores the
    VO.
  - controller binds `POST /api/alert-silences/update`, returns the updated
    schedule, and rejects a body without `id` with 400.
- Frontend (`vitest run src/api/ops.test.ts src/pages/ops/__tests__/SystemAlertsPage.test.tsx`):
  - the update API posts to `/alert-silences/update`.
  - page test: clicking Edit prefills the weekly window in its IANA time zone,
    submitting calls `updateAlertSilence` with converted UTC instants and the
    original recurrence scope, does not call create, refreshes the list and
    shows the success message.
- `tsc -b tsconfig.app.json` passes.
