### PR TITLE
[Studio] feat: add Topic delete impact precheck

### DIFF
--- a/web/src/components/TopicDeleteImpactModal.tsx
+++ b/web/src/components/TopicDeleteImpactModal.tsx
@@ -1,0 +1,301 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Alert, Button, Flex, Modal, Space, Spin, Table, Tag, Typography } from 'antd';
+import type { TableColumnsType } from 'antd';
+import {
+  CheckCircleOutlined,
+  DeleteOutlined,
+  ExclamationCircleOutlined,
+  ReloadOutlined,
+  WarningOutlined,
+} from '@ant-design/icons';
+import { formatNumber } from '../utils/format';
+import { tableScrollX } from '../utils/table';
+import type {
+  TopicDeleteImpactAssessment,
+  TopicDeleteImpactSummary,
+  TopicDeleteIssue,
+  TopicDeleteRiskLevel,
+} from '../utils/topicDeleteImpact';
+
+const { Text } = Typography;
+
+const RISK_META: Record<
+  TopicDeleteRiskLevel,
+  {
+    label: string;
+    color: string;
+    alertType: 'success' | 'warning' | 'error';
+    icon: React.ReactNode;
+  }
+> = {
+  low: { label: '低风险', color: 'success', alertType: 'success', icon: <CheckCircleOutlined /> },
+  medium: { label: '需确认', color: 'warning', alertType: 'warning', icon: <WarningOutlined /> },
+  high: {
+    label: '高风险',
+    color: 'error',
+    alertType: 'error',
+    icon: <ExclamationCircleOutlined />,
+  },
+  unknown: { label: '不可确认', color: 'default', alertType: 'warning', icon: <WarningOutlined /> },
+};
+
+const ISSUE_COLOR: Record<TopicDeleteIssue['severity'], string> = {
+  critical: 'error',
+  warning: 'warning',
+  info: 'blue',
+};
+
+interface TopicDeleteImpactModalProps {
+  open: boolean;
+  loading: boolean;
+  deleting: boolean;
+  title: string;
+  assessments: TopicDeleteImpactAssessment[];
+  summary: TopicDeleteImpactSummary | null;
+  error?: string | null;
+  onCancel: () => void;
+  onRetry: () => void;
+  onConfirm: () => void;
+}
+
+const riskTag = (riskLevel: TopicDeleteRiskLevel) => {
+  const meta = RISK_META[riskLevel];
+  return (
+    <Tag color={meta.color} icon={meta.icon}>
+      {meta.label}
+    </Tag>
+  );
+};
+
+const issueTags = (issues: TopicDeleteIssue[]) => (
+  <Space size={[4, 4]} wrap>
+    {issues.map((item) => (
+      <Tag key={item.code} color={ISSUE_COLOR[item.severity]} title={item.description}>
+        {item.title}
+      </Tag>
+    ))}
+  </Space>
+);
+
+const metricText = (label: string, value: React.ReactNode, strong = false) => (
+  <span>
+    <Text type="secondary">{label}</Text>
+    <Text strong={strong} style={{ marginLeft: 4, fontVariantNumeric: 'tabular-nums' }}>
+      {value}
+    </Text>
+  </span>
+);
+
+const metricBox = (label: string, value: React.ReactNode, helper?: React.ReactNode) => (
+  <div
+    style={{
+      border: '1px solid #f0f0f0',
+      borderRadius: 6,
+      padding: '10px 12px',
+      minWidth: 132,
+      flex: '1 1 132px',
+      background: '#fafafa',
+    }}
+  >
+    <Text type="secondary" style={{ display: 'block', fontSize: 13 }}>
+      {label}
+    </Text>
+    <Text strong style={{ fontSize: 20, fontVariantNumeric: 'tabular-nums' }}>
+      {value}
+    </Text>
+    {helper && (
+      <div style={{ marginTop: 2 }}>
+        <Text type="secondary" style={{ fontSize: 13 }}>
+          {helper}
+        </Text>
+      </div>
+    )}
+  </div>
+);
+
+const summaryMessage = (summary: TopicDeleteImpactSummary) => {
+  if (!summary.canDelete) return `发现 ${summary.blockedTopics.length} 个系统 Topic，已阻止删除。`;
+  if (summary.riskLevel === 'high')
+    return `发现 ${summary.highRiskTopics} 个高风险 Topic，删除前需要确认消费者和消息影响。`;
+  if (summary.riskLevel === 'unknown') return '部分依赖信息加载失败，删除影响不可完全确认。';
+  if (summary.riskLevel === 'medium')
+    return `发现 ${summary.mediumRiskTopics} 个需要确认的 Topic。`;
+  return '未发现明显消费者或路由依赖。';
+};
+
+const TopicDeleteImpactModal = ({
+  open,
+  loading,
+  deleting,
+  title,
+  assessments,
+  summary,
+  error,
+  onCancel,
+  onRetry,
+  onConfirm,
+}: TopicDeleteImpactModalProps) => {
+  const columns: TableColumnsType<TopicDeleteImpactAssessment> = [
+    {
+      title: 'Topic',
+      dataIndex: 'topicName',
+      key: 'topicName',
+      width: 220,
+      render: (topicName: string) => (
+        <Text strong ellipsis={{ tooltip: topicName }} style={{ display: 'block' }}>
+          {topicName}
+        </Text>
+      ),
+    },
+    {
+      title: '风险',
+      dataIndex: 'riskLevel',
+      key: 'riskLevel',
+      width: 110,
+      render: riskTag,
+      sorter: (left, right) => right.riskScore - left.riskScore,
+    },
+    {
+      title: '消费者影响',
+      key: 'consumers',
+      width: 210,
+      render: (_: unknown, record) => (
+        <Space direction="vertical" size={2}>
+          {metricText('消费者组', formatNumber(record.stats.consumerGroups), true)}
+          {metricText('活跃', formatNumber(record.stats.activeConsumerGroups))}
+          {metricText('堆积', formatNumber(record.stats.knownTotalLag))}
+        </Space>
+      ),
+    },
+    {
+      title: '生产与消息',
+      key: 'traffic',
+      width: 210,
+      render: (_: unknown, record) => (
+        <Space direction="vertical" size={2}>
+          {metricText('TPS', formatNumber(record.stats.topicTps), record.stats.topicTps > 0)}
+          {metricText('今日消息', formatNumber(record.stats.topicMessageCount))}
+          {metricText('可写路由', formatNumber(record.stats.writableRoutes))}
+        </Space>
+      ),
+    },
+    {
+      title: '诊断项',
+      key: 'issues',
+      width: 320,
+      render: (_: unknown, record) => issueTags(record.issues),
+    },
+  ];
+
+  return (
+    <Modal
+      title={
+        <Space>
+          <DeleteOutlined />
+          <span>{title}</span>
+        </Space>
+      }
+      open={open}
+      onCancel={onCancel}
+      onOk={onConfirm}
+      okText="确认删除"
+      okType="danger"
+      cancelText="取消"
+      confirmLoading={deleting}
+      okButtonProps={{ disabled: loading || Boolean(error) || !summary || !summary.canDelete }}
+      width={960}
+      destroyOnHidden
+    >
+      {loading ? (
+        <Flex justify="center" align="center" style={{ minHeight: 220 }}>
+          <Spin tip="正在分析消费者、消息和路由影响">
+            <div style={{ width: 240 }} />
+          </Spin>
+        </Flex>
+      ) : error ? (
+        <Alert
+          showIcon
+          type="error"
+          message="删除影响预检失败"
+          description={error}
+          action={
+            <Button size="small" icon={<ReloadOutlined />} onClick={onRetry}>
+              重试
+            </Button>
+          }
+        />
+      ) : summary ? (
+        <Space direction="vertical" size={14} style={{ width: '100%' }}>
+          <Alert
+            showIcon
+            type={RISK_META[summary.riskLevel].alertType}
+            message={
+              <Flex gap={8} align="center" wrap>
+                <span>{summaryMessage(summary)}</span>
+                {riskTag(summary.riskLevel)}
+              </Flex>
+            }
+            description={
+              summary.canDelete
+                ? '预检不替代变更审批；确认删除后会调用现有 Topic 删除接口。'
+                : `以下 Topic 被识别为系统 Topic：${summary.blockedTopics.join('、')}`
+            }
+          />
+          <Flex gap={10} wrap="wrap">
+            {metricBox('Topic 数', formatNumber(summary.totalTopics))}
+            {metricBox(
+              '消费者组',
+              formatNumber(summary.totalConsumerGroups),
+              `${formatNumber(summary.activeConsumerGroups)} 个活跃`,
+            )}
+            {metricBox(
+              '已知堆积',
+              formatNumber(summary.knownTotalLag),
+              `${formatNumber(summary.consumerGroupsWithLag)} 个 Group`,
+            )}
+            {metricBox('今日消息', formatNumber(summary.topicMessageCount))}
+            {metricBox('当前 TPS', formatNumber(summary.topicTps))}
+            {metricBox('可写路由', formatNumber(summary.writableRoutes))}
+          </Flex>
+          {(summary.consumerLookupFailedTopics > 0 ||
+            summary.routeLookupFailedTopics > 0 ||
+            summary.truncatedConsumerTopics > 0 ||
+            summary.metricsUnavailableGroups > 0) && (
+            <Alert
+              showIcon
+              type="warning"
+              message="存在不完整依赖信息"
+              description={`消费者加载失败 ${summary.consumerLookupFailedTopics} 个 Topic，路由加载失败 ${summary.routeLookupFailedTopics} 个 Topic，消费者列表截断 ${summary.truncatedConsumerTopics} 个 Topic，指标不可用消费者组 ${summary.metricsUnavailableGroups} 个。`}
+            />
+          )}
+          <Table<TopicDeleteImpactAssessment>
+            columns={columns}
+            dataSource={assessments}
+            rowKey="topicName"
+            size="small"
+            pagination={assessments.length > 8 ? { pageSize: 8, showSizeChanger: false } : false}
+            scroll={{ x: tableScrollX(columns) }}
+          />
+        </Space>
+      ) : null}
+    </Modal>
+  );
+};
+
+export default TopicDeleteImpactModal;

--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -420,16 +420,86 @@ describe('TopicPage', () => {
 
     const row = await screen.findByRole('row', { name: /topic-01/ });
     await user.click(within(row).getByRole('button', { name: /删除/ }));
-    const dialog = (await screen.findByText(/确定要删除 Topic「topic-01」/)).closest(
+    const dialog = (await screen.findByText('删除影响预检：topic-01')).closest(
       '.ant-modal',
     ) as HTMLElement;
-    await user.click(within(dialog).getByRole('button', { name: /删\s*除/ }));
+    expect(await within(dialog).findByText('未发现明显消费者或路由依赖。')).toBeInTheDocument();
+    expect(topicServiceMocks.getTopicConsumerPage).toHaveBeenCalledWith(
+      'topic-01',
+      'instance-proxy-1',
+      1,
+      100,
+    );
+    await user.click(within(dialog).getByRole('button', { name: /确认删除/ }));
 
     await waitFor(() =>
       expect(topicServiceMocks.deleteTopic).toHaveBeenCalledWith('topic-01', 'instance-proxy-1'),
     );
     await waitFor(() => expect(topicServiceMocks.listTopicsPage).toHaveBeenCalledTimes(2));
     expect(screen.getByText('共 0 个 Topic')).toBeInTheDocument();
+  });
+
+  it('previews topic delete impact from consumers and routes before deleting', async () => {
+    const user = userEvent.setup();
+    const topic = {
+      ...buildTopics(1)[0],
+      consumerGroupCount: 1,
+      messageCount: 1200,
+      tps: 15,
+    };
+    mockTopicsList([topic]);
+    topicServiceMocks.getTopicConsumerPage.mockResolvedValue({
+      items: [
+        {
+          group: 'GID_orders',
+          consumeType: 'CONSUME_PASSIVELY',
+          messageModel: '集群消费',
+          consumeTps: 6,
+          diffTotal: 450,
+        },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 100,
+    });
+    topicServiceMocks.getTopicRoutes.mockResolvedValue([
+      {
+        brokerName: 'broker-a',
+        brokerAddr: '10.0.0.1:10911',
+        masterAddr: '10.0.0.1:10911',
+        brokerAddrs: { '0': '10.0.0.1:10911' },
+        brokerIds: [0],
+        replicaCount: 0,
+        writeQueues: 8,
+        readQueues: 8,
+        perm: 'RW',
+        readable: true,
+        writable: true,
+        topicSysFlag: 0,
+      },
+    ]);
+    topicServiceMocks.deleteTopic.mockResolvedValue(undefined);
+    renderWithProviders();
+
+    const row = await screen.findByRole('row', { name: /topic-01/ });
+    await user.click(within(row).getByRole('button', { name: /删除/ }));
+    const dialog = (await screen.findByText('删除影响预检：topic-01')).closest(
+      '.ant-modal',
+    ) as HTMLElement;
+
+    expect(await within(dialog).findByText(/发现 1 个高风险 Topic/)).toBeInTheDocument();
+    expect(within(dialog).getAllByText('高风险').length).toBeGreaterThan(0);
+    expect(within(dialog).getByText('仍有关联消费者组')).toBeInTheDocument();
+    expect(within(dialog).getByText('存在活跃消费')).toBeInTheDocument();
+    expect(within(dialog).getByText('仍有消费堆积')).toBeInTheDocument();
+    expect(within(dialog).getAllByText('可写路由').length).toBeGreaterThan(0);
+    expect(topicServiceMocks.deleteTopic).not.toHaveBeenCalled();
+
+    await user.click(within(dialog).getByRole('button', { name: /确认删除/ }));
+
+    await waitFor(() =>
+      expect(topicServiceMocks.deleteTopic).toHaveBeenCalledWith('topic-01', 'instance-proxy-1'),
+    );
   });
 
   it('keeps the selected instance when rebuilding a topic without a broker route', async () => {
@@ -543,12 +613,17 @@ describe('TopicPage', () => {
     await user.click(screen.getAllByRole('checkbox')[0]);
     await user.click(screen.getByRole('button', { name: /删除 \(3\)$/ }));
 
-    const dialog = await screen.findByRole('dialog');
-    await user.click(within(dialog).getByRole('button', { name: /删\s*除/ }));
+    const dialog = (await screen.findByText('删除影响预检（3 个 Topic）')).closest(
+      '.ant-modal',
+    ) as HTMLElement;
+    expect(await within(dialog).findByText(/发现 2 个需要确认的 Topic/)).toBeInTheDocument();
+    await user.click(within(dialog).getByRole('button', { name: /确认删除/ }));
 
-    await waitFor(() => expect(screen.queryByText('topic-01')).not.toBeInTheDocument());
-    expect(screen.getByText('topic-02')).toBeInTheDocument();
-    expect(screen.queryByText('topic-03')).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(within(getTableBody()).queryByText('topic-01')).not.toBeInTheDocument(),
+    );
+    expect(within(getTableBody()).getByText('topic-02')).toBeInTheDocument();
+    expect(within(getTableBody()).queryByText('topic-03')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /删除 \(1\)$/ })).toBeInTheDocument();
     expect(screen.getByText('已删除 2 个 Topic，1 个删除失败')).toBeInTheDocument();
     expect(topicServiceMocks.listTopicsPage).toHaveBeenLastCalledWith({
@@ -595,10 +670,11 @@ describe('TopicPage', () => {
     expect(await screen.findByText('topic-21')).toBeInTheDocument();
     await user.click(screen.getAllByRole('checkbox')[0]);
     await user.click(screen.getByRole('button', { name: /删除 \(1\)$/ }));
-    const dialog = (await screen.findByText(/确定要删除选中的 1 个 Topic/)).closest(
+    const dialog = (await screen.findByText('删除影响预检（1 个 Topic）')).closest(
       '.ant-modal',
     ) as HTMLElement;
-    await user.click(within(dialog).getByRole('button', { name: /删\s*除/ }));
+    expect(await within(dialog).findByText(/发现 1 个需要确认的 Topic/)).toBeInTheDocument();
+    await user.click(within(dialog).getByRole('button', { name: /确认删除/ }));
 
     await waitFor(() =>
       expect(topicServiceMocks.batchDeleteTopics).toHaveBeenCalledWith(
@@ -606,8 +682,10 @@ describe('TopicPage', () => {
         'instance-proxy-1',
       ),
     );
-    await waitFor(() => expect(screen.queryByText('topic-21')).not.toBeInTheDocument());
-    expect(screen.getByText('topic-01')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(within(getTableBody()).queryByText('topic-21')).not.toBeInTheDocument(),
+    );
+    expect(within(getTableBody()).getByText('topic-01')).toBeInTheDocument();
     expect(topicServiceMocks.listTopicsPage).toHaveBeenLastCalledWith({
       instanceId: 'instance-proxy-1',
       type: undefined,

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -39,7 +39,6 @@ import {
   Typography,
   Spin,
   message,
-  App,
   Progress,
 } from 'antd';
 import type { TableColumnsType } from 'antd';
@@ -62,6 +61,7 @@ import PageHeader from '../../components/PageHeader';
 import InfoBanner from '../../components/InfoBanner';
 import { InstanceSelect } from '../../components/InstanceSelect';
 import TopicConfigComparisonDrawer from '../../components/TopicConfigComparisonDrawer';
+import TopicDeleteImpactModal from '../../components/TopicDeleteImpactModal';
 import { useLang } from '../../i18n/LangContext';
 import { TOPIC_TYPE_MAP, CLUSTER_TYPE_MAP } from '../../constants/theme';
 import type { Topic, BrokerRoute, ConsumerGroupInfo, TopicConsumerPage } from '../../api/metadata';
@@ -101,6 +101,11 @@ import {
   type MessagePayloadPreviewStatus,
   type MessagePropertyInput,
 } from '../../utils/messagePayloadPreview';
+import {
+  analyzeTopicDeleteImpact,
+  summarizeTopicDeleteImpacts,
+  type TopicDeleteImpactAssessment,
+} from '../../utils/topicDeleteImpact';
 
 const { Text } = Typography;
 
@@ -164,6 +169,11 @@ type SendMessageFormValues = {
   body: string;
   propsText?: string;
   properties?: MessagePropertyInput[];
+};
+
+type DeleteImpactTarget = {
+  mode: 'single' | 'batch';
+  topics: Topic[];
 };
 
 const visibleTopics = (
@@ -384,7 +394,6 @@ const TopicPage = () => {
   const sendPropsTextValue = Form.useWatch('propsText', sendForm);
   const sendPropertiesValue = Form.useWatch('properties', sendForm) as
     MessagePropertyInput[] | undefined;
-  const { modal } = App.useApp();
   const importInputRef = useRef<HTMLInputElement>(null);
   const [importModalOpen, setImportModalOpen] = useState(false);
   const [importFilename, setImportFilename] = useState('');
@@ -393,11 +402,20 @@ const TopicPage = () => {
   const [importing, setImporting] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [comparisonOpen, setComparisonOpen] = useState(false);
+  const [deleteImpactOpen, setDeleteImpactOpen] = useState(false);
+  const [deleteImpactLoading, setDeleteImpactLoading] = useState(false);
+  const [deleteImpactError, setDeleteImpactError] = useState<string | null>(null);
+  const [deleteImpactTarget, setDeleteImpactTarget] = useState<DeleteImpactTarget | null>(null);
+  const [deleteImpactAssessments, setDeleteImpactAssessments] = useState<
+    TopicDeleteImpactAssessment[]
+  >([]);
+  const [deletingTopics, setDeletingTopics] = useState(false);
 
   const topicRequestIdRef = useRef(0);
   const detailRequestIdRef = useRef(0);
   const consumersRequestIdRef = useRef(0);
   const createInFlightRef = useRef(false);
+  const deleteImpactRequestIdRef = useRef(0);
 
   const sendPayloadPreview = useMemo(
     () =>
@@ -420,6 +438,17 @@ const TopicPage = () => {
       sendTopic?.name,
     ],
   );
+  const deleteImpactSummary = useMemo(
+    () =>
+      deleteImpactAssessments.length > 0
+        ? summarizeTopicDeleteImpacts(deleteImpactAssessments)
+        : null,
+    [deleteImpactAssessments],
+  );
+  const deleteImpactTitle =
+    deleteImpactTarget?.mode === 'batch'
+      ? `删除影响预检（${deleteImpactTarget.topics.length} 个 Topic）`
+      : `删除影响预检：${deleteImpactTarget?.topics[0]?.name ?? ''}`;
 
   const loadTopicPage = useCallback(
     async (pageToLoad: number, pageSizeToLoad: number) => {
@@ -624,6 +653,129 @@ const TopicPage = () => {
     }
   };
 
+  const loadDeleteImpact = useCallback(
+    async (target: DeleteImpactTarget) => {
+      const requestId = ++deleteImpactRequestIdRef.current;
+      setDeleteImpactLoading(true);
+      setDeleteImpactError(null);
+      setDeleteImpactAssessments([]);
+
+      try {
+        const assessments = await Promise.all(
+          target.topics.map(async (topic) => {
+            const instanceId = topic.instanceId || selectedInstanceId || undefined;
+            let consumers: ConsumerGroupInfo[] = [];
+            let consumerTotal: number | undefined;
+            let consumerLookupFailed = false;
+            let routes: BrokerRoute[] = [];
+            let routeLookupFailed = false;
+
+            try {
+              const consumerPage = await getTopicConsumerPage(topic.name, instanceId, 1, 100);
+              consumers = consumerPage.items;
+              consumerTotal = consumerPage.total;
+            } catch {
+              consumerLookupFailed = true;
+            }
+
+            if (!isCloudInstance) {
+              try {
+                routes = await getTopicRoutes(topic.name, instanceId);
+              } catch {
+                routeLookupFailed = true;
+              }
+            }
+
+            return analyzeTopicDeleteImpact({
+              topic,
+              consumers,
+              consumerTotal,
+              routes,
+              consumerLookupFailed,
+              routeLookupFailed,
+              isCloudInstance,
+            });
+          }),
+        );
+
+        if (requestId === deleteImpactRequestIdRef.current) {
+          setDeleteImpactAssessments(assessments);
+        }
+      } catch (error) {
+        if (requestId === deleteImpactRequestIdRef.current) {
+          setDeleteImpactError(error instanceof Error ? error.message : '删除影响预检失败');
+        }
+      } finally {
+        if (requestId === deleteImpactRequestIdRef.current) {
+          setDeleteImpactLoading(false);
+        }
+      }
+    },
+    [isCloudInstance, selectedInstanceId],
+  );
+
+  const openDeleteImpact = useCallback(
+    (mode: DeleteImpactTarget['mode'], targetTopics: Topic[]) => {
+      if (targetTopics.length === 0) {
+        message.warning('请选择要删除的 Topic');
+        return;
+      }
+      const target = { mode, topics: targetTopics };
+      setDeleteImpactTarget(target);
+      setDeleteImpactOpen(true);
+      void loadDeleteImpact(target);
+    },
+    [loadDeleteImpact],
+  );
+
+  const closeDeleteImpact = () => {
+    if (deletingTopics) return;
+    deleteImpactRequestIdRef.current += 1;
+    setDeleteImpactOpen(false);
+    setDeleteImpactTarget(null);
+    setDeleteImpactAssessments([]);
+    setDeleteImpactError(null);
+    setDeleteImpactLoading(false);
+  };
+
+  const handleDeleteImpactConfirm = async () => {
+    if (!deleteImpactTarget || !deleteImpactSummary?.canDelete) return;
+    const names = deleteImpactTarget.topics.map((topic) => topic.name);
+    setDeletingTopics(true);
+    try {
+      if (deleteImpactTarget.mode === 'single') {
+        const topic = deleteImpactTarget.topics[0];
+        await deleteTopic(topic.name, topic.instanceId || selectedInstanceId || undefined);
+        await reloadTopicPageAfterDelete();
+        setSelectedRowKeys((previous) => previous.filter((key) => key !== topic.name));
+        message.success(`Topic「${topic.name}」已删除`);
+      } else {
+        const { deleted, failed } = await batchDeleteTopics(names, selectedInstanceId || undefined);
+        if (deleted.length > 0) await reloadTopicPageAfterDelete();
+        setSelectedRowKeys(failed);
+
+        if (failed.length === 0) {
+          message.success(`已删除 ${deleted.length} 个 Topic`);
+        } else if (deleted.length > 0) {
+          message.warning(`已删除 ${deleted.length} 个 Topic，${failed.length} 个删除失败`);
+        } else {
+          message.error(`${failed.length} 个 Topic 删除失败，请稍后重试`);
+        }
+      }
+      setDeleteImpactOpen(false);
+      setDeleteImpactTarget(null);
+      setDeleteImpactAssessments([]);
+    } catch {
+      message.error(
+        deleteImpactTarget.mode === 'single'
+          ? '删除 Topic 失败，请稍后重试'
+          : '批量删除 Topic 失败，请稍后重试',
+      );
+    } finally {
+      setDeletingTopics(false);
+    }
+  };
+
   const handleAction = (key: string, topic: Topic) => {
     if (key === 'detail') {
       void openDetail(topic);
@@ -635,22 +787,7 @@ const TopicPage = () => {
       sendForm.setFieldsValue({ topic: topic.name, tag: '', key: '', body: '', properties: [] });
       setSendModalOpen(true);
     } else if (key === 'delete') {
-      modal.confirm({
-        title: '确认删除',
-        content: `确定要删除 Topic「${topic.name}」吗？此操作不可撤销。`,
-        okText: '删除',
-        okType: 'danger',
-        cancelText: '取消',
-        onOk: async () => {
-          try {
-            await deleteTopic(topic.name, selectedInstanceId || undefined);
-            await reloadTopicPageAfterDelete();
-            message.success(`Topic「${topic.name}」已删除`);
-          } catch {
-            message.error('删除 Topic 失败，请稍后重试');
-          }
-        },
-      });
+      openDeleteImpact('single', [topic]);
     }
   };
 
@@ -1489,36 +1626,13 @@ const TopicPage = () => {
               danger
               icon={<DeleteOutlined />}
               onClick={() => {
-                Modal.confirm({
-                  title: '确认批量删除',
-                  content: `确定要删除选中的 ${selectedRowKeys.length} 个 Topic 吗？此操作不可撤销。`,
-                  okText: '删除',
-                  okType: 'danger',
-                  cancelText: '取消',
-                  onOk: async () => {
-                    try {
-                      const names = selectedRowKeys.map(String);
-                      const { deleted, failed } = await batchDeleteTopics(
-                        names,
-                        selectedInstanceId || undefined,
-                      );
-                      if (deleted.length > 0) await reloadTopicPageAfterDelete();
-                      setSelectedRowKeys(failed);
-
-                      if (failed.length === 0) {
-                        message.success(`已删除 ${deleted.length} 个 Topic`);
-                      } else if (deleted.length > 0) {
-                        message.warning(
-                          `已删除 ${deleted.length} 个 Topic，${failed.length} 个删除失败`,
-                        );
-                      } else {
-                        message.error(`${failed.length} 个 Topic 删除失败，请稍后重试`);
-                      }
-                    } catch {
-                      message.error('批量删除 Topic 失败，请稍后重试');
-                    }
-                  },
-                });
+                const names = new Set(selectedRowKeys.map(String));
+                const selectedTopics = topics.filter((topic) => names.has(topic.name));
+                if (selectedTopics.length !== selectedRowKeys.length) {
+                  message.warning('选中 Topic 不在当前列表，请刷新后重试');
+                  return;
+                }
+                openDeleteImpact('batch', selectedTopics);
               }}
             >
               删除 ({selectedRowKeys.length})
@@ -2028,6 +2142,21 @@ const TopicPage = () => {
           </>
         )}
       </Modal>
+
+      <TopicDeleteImpactModal
+        open={deleteImpactOpen}
+        loading={deleteImpactLoading}
+        deleting={deletingTopics}
+        title={deleteImpactTitle}
+        assessments={deleteImpactAssessments}
+        summary={deleteImpactSummary}
+        error={deleteImpactError}
+        onCancel={closeDeleteImpact}
+        onRetry={() => {
+          if (deleteImpactTarget) void loadDeleteImpact(deleteImpactTarget);
+        }}
+        onConfirm={() => void handleDeleteImpactConfirm()}
+      />
     </div>
   );
 };

--- a/web/src/utils/topicDeleteImpact.test.ts
+++ b/web/src/utils/topicDeleteImpact.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { BrokerRoute, ConsumerGroupInfo, Topic } from '../api/metadata';
+import {
+  analyzeTopicDeleteImpact,
+  isSystemTopicName,
+  summarizeTopicDeleteImpacts,
+} from './topicDeleteImpact';
+
+const baseTopic = (overrides: Partial<Topic> = {}): Topic => ({
+  name: 'orders-topic',
+  namespace: 'default',
+  type: 'NORMAL',
+  clusterId: 'rmq-cluster',
+  instanceId: 'instance-a',
+  writeQueues: 8,
+  readQueues: 8,
+  perm: 'RW',
+  messageCount: 0,
+  tps: 0,
+  consumerGroupCount: 0,
+  remark: '',
+  gmtCreate: '2026-01-01T00:00:00Z',
+  gmtModified: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const route = (overrides: Partial<BrokerRoute> = {}): BrokerRoute => ({
+  brokerName: 'broker-a',
+  brokerAddr: '10.0.0.1:10911',
+  masterAddr: '10.0.0.1:10911',
+  brokerAddrs: { '0': '10.0.0.1:10911' },
+  brokerIds: [0],
+  replicaCount: 0,
+  writeQueues: 8,
+  readQueues: 8,
+  perm: 'RW',
+  readable: true,
+  writable: true,
+  topicSysFlag: 0,
+  ...overrides,
+});
+
+const consumer = (overrides: Partial<ConsumerGroupInfo> = {}): ConsumerGroupInfo => ({
+  group: 'GID_orders',
+  consumeType: 'CONSUME_ACTIVELY',
+  messageModel: '集群消费',
+  consumeTps: 0,
+  diffTotal: 0,
+  ...overrides,
+});
+
+describe('topic delete impact diagnostics', () => {
+  it('recognizes RocketMQ internal topic names as protected', () => {
+    expect(isSystemTopicName('%RETRY%GID_orders')).toBe(true);
+    expect(isSystemTopicName('%DLQ%GID_orders')).toBe(true);
+    expect(isSystemTopicName('SCHEDULE_TOPIC_XXXX')).toBe(true);
+    expect(isSystemTopicName('orders-topic')).toBe(false);
+  });
+
+  it('marks topics with consumers, active traffic, and backlog as high risk', () => {
+    const assessment = analyzeTopicDeleteImpact({
+      topic: baseTopic({ consumerGroupCount: 2, messageCount: 1200, tps: 12 }),
+      consumers: [
+        consumer({ consumeTps: 8, diffTotal: 600 }),
+        consumer({ group: 'GID_billing', consumeTps: 0, diffTotal: 0 }),
+      ],
+      consumerTotal: 2,
+      routes: [route()],
+    });
+
+    expect(assessment.riskLevel).toBe('high');
+    expect(assessment.canDelete).toBe(true);
+    expect(assessment.stats.consumerGroups).toBe(2);
+    expect(assessment.stats.activeConsumerGroups).toBe(1);
+    expect(assessment.stats.knownTotalLag).toBe(600);
+    expect(assessment.issues.map((item) => item.code)).toEqual(
+      expect.arrayContaining([
+        'CONSUMER_GROUPS_ATTACHED',
+        'ACTIVE_CONSUMPTION',
+        'BACKLOG_REMAINS',
+        'RECENT_TRAFFIC',
+        'RETAINED_MESSAGES',
+        'WRITABLE_ROUTE',
+      ]),
+    );
+  });
+
+  it('keeps metadata-only topics as low risk when no dependency is visible', () => {
+    const assessment = analyzeTopicDeleteImpact({
+      topic: baseTopic(),
+      consumers: [],
+      consumerTotal: 0,
+      routes: [],
+    });
+
+    expect(assessment.riskLevel).toBe('low');
+    expect(assessment.stats.routeCount).toBe(0);
+    expect(assessment.issues.map((item) => item.code)).toEqual(['NO_ROUTE']);
+  });
+
+  it('reports unknown risk when dependency lookups fail', () => {
+    const assessment = analyzeTopicDeleteImpact({
+      topic: baseTopic(),
+      consumerLookupFailed: true,
+      routeLookupFailed: true,
+    });
+
+    expect(assessment.riskLevel).toBe('unknown');
+    expect(assessment.stats.consumerLookupFailed).toBe(true);
+    expect(assessment.stats.routeLookupFailed).toBe(true);
+    expect(assessment.issues.map((item) => item.code)).toEqual([
+      'CONSUMER_LOOKUP_FAILED',
+      'ROUTE_LOOKUP_FAILED',
+    ]);
+  });
+
+  it('blocks system topic deletion and includes it in the summary', () => {
+    const systemTopic = analyzeTopicDeleteImpact({
+      topic: baseTopic({ name: '%RETRY%GID_orders' }),
+      consumers: [],
+      routes: [],
+    });
+    const normalTopic = analyzeTopicDeleteImpact({
+      topic: baseTopic({ name: 'orders-topic' }),
+      consumers: [],
+      routes: [],
+    });
+    const summary = summarizeTopicDeleteImpacts([systemTopic, normalTopic]);
+
+    expect(systemTopic.canDelete).toBe(false);
+    expect(summary.canDelete).toBe(false);
+    expect(summary.riskLevel).toBe('high');
+    expect(summary.blockedTopics).toEqual(['%RETRY%GID_orders']);
+  });
+});

--- a/web/src/utils/topicDeleteImpact.ts
+++ b/web/src/utils/topicDeleteImpact.ts
@@ -1,0 +1,356 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { BrokerRoute, ConsumerGroupInfo, Topic } from '../api/metadata';
+
+export type TopicDeleteRiskLevel = 'low' | 'medium' | 'high' | 'unknown';
+export type TopicDeleteIssueSeverity = 'info' | 'warning' | 'critical';
+
+export type TopicDeleteIssueCode =
+  | 'SYSTEM_TOPIC'
+  | 'CONSUMER_GROUPS_ATTACHED'
+  | 'ACTIVE_CONSUMPTION'
+  | 'BACKLOG_REMAINS'
+  | 'RECENT_TRAFFIC'
+  | 'RETAINED_MESSAGES'
+  | 'WRITABLE_ROUTE'
+  | 'NO_ROUTE'
+  | 'ROUTE_LOOKUP_FAILED'
+  | 'CONSUMER_LOOKUP_FAILED'
+  | 'CONSUMER_PAGE_TRUNCATED'
+  | 'CONSUMER_METRICS_UNAVAILABLE'
+  | 'CLOUD_ROUTE_UNAVAILABLE';
+
+export interface TopicDeleteIssue {
+  code: TopicDeleteIssueCode;
+  severity: TopicDeleteIssueSeverity;
+  title: string;
+  description: string;
+}
+
+export interface TopicDeleteImpactInput {
+  topic: Topic;
+  consumers?: ConsumerGroupInfo[];
+  consumerTotal?: number;
+  routes?: BrokerRoute[];
+  consumerLookupFailed?: boolean;
+  routeLookupFailed?: boolean;
+  isCloudInstance?: boolean;
+}
+
+export interface TopicDeleteImpactAssessment {
+  topicName: string;
+  riskLevel: TopicDeleteRiskLevel;
+  riskScore: number;
+  canDelete: boolean;
+  issues: TopicDeleteIssue[];
+  stats: {
+    consumerGroups: number;
+    activeConsumerGroups: number;
+    consumerGroupsWithLag: number;
+    metricsUnavailableGroups: number;
+    knownTotalLag: number;
+    topicMessageCount: number;
+    topicTps: number;
+    routeCount: number;
+    writableRoutes: number;
+    truncatedConsumers: boolean;
+    consumerLookupFailed: boolean;
+    routeLookupFailed: boolean;
+  };
+}
+
+export interface TopicDeleteImpactSummary {
+  totalTopics: number;
+  riskLevel: TopicDeleteRiskLevel;
+  canDelete: boolean;
+  highRiskTopics: number;
+  mediumRiskTopics: number;
+  lowRiskTopics: number;
+  unknownRiskTopics: number;
+  blockedTopics: string[];
+  totalConsumerGroups: number;
+  activeConsumerGroups: number;
+  consumerGroupsWithLag: number;
+  metricsUnavailableGroups: number;
+  knownTotalLag: number;
+  topicMessageCount: number;
+  topicTps: number;
+  writableRoutes: number;
+  routeLookupFailedTopics: number;
+  consumerLookupFailedTopics: number;
+  truncatedConsumerTopics: number;
+}
+
+const SEVERITY_SCORE: Record<TopicDeleteIssueSeverity, number> = {
+  info: 1,
+  warning: 2,
+  critical: 4,
+};
+
+const SYSTEM_TOPIC_PREFIXES = ['%RETRY%', '%DLQ%', 'SCHEDULE_TOPIC_', 'RMQ_SYS_', 'TBW102'];
+const SYSTEM_TOPIC_NAMES = new Set([
+  'SELF_TEST_TOPIC',
+  'OFFSET_MOVED_EVENT',
+  'TRANS_CHECK_MAX_TIME_TOPIC',
+  'BenchmarkTest',
+]);
+
+const num = (value: unknown): number =>
+  typeof value === 'number' && Number.isFinite(value) ? Math.max(0, value) : 0;
+
+const routeWritable = (route: BrokerRoute): boolean => {
+  if (typeof route.writable === 'boolean') return route.writable;
+  return route.perm === 'RW' || route.perm === 'WO';
+};
+
+const issue = (
+  code: TopicDeleteIssueCode,
+  severity: TopicDeleteIssueSeverity,
+  title: string,
+  description: string,
+): TopicDeleteIssue => ({ code, severity, title, description });
+
+export const isSystemTopicName = (topicName: string): boolean => {
+  const normalized = topicName.trim();
+  return (
+    SYSTEM_TOPIC_NAMES.has(normalized) ||
+    SYSTEM_TOPIC_PREFIXES.some((prefix) => normalized.startsWith(prefix))
+  );
+};
+
+const riskLevel = (
+  issues: TopicDeleteIssue[],
+  input: Pick<TopicDeleteImpactInput, 'consumerLookupFailed' | 'routeLookupFailed'>,
+): TopicDeleteRiskLevel => {
+  if (issues.some((item) => item.severity === 'critical')) return 'high';
+  if (input.consumerLookupFailed || input.routeLookupFailed) return 'unknown';
+  if (issues.some((item) => item.severity === 'warning')) return 'medium';
+  return 'low';
+};
+
+export const analyzeTopicDeleteImpact = (
+  input: TopicDeleteImpactInput,
+): TopicDeleteImpactAssessment => {
+  const consumers = input.consumers ?? [];
+  const routes = input.routes ?? [];
+  const consumerGroups = Math.max(
+    num(input.topic.consumerGroupCount),
+    consumers.length,
+    num(input.consumerTotal),
+  );
+  const activeConsumerGroups = consumers.filter(
+    (item) => item.metricsAvailable !== false && num(item.consumeTps) > 0,
+  ).length;
+  const consumerGroupsWithLag = consumers.filter(
+    (item) => item.metricsAvailable !== false && num(item.diffTotal) > 0,
+  ).length;
+  const metricsUnavailableGroups = consumers.filter(
+    (item) => item.metricsAvailable === false,
+  ).length;
+  const knownTotalLag = consumers.reduce(
+    (sum, item) => (item.metricsAvailable === false ? sum : sum + num(item.diffTotal)),
+    0,
+  );
+  const topicMessageCount = num(input.topic.messageCount);
+  const topicTps = num(input.topic.tps);
+  const writableRoutes = routes.filter(routeWritable).length;
+  const issues: TopicDeleteIssue[] = [];
+
+  if (isSystemTopicName(input.topic.name)) {
+    issues.push(
+      issue(
+        'SYSTEM_TOPIC',
+        'critical',
+        '系统 Topic',
+        '名称符合 RocketMQ 内部 Topic 命名，误删可能影响重试、死信或调度链路。',
+      ),
+    );
+  }
+  if (input.consumerLookupFailed) {
+    issues.push(
+      issue(
+        'CONSUMER_LOOKUP_FAILED',
+        'warning',
+        '消费者依赖不可确认',
+        '消费者列表加载失败，无法判断是否仍有订阅关系。',
+      ),
+    );
+  } else if (consumerGroups > 0) {
+    issues.push(
+      issue(
+        'CONSUMER_GROUPS_ATTACHED',
+        'critical',
+        '仍有关联消费者组',
+        `当前至少有 ${consumerGroups} 个消费者组订阅该 Topic。`,
+      ),
+    );
+  }
+  if (activeConsumerGroups > 0) {
+    issues.push(
+      issue(
+        'ACTIVE_CONSUMPTION',
+        'critical',
+        '存在活跃消费',
+        `${activeConsumerGroups} 个消费者组仍有消费 TPS。`,
+      ),
+    );
+  }
+  if (consumerGroupsWithLag > 0 || knownTotalLag > 0) {
+    issues.push(
+      issue(
+        'BACKLOG_REMAINS',
+        'critical',
+        '仍有消费堆积',
+        `${consumerGroupsWithLag} 个消费者组存在堆积，已知堆积量 ${knownTotalLag.toLocaleString()}。`,
+      ),
+    );
+  }
+  if (consumerGroups > consumers.length) {
+    issues.push(
+      issue(
+        'CONSUMER_PAGE_TRUNCATED',
+        'warning',
+        '消费者列表未完整展开',
+        `已加载 ${consumers.length} / ${consumerGroups} 个消费者组。`,
+      ),
+    );
+  }
+  if (metricsUnavailableGroups > 0) {
+    issues.push(
+      issue(
+        'CONSUMER_METRICS_UNAVAILABLE',
+        'warning',
+        '消费者指标不可用',
+        `${metricsUnavailableGroups} 个消费者组指标不可用。`,
+      ),
+    );
+  }
+  if (topicTps > 0) {
+    issues.push(
+      issue(
+        'RECENT_TRAFFIC',
+        'warning',
+        'Topic 仍有写入流量',
+        `当前 TPS 为 ${topicTps.toLocaleString()}。`,
+      ),
+    );
+  }
+  if (topicMessageCount > 0) {
+    issues.push(
+      issue(
+        'RETAINED_MESSAGES',
+        'warning',
+        '仍有消息统计',
+        `今日消息量为 ${topicMessageCount.toLocaleString()}。`,
+      ),
+    );
+  }
+  if (input.isCloudInstance) {
+    issues.push(
+      issue(
+        'CLOUD_ROUTE_UNAVAILABLE',
+        'info',
+        '云实例路由不可见',
+        '云厂商托管实例不直接展示 Broker 路由影响。',
+      ),
+    );
+  } else if (input.routeLookupFailed) {
+    issues.push(
+      issue(
+        'ROUTE_LOOKUP_FAILED',
+        'warning',
+        '路由影响不可确认',
+        'Broker 路由加载失败，无法判断生产链路是否仍可写。',
+      ),
+    );
+  } else if (routes.length === 0) {
+    issues.push(
+      issue('NO_ROUTE', 'info', '未发现 Broker 路由', '该 Topic 可能只存在于 Studio 元数据中。'),
+    );
+  } else if (writableRoutes > 0) {
+    issues.push(
+      issue(
+        'WRITABLE_ROUTE',
+        'warning',
+        'Broker 路由仍可写',
+        `${writableRoutes} 个 Broker 路由仍允许写入。`,
+      ),
+    );
+  }
+
+  return {
+    topicName: input.topic.name,
+    riskLevel: riskLevel(issues, input),
+    riskScore: issues.reduce((sum, item) => sum + SEVERITY_SCORE[item.severity], 0),
+    canDelete: !isSystemTopicName(input.topic.name),
+    issues,
+    stats: {
+      consumerGroups,
+      activeConsumerGroups,
+      consumerGroupsWithLag,
+      metricsUnavailableGroups,
+      knownTotalLag,
+      topicMessageCount,
+      topicTps,
+      routeCount: routes.length,
+      writableRoutes,
+      truncatedConsumers: consumerGroups > consumers.length,
+      consumerLookupFailed: Boolean(input.consumerLookupFailed),
+      routeLookupFailed: Boolean(input.routeLookupFailed),
+    },
+  };
+};
+
+const summaryRiskLevel = (items: TopicDeleteImpactAssessment[]): TopicDeleteRiskLevel => {
+  if (items.some((item) => item.riskLevel === 'high')) return 'high';
+  if (items.some((item) => item.riskLevel === 'unknown')) return 'unknown';
+  if (items.some((item) => item.riskLevel === 'medium')) return 'medium';
+  return 'low';
+};
+
+const countByRisk = (items: TopicDeleteImpactAssessment[], risk: TopicDeleteRiskLevel) =>
+  items.filter((item) => item.riskLevel === risk).length;
+
+const sum = (
+  items: TopicDeleteImpactAssessment[],
+  selector: (item: TopicDeleteImpactAssessment) => number,
+) => items.reduce((total, item) => total + selector(item), 0);
+
+export const summarizeTopicDeleteImpacts = (
+  assessments: TopicDeleteImpactAssessment[],
+): TopicDeleteImpactSummary => ({
+  totalTopics: assessments.length,
+  riskLevel: summaryRiskLevel(assessments),
+  canDelete: assessments.every((item) => item.canDelete),
+  highRiskTopics: countByRisk(assessments, 'high'),
+  mediumRiskTopics: countByRisk(assessments, 'medium'),
+  lowRiskTopics: countByRisk(assessments, 'low'),
+  unknownRiskTopics: countByRisk(assessments, 'unknown'),
+  blockedTopics: assessments.filter((item) => !item.canDelete).map((item) => item.topicName),
+  totalConsumerGroups: sum(assessments, (item) => item.stats.consumerGroups),
+  activeConsumerGroups: sum(assessments, (item) => item.stats.activeConsumerGroups),
+  consumerGroupsWithLag: sum(assessments, (item) => item.stats.consumerGroupsWithLag),
+  metricsUnavailableGroups: sum(assessments, (item) => item.stats.metricsUnavailableGroups),
+  knownTotalLag: sum(assessments, (item) => item.stats.knownTotalLag),
+  topicMessageCount: sum(assessments, (item) => item.stats.topicMessageCount),
+  topicTps: sum(assessments, (item) => item.stats.topicTps),
+  writableRoutes: sum(assessments, (item) => item.stats.writableRoutes),
+  routeLookupFailedTopics: assessments.filter((item) => item.stats.routeLookupFailed).length,
+  consumerLookupFailedTopics: assessments.filter((item) => item.stats.consumerLookupFailed).length,
+  truncatedConsumerTopics: assessments.filter((item) => item.stats.truncatedConsumers).length,
+});


### PR DESCRIPTION
## What is the purpose of the change

This PR adds a Topic deletion impact precheck in RocketMQ Studio.

Before deleting a single Topic or selected Topics in batch, the UI now checks visible consumer dependencies, consumer lag, active consumption, message statistics, and broker routes. It summarizes the delete risk before confirmation and blocks deletion for RocketMQ system Topics to avoid accidental removal of internal retry, DLQ, schedule, or system resources.

## Brief changelog

- Add Topic delete impact analysis for consumer groups, lag, traffic, writable routes, and system Topic names.
- Replace the direct delete confirmation with a precheck modal for single and batch Topic deletion.
- Keep normal high-risk Topic deletion confirmable, while blocking detected system Topics.
- Add focused unit and page tests for the precheck analyzer and delete flow.

## Verifying this change

- `git diff --check`
- `npm run test -- --run src/utils/topicDeleteImpact.test.ts src/pages/instance/__tests__/TopicPage.test.tsx`
- `npm run lint -- src/components/TopicDeleteImpactModal.tsx src/utils/topicDeleteImpact.ts src/utils/topicDeleteImpact.test.ts src/pages/instance/topic.tsx src/pages/instance/__tests__/TopicPage.test.tsx`
- `npm run build`
- `npm run test -- --run`