### PR TITLE
[studio] test(audit): cover empty audit presentation values

### DIFF
--- a/web/src/pages/ops/__tests__/auditPresentation.test.ts
+++ b/web/src/pages/ops/__tests__/auditPresentation.test.ts
@@ -161,3 +161,11 @@ describe('audit presentation helpers', () => {
     expect(isControlPlaneAuditRecord({ operationType: 'SEND_MESSAGE' })).toBe(false);
   });
 });
+
+describe('audit presentation empty values', () => {
+  it('treats blank codes and details as empty presentation values', () => {
+    expect(normalizeAuditCode('  ')).toBe('');
+    expect(formatAuditCode(undefined)).toBe('-');
+    expect(parseAuditDetail('  ')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Add regression coverage verifying that normalizeAuditCode, formatAuditCode, and parseAuditDetail handle blank and undefined inputs correctly.

Closes #4020