### PR TITLE
feat(alert): retry failed deliveries matching channel and instance filters

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
@@ -262,6 +262,21 @@ public class NotificationOutboxService {
         return new NotificationDeliveryBulkRetryResult(succeeded, failures);
     }
 
+    public NotificationDeliveryBulkRetryResult retryFilteredDeliveries(String channel, String instanceId,
+            int limit) {
+        if (limit < 1 || limit > 100) {
+            throw new org.apache.rocketmq.studio.common.exception.BusinessException(400,
+                    "Limit must be between 1 and 100");
+        }
+        String normalizedChannel = normalizeFilter(channel);
+        String normalizedInstanceId = normalizeTrim(instanceId);
+        List<Long> failedIds = mapper.findFailedIds(normalizedChannel, normalizedInstanceId, limit);
+        if (failedIds.isEmpty()) {
+            return new NotificationDeliveryBulkRetryResult(List.of(), Map.of());
+        }
+        return retryFailedDeliveries(failedIds);
+    }
+
     private static String normalizeFilter(String value) {
         String normalized = normalizeTrim(value);
         return normalized == null ? null : normalized.toLowerCase(Locale.ROOT);

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/RetryFilteredDeliveriesDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/RetryFilteredDeliveriesDTO.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Filters for bulk-retrying failed notification deliveries matching a channel and/or instance. */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RetryFilteredDeliveriesDTO {
+    private String channel;
+
+    private String instanceId;
+
+    @Min(value = 1, message = "limit must be between 1 and 100")
+    @Max(value = 100, message = "limit must be between 1 and 100")
+    private Integer limit = 100;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertController.java
@@ -99,6 +99,15 @@ public class SystemAlertController {
         return Result.ok(notificationOutboxService.retryFailedDeliveries(deliveryIds));
     }
 
+    @PostMapping("/deliveries/retry-filtered")
+    public Result<NotificationDeliveryBulkRetryResult> retryFilteredDeliveries(
+            @Valid @RequestBody(required = false) RetryFilteredDeliveriesDTO request) {
+        RetryFilteredDeliveriesDTO dto = request == null ? new RetryFilteredDeliveriesDTO() : request;
+        int limit = dto.getLimit() == null ? 100 : dto.getLimit();
+        return Result.ok(notificationOutboxService.retryFilteredDeliveries(
+                dto.getChannel(), dto.getInstanceId(), limit));
+    }
+
     @PostMapping("/acknowledge")
     public Result<SystemAlertVO> acknowledgeAlert(
             @Valid @RequestBody(required = false) AcknowledgeSystemAlertDTO request) {

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/mapper/RmqAlertNotificationOutboxMapper.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/mapper/RmqAlertNotificationOutboxMapper.java
@@ -77,4 +77,15 @@ public interface RmqAlertNotificationOutboxMapper extends BaseMapper<RmqAlertNot
             + "</script>")
     long countPage(@Param("channel") String channel, @Param("status") String status,
             @Param("instanceId") String instanceId);
+
+    @Select("<script>"
+            + "SELECT o.id FROM rmq_alert_notification_outbox o "
+            + "JOIN rmq_system_alert a ON a.id = o.alert_id "
+            + "WHERE o.status = 'FAILED'"
+            + "<if test='channel != null and channel != \"\"'> AND o.channel = #{channel}</if>"
+            + "<if test='instanceId != null and instanceId != \"\"'> AND a.instance_id = #{instanceId}</if>"
+            + " ORDER BY o.id LIMIT #{limit}"
+            + "</script>")
+    List<Long> findFailedIds(@Param("channel") String channel, @Param("instanceId") String instanceId,
+            @Param("limit") int limit);
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxServiceTest.java
@@ -531,6 +531,78 @@ class NotificationOutboxServiceTest {
     }
 
     @Test
+    void retriesFailedDeliveriesMatchingTheNormalizedFiltersTest() {
+        RmqAlertNotificationOutboxMapper mapper = mock(RmqAlertNotificationOutboxMapper.class);
+        RmqAlertNotificationOutbox failed = new RmqAlertNotificationOutbox();
+        failed.setId(8L);
+        failed.setAlertId(9L);
+        failed.setChannel("dingtalk");
+        failed.setStatus(NotificationOutboxStatus.FAILED.name());
+        when(mapper.findFailedIds("dingtalk", "local", 50)).thenReturn(List.of(8L));
+        when(mapper.selectById(8L)).thenReturn(failed);
+        when(mapper.update(org.mockito.ArgumentMatchers.isNull(), any(UpdateWrapper.class))).thenReturn(1);
+
+        NotificationDeliveryBulkRetryResult result = new NotificationOutboxService(mapper,
+                mock(SettingsRepository.class), mock(AlertSilenceService.class), mock(AlertRepository.class),
+                mock(OperationAuditService.class)).retryFilteredDeliveries(" DingTalk ", "local", 50);
+
+        verify(mapper).findFailedIds("dingtalk", "local", 50);
+        assertThat(result.getSucceededIds()).containsExactly(8L);
+        assertThat(result.getFailures()).isEmpty();
+    }
+
+    @Test
+    void reusesThePerDeliveryRetryPathForFilteredRetriesTest() {
+        RmqAlertNotificationOutboxMapper mapper = mock(RmqAlertNotificationOutboxMapper.class);
+        RmqAlertNotificationOutbox failed = new RmqAlertNotificationOutbox();
+        failed.setId(8L);
+        failed.setAlertId(9L);
+        failed.setChannel("dingtalk");
+        failed.setStatus(NotificationOutboxStatus.FAILED.name());
+        when(mapper.findFailedIds("dingtalk", "local", 100)).thenReturn(List.of(8L, 9L));
+        when(mapper.selectById(8L)).thenReturn(failed);
+        when(mapper.selectById(9L)).thenReturn(null);
+        when(mapper.update(org.mockito.ArgumentMatchers.isNull(), any(UpdateWrapper.class))).thenReturn(1);
+
+        NotificationDeliveryBulkRetryResult result = new NotificationOutboxService(mapper,
+                mock(SettingsRepository.class), mock(AlertSilenceService.class), mock(AlertRepository.class),
+                mock(OperationAuditService.class)).retryFilteredDeliveries("dingtalk", "local", 100);
+
+        assertThat(result.getSucceededIds()).containsExactly(8L);
+        assertThat(result.getFailures()).containsEntry(9L, "Only failed notification deliveries can be retried");
+    }
+
+    @Test
+    void shortCircuitsFilteredRetryWhenNoFailedDeliveriesMatchTest() {
+        RmqAlertNotificationOutboxMapper mapper = mock(RmqAlertNotificationOutboxMapper.class);
+        when(mapper.findFailedIds("dingtalk", "local", 100)).thenReturn(List.of());
+
+        NotificationDeliveryBulkRetryResult result = new NotificationOutboxService(mapper,
+                mock(SettingsRepository.class), mock(AlertSilenceService.class), mock(AlertRepository.class),
+                mock(OperationAuditService.class)).retryFilteredDeliveries("dingtalk", "local", 100);
+
+        assertThat(result.getSucceededIds()).isEmpty();
+        assertThat(result.getFailures()).isEmpty();
+        verify(mapper, never()).selectById(anyLong());
+        verify(mapper, never()).update(any(), any());
+    }
+
+    @Test
+    void rejectsFilteredRetryWhenLimitIsOutOfRangeTest() {
+        RmqAlertNotificationOutboxMapper mapper = mock(RmqAlertNotificationOutboxMapper.class);
+        NotificationOutboxService service = new NotificationOutboxService(mapper, mock(SettingsRepository.class),
+                mock(AlertSilenceService.class), mock(AlertRepository.class), mock(OperationAuditService.class));
+
+        for (int limit : new int[] {0, 101}) {
+            org.assertj.core.api.Assertions.assertThatThrownBy(
+                            () -> service.retryFilteredDeliveries("dingtalk", "local", limit))
+                    .isInstanceOf(org.apache.rocketmq.studio.common.exception.BusinessException.class)
+                    .hasMessage("Limit must be between 1 and 100");
+        }
+        verify(mapper, never()).findFailedIds(anyString(), anyString(), any(Integer.class));
+    }
+
+    @Test
     void renewsClaimWhileEmailDeliveryIsStillInFlightTest() throws Exception {
         RmqAlertNotificationOutboxMapper mapper = mock(RmqAlertNotificationOutboxMapper.class);
         SettingsRepository settings = mock(SettingsRepository.class);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
@@ -159,6 +159,51 @@ class SystemAlertControllerTest {
     }
 
     @Test
+    void retryFilteredDeliveriesShouldForwardChannelInstanceAndLimitTest() throws Exception {
+        NotificationDeliveryBulkRetryResult result = new NotificationDeliveryBulkRetryResult(
+                List.of(8L), Map.of());
+        when(notificationOutboxService.retryFilteredDeliveries("dingtalk", "local", 50)).thenReturn(result);
+
+        mockMvc.perform(post("/api/system-alerts/deliveries/retry-filtered")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("channel", "dingtalk", "instanceId", "local", "limit", 50))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.succeededIds[0]").value(8));
+
+        verify(notificationOutboxService).retryFilteredDeliveries("dingtalk", "local", 50);
+    }
+
+    @Test
+    void retryFilteredDeliveriesShouldDefaultTheLimitTest() throws Exception {
+        NotificationDeliveryBulkRetryResult result = new NotificationDeliveryBulkRetryResult(
+                List.of(), Map.of());
+        when(notificationOutboxService.retryFilteredDeliveries("dingtalk", null, 100)).thenReturn(result);
+
+        mockMvc.perform(post("/api/system-alerts/deliveries/retry-filtered")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("channel", "dingtalk"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.succeededIds").isEmpty());
+
+        verify(notificationOutboxService).retryFilteredDeliveries("dingtalk", null, 100);
+    }
+
+    @Test
+    void retryFilteredDeliveriesShouldRejectOutOfRangeLimitTest() throws Exception {
+        mockMvc.perform(post("/api/system-alerts/deliveries/retry-filtered")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("limit", 101))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("limit must be between 1 and 100"));
+
+        verifyNoInteractions(notificationOutboxService);
+    }
+
+    @Test
     void acknowledgeAlertShouldPassValidatedRequestTest() throws Exception {
         SystemAlertVO acknowledged = SystemAlertVO.builder()
                 .id(1L)

--- a/web/src/api/ops.test.ts
+++ b/web/src/api/ops.test.ts
@@ -43,6 +43,7 @@ import {
   acknowledgeAlert,
   clearAcknowledgedAlerts,
   listAlertDeliveries,
+  retryFilteredDeliveries,
   listAlertSilences,
   listAlertSilencesPage,
   createAlertSilence,
@@ -358,6 +359,21 @@ describe('Ops API - System Alerts & Audit', () => {
     await expect(listAlertDeliveries(1)).resolves.toEqual([
       { id: 1, channel: 'dingtalk', status: 'DELIVERED', attemptCount: 1 },
     ]);
+  });
+
+  it('retries failed deliveries matching the channel and instance filters', async () => {
+    mock.onPost('/system-alerts/deliveries/retry-filtered').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({
+        channel: 'dingtalk',
+        instanceId: 'local',
+        limit: 50,
+      });
+      return [200, { code: 200, data: { succeededIds: [8], failures: { 9: 'not failed' } } }];
+    });
+
+    await expect(
+      retryFilteredDeliveries({ channel: 'dingtalk', instanceId: 'local', limit: 50 }),
+    ).resolves.toEqual({ succeededIds: [8], failures: { 9: 'not failed' } });
   });
 
   it('manages alert silences', async () => {

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -145,6 +145,12 @@ export interface NotificationDeliveryQuery {
   pageSize?: number;
 }
 
+export interface RetryFilteredDeliveriesRequest {
+  channel?: string;
+  instanceId?: string;
+  limit?: number;
+}
+
 export interface AlertSilenceQuery {
   page?: number;
   pageSize?: number;
@@ -350,6 +356,14 @@ export async function retryAlertDeliveries(ids: number[]) {
   const res = await client.post<{ data: NotificationDeliveryBulkRetryResult }>(
     '/system-alerts/deliveries/retry',
     ids,
+  );
+  return res.data.data;
+}
+
+export async function retryFilteredDeliveries(params: RetryFilteredDeliveriesRequest = {}) {
+  const res = await client.post<{ data: NotificationDeliveryBulkRetryResult }>(
+    '/system-alerts/deliveries/retry-filtered',
+    params,
   );
   return res.data.data;
 }

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -584,6 +584,10 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: '重试当前页失败记录',
     en: 'Retry failed records on this page',
   },
+  'deliveries.retryMatchingFailures': {
+    zh: '重试匹配的失败记录',
+    en: 'Retry matching failures',
+  },
 
   // ─── General Settings ───
   'settings.generalLoadFailed': {

--- a/web/src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
+++ b/web/src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
@@ -10,7 +10,11 @@ import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LangProvider } from '../../../i18n/LangContext';
 import { listInstances } from '../../../services/instanceService';
-import { listAlertDeliveriesPage, retryAlertDelivery } from '../../../services/opsService';
+import {
+  listAlertDeliveriesPage,
+  retryAlertDelivery,
+  retryFilteredDeliveries,
+} from '../../../services/opsService';
 import NotificationDeliveriesPage from '../notificationDeliveries';
 
 vi.mock('../../../services/instanceService', () => ({
@@ -20,6 +24,7 @@ vi.mock('../../../services/opsService', () => ({
   listAlertDeliveriesPage: vi.fn(),
   retryAlertDeliveries: vi.fn(),
   retryAlertDelivery: vi.fn(),
+  retryFilteredDeliveries: vi.fn(),
 }));
 
 const deferred = <T,>() => {
@@ -80,6 +85,32 @@ describe('NotificationDeliveriesPage', () => {
     await user.click(screen.getByRole('button', { name: '重新投递' }));
 
     await waitFor(() => expect(retryAlertDelivery).toHaveBeenCalledWith(7));
+    await waitFor(() => expect(listAlertDeliveriesPage).toHaveBeenCalledTimes(2));
+  });
+
+  it('retries all failed deliveries matching the current channel and instance filters', async () => {
+    vi.mocked(retryFilteredDeliveries).mockResolvedValue({
+      succeededIds: [7, 8],
+      failures: { 9: 'Delivery is not failed' },
+    });
+    const user = userEvent.setup();
+    render(
+      <App>
+        <LangProvider>
+          <NotificationDeliveriesPage />
+        </LangProvider>
+      </App>,
+    );
+
+    await screen.findByText('Broker disk usage');
+    await user.click(screen.getByRole('button', { name: '重试匹配的失败记录' }));
+
+    await waitFor(() =>
+      expect(retryFilteredDeliveries).toHaveBeenCalledWith({
+        channel: undefined,
+        instanceId: undefined,
+      }),
+    );
     await waitFor(() => expect(listAlertDeliveriesPage).toHaveBeenCalledTimes(2));
   });
 

--- a/web/src/pages/ops/notificationDeliveries.tsx
+++ b/web/src/pages/ops/notificationDeliveries.tsx
@@ -29,6 +29,7 @@ import {
   listAlertDeliveriesPage,
   retryAlertDeliveries,
   retryAlertDelivery,
+  retryFilteredDeliveries,
 } from '../../services/opsService';
 import { formatUtcDateTime } from '../../utils/format';
 import { tableScrollX } from '../../utils/table';
@@ -55,8 +56,10 @@ const NotificationDeliveriesPage = () => {
   const [selectedDelivery, setSelectedDelivery] = useState<NotificationDeliveryRecord>();
   const [retryingIds, setRetryingIds] = useState<Set<number>>(() => new Set());
   const [retryingVisible, setRetryingVisible] = useState(false);
+  const [retryingFiltered, setRetryingFiltered] = useState(false);
   const retryingIdsInFlight = useRef(new Set<number>());
   const retryingVisibleInFlight = useRef(false);
+  const retryingFilteredInFlight = useRef(false);
   const [refreshNonce, setRefreshNonce] = useState(0);
 
   const refresh = () => {
@@ -111,6 +114,28 @@ const NotificationDeliveriesPage = () => {
     } finally {
       retryingVisibleInFlight.current = false;
       setRetryingVisible(false);
+    }
+  };
+
+  const retryMatchingFailures = async () => {
+    if (retryingFilteredInFlight.current) return;
+    retryingFilteredInFlight.current = true;
+    setRetryingFiltered(true);
+    try {
+      const result = await retryFilteredDeliveries({ channel, instanceId });
+      const failed = Object.keys(result.failures).length;
+      message.success(
+        t('deliveries.bulkRetryQueued', {
+          succeeded: result.succeededIds.length,
+          failed: failed ? t('deliveries.bulkRetryFailures', { count: failed }) : '',
+        }),
+      );
+      refresh();
+    } catch {
+      message.error(t('deliveries.bulkRetryFailed'));
+    } finally {
+      retryingFilteredInFlight.current = false;
+      setRetryingFiltered(false);
     }
   };
 
@@ -239,6 +264,9 @@ const NotificationDeliveriesPage = () => {
               onClick={() => void retryVisibleFailures()}
             >
               {t('deliveries.retryCurrentPage')}
+            </Button>
+            <Button loading={retryingFiltered} onClick={() => void retryMatchingFailures()}>
+              {t('deliveries.retryMatchingFailures')}
             </Button>
             <Select
               allowClear

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -25,6 +25,7 @@ import type {
   NotificationDeliveryBulkRetryResult,
   NotificationDeliveryQuery,
   NotificationDeliveryRecord,
+  RetryFilteredDeliveriesRequest,
   AlertSilenceQuery,
   AlertSilence,
   CreateAlertSilence,
@@ -431,6 +432,13 @@ export async function retryAlertDeliveries(
 ): Promise<NotificationDeliveryBulkRetryResult> {
   if (isMockMode()) return { succeededIds: ids, failures: {} };
   return opsApi.retryAlertDeliveries(ids);
+}
+
+export async function retryFilteredDeliveries(
+  params: RetryFilteredDeliveriesRequest = {},
+): Promise<NotificationDeliveryBulkRetryResult> {
+  if (isMockMode()) return { succeededIds: [], failures: {} };
+  return opsApi.retryFilteredDeliveries(params);
 }
 
 export async function listAlertDeliveriesPage(


### PR DESCRIPTION
Fixes #3561

## Summary

- Add `POST /api/system-alerts/deliveries/retry-filtered` with body
  `{ channel?, instanceId?, limit? }` validated by the new
  `RetryFilteredDeliveriesDTO` (limit defaults to 100, allowed range 1-100;
  out-of-range values are rejected with HTTP 400; the service enforces the
  same range with a 400 `BusinessException`).
- `RmqAlertNotificationOutboxMapper.findFailedIds` selects only `o.id` for
  deliveries with `status = 'FAILED'` matching the optional channel/instance
  filters, ordered by `o.id` with `LIMIT #{limit}`.
- `NotificationOutboxService.retryFilteredDeliveries` reuses the existing
  per-id `retryFailedDeliveries(List<Long>)` path (state reset, audit,
  per-id error reporting), and short-circuits to an empty result when no
  deliveries match.
- The notification deliveries page gets a "Retry matching failures" button
  that retries FAILED deliveries matching the current channel/instance
  filters and reports the returned succeeded/failed counts. The existing
  current-page retry is unchanged.

## Why

Issue #3561: the deliveries page only retries FAILED rows on the current
page, so operators with many failed notifications had to page through every
result to retry them all. This endpoint lets them retry up to 100 matching
failed deliveries (across pages, filtered by channel/instance) in one
deterministic, audited action.

## Testing

- `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` → exit 0
- `cd web && ./node_modules/.bin/vitest run src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx src/api/ops.test.ts`
  → 2 files passed, 31 tests passed
- `cd server && mvn -B -ntp test -Dtest=NotificationOutboxServiceTest,SystemAlertControllerTest -DfailIfNoTests=false`
  → Tests run: 43, Failures: 0, Errors: 0, Skipped: 0; BUILD SUCCESS
