### PR TITLE
test(auth-store): cover auth session persistence

### DIFF
--- a/web/src/stores/__tests__/authStore.test.ts
+++ b/web/src/stores/__tests__/authStore.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import useAuthStore from '../authStore';
+
+describe('authStore', () => {
+  afterEach(() => {
+    useAuthStore.getState().logout();
+    localStorage.clear();
+  });
+
+  it('updates the in-memory session through login and logout', () => {
+    useAuthStore.getState().login('studio-admin', 7, true);
+    expect(useAuthStore.getState()).toMatchObject({
+      user: 'studio-admin',
+      userId: 7,
+      admin: true,
+    });
+
+    useAuthStore.getState().logout();
+    expect(useAuthStore.getState()).toMatchObject({
+      user: null,
+      userId: null,
+      admin: null,
+    });
+  });
+
+  it('persists display identity without a bearer token', () => {
+    useAuthStore.getState().login('studio-admin', 7, true);
+
+    expect(localStorage.getItem('rocketmq-studio-user')).toBe('studio-admin');
+    expect(localStorage.getItem('rocketmq-studio-user-id')).toBe('7');
+    expect(localStorage.getItem('rocketmq-studio-user-admin')).toBe('true');
+    expect(localStorage.getItem('token')).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #4038


## Summary

Adds a focused Vitest suite for the auth store (`web/src/stores/authStore.ts`) that locks in the in-memory session updates through `login`/`logout` and the localStorage persistence of the display identity without writing a bearer token.

## Why

The auth store is the single source of truth for the logged-in session and is restored from localStorage across reloads. It had no direct regression coverage, so changes to login/logout or the persistence keys could silently break session restore.

## Testing

- `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` → exit 0
- `./node_modules/.bin/vitest run src/stores/__tests__/authStore.test.ts` → 2 tests pass
