### PR TITLE
test(config): cover the deprecated static mock flag

### DIFF
--- a/web/src/config.test.ts
+++ b/web/src/config.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { API_BASE_URL } from './config';
+import { API_BASE_URL, USE_MOCK } from './config';
 
 describe('config API base url', () => {
   it('defaults to a relative /api path when no env override is set', () => {
@@ -31,5 +31,11 @@ describe('config API base url', () => {
 
   it('strips a single trailing slash', () => {
     expect(API_BASE_URL.endsWith('/')).toBe(false);
+  });
+});
+
+describe('config deprecated static mock flag', () => {
+  it('remains disabled so the legacy mock-data code path stays off', () => {
+    expect(USE_MOCK).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #4010


## Summary

Add a regression test in `web/src/config.test.ts` that locks the deprecated static mock flag `USE_MOCK` (exported by `web/src/config.ts`) to `false` for the current Studio runtime.

## Why

`USE_MOCK` is kept only for backward compatibility, but the existing `config.test.ts` covered `API_BASE_URL` exclusively. The deprecated flag was unprotected, so it could be accidentally flipped and silently reintroduce the legacy mock-data code path. A focused Vitest case now fails if the flag changes.

## Testing

- `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` — passes (exit 0)
- `./node_modules/.bin/vitest run src/config.test.ts` — all tests green
- `git diff --check` — clean
