### PR TITLE
test(message-properties): cover reserved property detection

### DIFF
--- a/web/src/utils/messagePayloadPreview.test.ts
+++ b/web/src/utils/messagePayloadPreview.test.ts
@@ -254,3 +254,11 @@ describe('messagePayloadPreview', () => {
     );
   });
 });
+
+describe('message reserved property detection', () => {
+  it('recognizes reserved message properties case-insensitively after trimming', () => {
+    expect(isReservedMessageProperty('  UNIQ_KEY  ')).toBe(true);
+    expect(isReservedMessageProperty('wait')).toBe(true);
+    expect(isReservedMessageProperty('tenant')).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #4044


## Summary

Adds a regression case to `web/src/utils/messagePayloadPreview.test.ts` for reserved message property detection, covering whitespace trimming and case-insensitive matching (`'  UNIQ_KEY  '`, `'wait'`) plus a negative non-reserved name (`'tenant'`).

## Why

`isReservedMessageProperty('tags')` and a negative case were already covered by an existing test, but the trim + case-insensitive normalization boundary was untested. A regression there would misclassify reserved properties entered with surrounding whitespace or lowercase.

## Testing

- `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` → exit 0
- `./node_modules/.bin/vitest run src/utils/messagePayloadPreview.test.ts` → 14 tests pass
