### PR TITLE
test(data-mode): cover the runtime data-mode service

### DIFF
--- a/web/src/services/__tests__/dataMode.test.ts
+++ b/web/src/services/__tests__/dataMode.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { useDataModeStore } from '../../stores/dataModeStore';
+import { isMockMode } from '../dataMode';
+
+describe('dataMode service', () => {
+  afterEach(() => {
+    useDataModeStore.setState({ useMock: false });
+    localStorage.clear();
+  });
+
+  it('reflects the runtime mock-data store flag', () => {
+    useDataModeStore.setState({ useMock: true });
+    expect(isMockMode()).toBe(true);
+
+    useDataModeStore.setState({ useMock: false });
+    expect(isMockMode()).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #4036


## Summary

Adds a focused Vitest regression test file at `web/src/services/__tests__/dataMode.test.ts` covering the runtime data-mode service. The test locks the current behavior of `isMockMode()` from `web/src/services/dataMode.ts`: it reads the `useMock` flag from the runtime Zustand store (`web/src/stores/dataModeStore.ts`), so toggling the store state at runtime is reflected immediately.

Note: the issue skeleton's source path placed the service under `web/src/pages/studio/`; in this repository the service actually lives at `web/src/services/dataMode.ts`, so the test file is placed next to it under `web/src/services/__tests__/` and imports the store via `../../stores/dataModeStore` (matching the issue's `TestFile` location).

## Why

The existing suite does not cover the runtime data-mode service. A regression here would make the mock/real data mode diverge from the runtime store flag, so the bridge is locked with a dedicated test file. No runtime behavior changes are made.

## Testing

- Local type check: `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` (exit 0).
- Targeted Vitest run: `cd web && ./node_modules/.bin/vitest run src/services/__tests__/dataMode.test.ts` (all tests pass).
