### PR TITLE
test(cluster): cover partial cluster component counting

### DIFF
--- a/web/src/pages/cluster/clusterStats.test.ts
+++ b/web/src/pages/cluster/clusterStats.test.ts
@@ -108,3 +108,22 @@ describe('countClusterComponents', () => {
     expect(countClusterComponents(clusters)).toEqual({ brokers: 0, nameServers: 0, proxies: 0 });
   });
 });
+
+describe('countClusterComponents partial inventories', () => {
+  it('counts only the component kinds present on a cluster', () => {
+    const clusters = [
+      {
+        ...baseCluster,
+        brokers: [],
+        proxies: [{ addr: 'p:8081' } as ClusterInfo['proxies'][number]],
+        nameServers: [],
+      },
+    ];
+
+    expect(countClusterComponents(clusters)).toEqual({
+      brokers: 0,
+      nameServers: 0,
+      proxies: 1,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #4018


## Summary

Add a regression test in `web/src/pages/cluster/clusterStats.test.ts` covering partial cluster component counting: a cluster that carries only proxies (empty broker and name server lists) is summarized as exactly `{ brokers: 0, nameServers: 0, proxies: 1 }`.

## Why

The existing suite only covered an empty cluster list, fully-populated clusters across multiple entries, and null/missing component lists. Partial inventories — some component kinds present, others empty — were not protected, so the per-kind counting in `countClusterComponents` could regress unnoticed.

## Testing

- `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` — passes (exit 0)
- `./node_modules/.bin/vitest run src/pages/cluster/clusterStats.test.ts` — all tests green
- `git diff --check` — clean
