### PR TITLE
[studio] test(message-trace): cover consumer group counting

### DIFF
--- a/web/src/utils/messageTraceDiagnostics.test.ts
+++ b/web/src/utils/messageTraceDiagnostics.test.ts
@@ -202,3 +202,15 @@ describe('message trace diagnostics', () => {
     );
   });
 });
+
+describe('message trace delivery counting', () => {
+  it('counts distinct consumer groups from delivery statuses', () => {
+    const diagnostics = analyzeMessageTrace(
+      baseTrace({
+        consumerStatus: [delivery('cg-orders'), delivery('cg-billing')],
+      }),
+    );
+
+    expect(diagnostics.summary.consumerGroupCount).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Add regression coverage verifying that analyzeMessageTrace counts distinct consumer groups from delivery statuses.

Closes #4026