### PR TITLE
[studio] test(navigation): cover blank navigation search queries

### DIFF
--- a/web/src/layouts/navigationSearch.test.ts
+++ b/web/src/layouts/navigationSearch.test.ts
@@ -106,3 +106,12 @@ describe('navigation search helpers', () => {
     }
   });
 });
+
+describe('navigation search blank queries', () => {
+  it('returns entries unchanged for empty and whitespace-only queries', () => {
+    const entries = [{ key: '/cluster', label: 'RocketMQ 集群' }];
+
+    expect(filterNavigationEntries(entries, '')).toEqual(entries);
+    expect(filterNavigationEntries(entries, '   ')).toEqual(entries);
+  });
+});


### PR DESCRIPTION
## Summary

Add regression coverage verifying that filterNavigationEntries returns the full entry list unchanged for empty and whitespace-only queries.

Closes #4014