### PR TITLE
test(acl): cover enabled ACL with no plain access accounts

### DIFF
--- a/web/src/utils/aclRiskDiagnostics.test.ts
+++ b/web/src/utils/aclRiskDiagnostics.test.ts
@@ -170,3 +170,13 @@ describe('ACL risk diagnostics', () => {
     );
   });
 });
+
+describe('ACL risk diagnostics missing accounts', () => {
+  it('flags an enabled ACL with no plain access accounts as critical', () => {
+    const diagnostics = analyzeAclRisk(config({ accounts: [], accountCount: 0 }));
+
+    expect(diagnostics.status).toBe('critical');
+    expect(diagnostics.summary.accountCount).toBe(0);
+    expect(diagnostics.issues.map((issue) => issue.code)).toContain('NO_PLAIN_ACCESS_ACCOUNTS');
+  });
+});


### PR DESCRIPTION
Fixes #4042


## Summary

Adds a regression case to `web/src/utils/aclRiskDiagnostics.test.ts` covering a cluster with ACL enabled but zero Plain Access accounts: it asserts `critical` status, `accountCount` of 0 in the summary, and the `NO_PLAIN_ACCESS_ACCOUNTS` issue code.

## Why

Existing coverage only exercised the no-accounts path while ACL was also disabled (where the issue is a `warning`). When ACL is enabled, the same condition is elevated to `critical`, and that boundary had no coverage.

## Testing

- `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` → exit 0
- `./node_modules/.bin/vitest run src/utils/aclRiskDiagnostics.test.ts` → 5 tests pass
