### PR TITLE
test(client-connections): cover a single connection inventory

### DIFF
--- a/web/src/utils/clientConnectionDiagnostics.test.ts
+++ b/web/src/utils/clientConnectionDiagnostics.test.ts
@@ -206,3 +206,13 @@ describe('client connection diagnostics', () => {
     );
   });
 });
+
+describe('client connection diagnostics single connection', () => {
+  it('reports a single producer connection with stable summary counts', () => {
+    const diagnostics = analyzeClientConnections([connection({})]);
+
+    expect(diagnostics.summary.totalConnections).toBe(1);
+    expect(diagnostics.summary.uniqueClientCount).toBe(1);
+    expect(diagnostics.resources).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Fixes #4022


## Summary

Add a regression test in `web/src/utils/clientConnectionDiagnostics.test.ts` covering a single client connection inventory: one producer connection reports `totalConnections: 1`, `uniqueClientCount: 1` and exactly one resource summary.

## Why

The existing suite covered empty, multi-client, partial-scan, mixed-protocol/version and unknown-field inventories, but never a minimal single-connection inventory, leaving the baseline summary computation in `analyzeClientConnections` unprotected.

## Testing

- `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` — passes (exit 0)
- `./node_modules/.bin/vitest run src/utils/clientConnectionDiagnostics.test.ts` — all tests green
- `git diff --check` — clean
