### PR TITLE
feat(proxy): search and export the proxy node inventory

### DIFF
--- a/web/src/pages/studio/Proxy.tsx
+++ b/web/src/pages/studio/Proxy.tsx
@@ -46,6 +46,7 @@ import {
   Plus,
   Trash,
   MagnifyingGlass,
+  DownloadSimple,
 } from '@phosphor-icons/react';
 import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
@@ -59,6 +60,7 @@ import {
   type ProxyNode,
 } from '../../api/proxy';
 import { readLocalStorage, writeLocalStorage } from '../../utils/browserStorage';
+import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 
 const { Text } = Typography;
 
@@ -66,6 +68,24 @@ const persistProxyAddress = (address?: string) => {
   if (!address) return;
   writeLocalStorage('proxyAddr', address);
 };
+
+const PROXY_NODE_EXPORT_STATUS_LABEL: Record<ProxyNode['status'], string> = {
+  healthy: 'Healthy',
+  unhealthy: 'Unhealthy',
+  warning: 'Warning',
+  unknown: 'Unknown',
+};
+
+const PROXY_NODE_EXPORT_COLUMNS: CsvColumn<ProxyNode>[] = [
+  { header: 'Address', value: (node) => node.address },
+  { header: 'Status', value: (node) => PROXY_NODE_EXPORT_STATUS_LABEL[node.status] },
+  { header: 'Version', value: (node) => node.version ?? '' },
+  { header: 'Connections', value: (node) => node.connections ?? '' },
+  { header: 'TPS', value: (node) => node.tps ?? '' },
+  { header: 'Memory (%)', value: (node) => node.memory ?? '' },
+  { header: 'CPU (%)', value: (node) => node.cpu ?? '' },
+  { header: 'Uptime', value: (node) => node.uptime ?? '' },
+];
 
 const ProxyPage: React.FC = () => {
   const { t } = useLang();
@@ -342,6 +362,11 @@ const ProxyPage: React.FC = () => {
   const compareNullable = (left: number | null, right: number | null) =>
     (left ?? Number.NEGATIVE_INFINITY) - (right ?? Number.NEGATIVE_INFINITY);
 
+  const handleExport = () => {
+    const filename = `rocketmq-proxy-nodes-${new Date().toISOString().slice(0, 10)}.csv`;
+    downloadCsv(filename, buildCsv(PROXY_NODE_EXPORT_COLUMNS, filteredProxyNodes));
+  };
+
   // ─── Columns ─────────────────────────────────────────────────
 
   const columns: ColumnsType<ProxyNode> = [
@@ -556,15 +581,24 @@ const ProxyPage: React.FC = () => {
           variant="borderless"
           style={{ borderRadius: 8, marginBottom: 24 }}
           extra={
-            <Input
-              allowClear
-              aria-label={t('proxy.nodeFilter')}
-              placeholder={t('proxy.nodeFilterPlaceholder')}
-              prefix={<MagnifyingGlass size={14} />}
-              value={nodeFilter}
-              onChange={(event) => setNodeFilter(event.target.value)}
-              style={{ width: 260 }}
-            />
+            <Space>
+              <Input
+                allowClear
+                aria-label={t('proxy.nodeFilter')}
+                placeholder={t('proxy.nodeFilterPlaceholder')}
+                prefix={<MagnifyingGlass size={14} />}
+                value={nodeFilter}
+                onChange={(event) => setNodeFilter(event.target.value)}
+                style={{ width: 260 }}
+              />
+              <Button
+                icon={<DownloadSimple size={14} />}
+                disabled={filteredProxyNodes.length === 0}
+                onClick={handleExport}
+              >
+                {t('common.export')}
+              </Button>
+            </Space>
           }
         >
           <Table

--- a/web/src/pages/studio/__tests__/Proxy.test.tsx
+++ b/web/src/pages/studio/__tests__/Proxy.test.tsx
@@ -313,4 +313,86 @@ describe('ProxyPage', () => {
     expect(screen.getByText('127.0.0.2:8081')).toBeInTheDocument();
     expect(screen.queryByText('127.0.0.1:8081')).not.toBeInTheDocument();
   });
+
+  it('exports the currently filtered Proxy nodes as CSV', async () => {
+    const createObjectURL = vi.fn((blob: Blob | MediaSource) => {
+      expect(blob).toBeInstanceOf(Blob);
+      return 'blob:proxy-nodes';
+    });
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+      writable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      writable: true,
+      value: revokeObjectURL,
+    });
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    try {
+      const user = userEvent.setup();
+      vi.mocked(queryProxyHomePage).mockResolvedValueOnce({
+        proxyAddrList: ['127.0.0.1:8081', '10.0.0.10:8081'],
+        currentProxyAddr: '127.0.0.1:8081',
+      });
+      vi.mocked(getProxyTopology).mockResolvedValueOnce([
+        {
+          proxyAddr: '127.0.0.1:8081',
+          status: 'UP',
+          grpcPort: 8081,
+          remotingPort: null,
+          grpcReachable: true,
+          remotingReachable: false,
+          latencyMs: 3,
+        },
+        {
+          proxyAddr: '10.0.0.10:8081',
+          status: 'DOWN',
+          grpcPort: 8081,
+          remotingPort: null,
+          grpcReachable: false,
+          remotingReachable: false,
+          latencyMs: 0,
+        },
+      ]);
+
+      renderPage();
+      await screen.findByText('127.0.0.1:8081');
+
+      const filter = screen.getByRole('textbox', { name: '筛选 Proxy 节点' });
+      await user.type(filter, '不健康');
+      expect(screen.queryByText('127.0.0.1:8081')).not.toBeInTheDocument();
+      expect(screen.getByText('10.0.0.10:8081')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: '导出' }));
+
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      const blob = createObjectURL.mock.calls[0][0] as Blob;
+      await expect(blob.text()).resolves.toBe(
+        [
+          '"Address","Status","Version","Connections","TPS","Memory (%)","CPU (%)","Uptime"',
+          '"10.0.0.10:8081","Unhealthy","","","","","",""',
+        ].join('\n'),
+      );
+      expect(
+        document.querySelector('a[download^="rocketmq-proxy-nodes-"]'),
+      ).not.toBeInTheDocument();
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:proxy-nodes');
+    } finally {
+      clickSpy.mockRestore();
+    }
+  });
+
+  it('disables the CSV export button when the filtered node list is empty', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText('127.0.0.1:8081');
+
+    const exportButton = screen.getByRole('button', { name: '导出' });
+    expect(exportButton).toBeEnabled();
+
+    const filter = screen.getByRole('textbox', { name: '筛选 Proxy 节点' });
+    await user.type(filter, 'no-such-node');
+    expect(exportButton).toBeDisabled();
+  });
 });


### PR DESCRIPTION
## Summary
Adds CSV export to the Proxy cluster node table in the Studio Proxy page
(`web/src/pages/studio/Proxy.tsx`). The export button sits next to the existing
node filter input above the table and exports the **currently filtered** proxy
node inventory with the same fields shown in the table:

- Address
- Status (Healthy / Unhealthy / Warning / Unknown)
- Version
- Connections
- TPS
- Memory (%)
- CPU (%)
- Uptime

The file is named `rocketmq-proxy-nodes-YYYY-MM-DD.csv` and is built with the
shared `buildCsv`/`downloadCsv` helpers from `web/src/utils/download.ts` (same
pattern as `Producer.tsx` and `cluster/clients.tsx`). The button is disabled
while the filtered node list is empty. Null metrics are exported as empty
cells.

Note: the search box above the node table (filtering the loaded list by
address/status/version) was already present on the baseline commit; this PR
keeps it as the filter source for the export, so the exported rows always match
what the table currently shows.

## Why
Operators need an offline/auditable snapshot of the proxy node inventory
(e.g. during upgrades, capacity reviews or incident reports). Filtering the
table first and exporting the filtered subset lets them capture exactly the
nodes they care about instead of hand-copying table cells.

## Testing
- Local typecheck: `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` → exit 0.
- Server (Node 20): `./node_modules/.bin/vitest run src/pages/studio/__tests__/Proxy.test.tsx` → 16/16 passed, including new cases:
  - `exports the currently filtered Proxy nodes as CSV` (verifies blob content, CSV escaping, file name and object URL revocation)
  - `disables the CSV export button when the filtered node list is empty`
