### PR TITLE
feat(acl): filter ACL users by admin role

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1027,6 +1027,8 @@ const translations: Record<string, Record<Lang, string>> = {
   'acl.addUser': { zh: '添加用户', en: 'Add User' },
   'acl.ruleTab': { zh: 'ACL 规则', en: 'ACL Rules' },
   'acl.userTab': { zh: '用户管理', en: 'Users' },
+  'acl.userStatusFilter': { zh: '状态', en: 'Status' },
+  'acl.regularUser': { zh: '普通用户', en: 'Regular user' },
   'acl.principal': { zh: '主体', en: 'Principal' },
   'acl.resource': { zh: '资源', en: 'Resource' },
   'acl.permissions': { zh: '操作权限', en: 'Permissions' },

--- a/web/src/pages/instance/__tests__/AclPage.test.tsx
+++ b/web/src/pages/instance/__tests__/AclPage.test.tsx
@@ -912,4 +912,60 @@ describe('ACL page', () => {
       expect.objectContaining({ accessKey: 'new-svc' }),
     );
   });
+
+  it('filters ACL users by status on the user tab', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclService.pageAclUsers).mockResolvedValue({
+      items: [
+        {
+          id: 11,
+          username: 'remote-admin',
+          accessKey: 'acce****3456',
+          secretKey: 'secr****7654',
+          admin: true,
+          clusters: ['cluster-a'],
+          gmtCreate: '2026-07-23T00:00:00Z',
+        },
+        {
+          id: 12,
+          username: 'remote-regular',
+          accessKey: 'acce****1111',
+          secretKey: 'secr****2222',
+          admin: false,
+          clusters: ['cluster-a'],
+          gmtCreate: '2026-07-23T00:00:00Z',
+        },
+      ],
+      total: 2,
+      page: 1,
+      size: 20,
+    });
+    renderWithProviders(<AclPage />);
+
+    await user.click(await screen.findByText('用户管理'));
+    expect(await screen.findByText('remote-admin')).toBeInTheDocument();
+    expect(screen.getByText('remote-regular')).toBeInTheDocument();
+
+    const statusSelect = screen.getByRole('combobox', { name: '状态' });
+    await user.click(statusSelect);
+    await user.click(
+      await screen.findByText('管理员', { selector: '.ant-select-item-option-content' }),
+    );
+    expect(screen.getByText('remote-admin')).toBeInTheDocument();
+    expect(screen.queryByText('remote-regular')).not.toBeInTheDocument();
+
+    await user.click(statusSelect);
+    await user.click(
+      await screen.findByText('普通用户', { selector: '.ant-select-item-option-content' }),
+    );
+    expect(screen.queryByText('remote-admin')).not.toBeInTheDocument();
+    expect(screen.getByText('remote-regular')).toBeInTheDocument();
+
+    await user.click(statusSelect);
+    await user.click(
+      await screen.findByText('全部', { selector: '.ant-select-item-option-content' }),
+    );
+    expect(screen.getByText('remote-admin')).toBeInTheDocument();
+    expect(screen.getByText('remote-regular')).toBeInTheDocument();
+  });
 });

--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -138,6 +138,7 @@ const AclPageContent = ({
   const [userPageSize, setUserPageSize] = useState(20);
   const [userTotal, setUserTotal] = useState(0);
   const [userKeyword, setUserKeyword] = useState('');
+  const [userStatusFilter, setUserStatusFilter] = useState<'all' | 'admin' | 'regular'>('all');
   const [ruleSubmitting, setRuleSubmitting] = useState(false);
   const [userSubmitting, setUserSubmitting] = useState(false);
   const [activeTab, setActiveTab] = useState('rules');
@@ -183,6 +184,11 @@ const AclPageContent = ({
   const [editingPlain, setEditingPlain] = useState<PlainAccessConfig | null>(null);
   const [plainSubmitting, setPlainSubmitting] = useState(false);
   const [plainForm] = Form.useForm();
+
+  const visibleUsers =
+    userStatusFilter === 'all'
+      ? users
+      : users.filter((user) => (userStatusFilter === 'admin') === user.admin);
 
   useEffect(() => {
     let mounted = true;
@@ -1232,12 +1238,29 @@ const AclPageContent = ({
                         allowClear
                         style={{ width: 240 }}
                       />
+                      <Typography.Text type="secondary" style={{ fontSize: 14 }}>
+                        {t('acl.userStatusFilter')}
+                      </Typography.Text>
+                      <Select
+                        aria-label={t('acl.userStatusFilter')}
+                        value={userStatusFilter}
+                        onChange={(value) => {
+                          setUserPage(1);
+                          setUserStatusFilter(value);
+                        }}
+                        style={{ width: 130 }}
+                        options={[
+                          { value: 'all', label: t('common.all') },
+                          { value: 'admin', label: t('acl.admin') },
+                          { value: 'regular', label: t('acl.regularUser') },
+                        ]}
+                      />
                     </Space>
                   </div>
 
                   <Table
                     columns={userColumns}
-                    dataSource={users}
+                    dataSource={visibleUsers}
                     rowKey="id"
                     loading={usersLoading}
                     pagination={{


### PR DESCRIPTION
## Summary

ACL「用户管理」tab 用户表上方新增「状态:全部 / 管理员 / 普通用户」过滤(Select,样式与规则过滤一致)。

现状调研:用户数据模型(`server/.../instance/acl/AclUserVO.java`、`RmqAclUser` 实体)没有任何 enabled/status 字段;腾讯云 provider(`TencentAclService` 的 RoleItem 映射)同样没有状态字段,阿里云 provider 没有 ACL 用户模型;后端 `listAclUsers` / `pageAclUsers` 也无 status 查询参数。因此无法做服务端过滤,本 PR 采用纯前端表格列过滤:基于用户唯一的角色状态 `admin`(管理员/普通用户)过滤当前已加载列表,不新增请求。若未来后端补充 enabled/status 字段,可将该 Select 直接接到服务端参数。

## Why

用户列表量大时难以快速区分管理员与普通用户;状态过滤提升管理效率。

## Testing

- 本地编译:`cd web && ./node_modules/.bin/tsc -b tsconfig.app.json`(exit 0)
- 前端测试:`./node_modules/.bin/vitest run src/pages/instance/__tests__/AclPage.test.tsx` 全绿;新增用例覆盖 全部→管理员→普通用户→全部 的过滤交互。
- 无后端改动,故无 mvn 测试。
