### PR TITLE
feat(certs): export the Kubernetes certificate inventory as CSV

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -30,6 +30,7 @@ const translations: Record<string, Record<Lang, string>> = {
   'nav.dlq': { zh: '死信队列', en: 'Dead Letter Queue' },
   'nav.clusterOps': { zh: '集群管理', en: 'Cluster Management' },
   'nav.certs': { zh: 'K8s 证书配置', en: 'K8s Certificate Config' },
+  'certs.exportCsv': { zh: '导出 CSV', en: 'Export CSV' },
   'nav.rocketmqCluster': { zh: 'RocketMQ 集群', en: 'RocketMQ Cluster' },
   'nav.clients': { zh: '客户端连接', en: 'Client Connections' },
   'nav.alertEvents': { zh: '告警事件', en: 'Alert Events' },

--- a/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
@@ -192,4 +192,99 @@ describe('K8sCertsPage', () => {
     await waitFor(() => expect(deleteK8sCert).toHaveBeenCalledWith(1));
     await waitFor(() => expect(screen.queryByText('rocketmq-prod-tls')).not.toBeInTheDocument());
   });
+
+  it('exports the filtered certificate metadata as CSV', async () => {
+    const createObjectURL = vi.fn((blob: Blob | MediaSource) => {
+      expect(blob).toBeInstanceOf(Blob);
+      return 'blob:k8s-certs';
+    });
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+      writable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      writable: true,
+      value: revokeObjectURL,
+    });
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    try {
+      const user = userEvent.setup();
+      renderPage();
+
+      await screen.findByText('rocketmq-prod-tls');
+      await user.type(screen.getByPlaceholderText('搜索 k8s ID 或集群'), 'staging{enter}');
+      expect(screen.queryByText('rocketmq-prod-tls')).not.toBeInTheDocument();
+      expect(screen.getByText('rocketmq-staging-tls')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: '导出 CSV' }));
+
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      const blob = createObjectURL.mock.calls[0][0] as Blob;
+      await expect(blob.text()).resolves.toBe(
+        [
+          '"ID","K8s ID","Cluster","Type","Issuer","Not Before","Not After","Days Remaining","Status"',
+          '"2","rocketmq-staging-tls","staging-cluster","TLS","kubernetes-ca","2026-01-01T00:00:00Z","2027-01-01T00:00:00Z","365","valid"',
+        ].join('\n'),
+      );
+      expect(
+        document.querySelector('a[download^="rocketmq-k8s-certs-"]'),
+      ).not.toBeInTheDocument();
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:k8s-certs');
+    } finally {
+      clickSpy.mockRestore();
+    }
+  });
+
+  it('never exports PEM private key material', async () => {
+    vi.mocked(listK8sCerts).mockResolvedValueOnce([
+      {
+        ...certs[0],
+        certPem: '-----BEGIN CERTIFICATE-----cert-material',
+        keyPem: '-----BEGIN PRIVATE KEY-----secret-key-material',
+      },
+      certs[2],
+    ]);
+    const createObjectURL = vi.fn((blob: Blob | MediaSource) => {
+      expect(blob).toBeInstanceOf(Blob);
+      return 'blob:k8s-certs-secret-check';
+    });
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+      writable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      writable: true,
+      value: revokeObjectURL,
+    });
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    try {
+      const user = userEvent.setup();
+      renderPage();
+
+      await screen.findByText('rocketmq-prod-tls');
+      await user.click(screen.getByRole('button', { name: '导出 CSV' }));
+
+      const blob = createObjectURL.mock.calls[0][0] as Blob;
+      const csv = await blob.text();
+      expect(csv).toContain('rocketmq-prod-tls');
+      expect(csv).toContain('rocketmq-staging-tls');
+      expect(csv).not.toContain('BEGIN');
+      expect(csv).not.toContain('PRIVATE KEY');
+      expect(csv).not.toContain('secret-key-material');
+      expect(csv).not.toContain('cert-material');
+    } finally {
+      clickSpy.mockRestore();
+    }
+  });
+
+  it('disables the CSV export button when no certificate matches', async () => {
+    vi.mocked(listK8sCerts).mockResolvedValueOnce([]);
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: '导出 CSV' })).toBeDisabled(),
+    );
+  });
 });

--- a/web/src/pages/cluster/certs.tsx
+++ b/web/src/pages/cluster/certs.tsx
@@ -31,14 +31,16 @@ import {
   Popconfirm,
   message,
 } from 'antd';
-import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
+import { PlusOutlined, DeleteOutlined, DownloadOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import PageHeader from '../../components/PageHeader';
 import InfoBanner from '../../components/InfoBanner';
 import type { K8sCertInfo } from '../../api/cluster';
 import { listK8sCerts, createK8sCert, deleteK8sCert } from '../../services/clusterService';
 import { formatDateTime } from '../../utils/format';
+import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 import { tableScrollX } from '../../utils/table';
+import { useLang } from '../../i18n/LangContext';
 
 const { Text } = Typography;
 
@@ -53,7 +55,21 @@ interface CreateCertFormValues {
   keyPem?: string;
 }
 
+// Metadata only: the export never includes certPem/keyPem private material.
+const CERT_EXPORT_COLUMNS: CsvColumn<K8sCertInfo>[] = [
+  { header: 'ID', value: (cert) => cert.id },
+  { header: 'K8s ID', value: (cert) => cert.k8sId },
+  { header: 'Cluster', value: (cert) => cert.cluster },
+  { header: 'Type', value: (cert) => cert.type ?? '' },
+  { header: 'Issuer', value: (cert) => cert.issuer ?? '' },
+  { header: 'Not Before', value: (cert) => cert.notBefore ?? '' },
+  { header: 'Not After', value: (cert) => cert.notAfter ?? '' },
+  { header: 'Days Remaining', value: (cert) => cert.daysRemaining },
+  { header: 'Status', value: (cert) => cert.status ?? '' },
+];
+
 const K8sCertsPage = () => {
+  const { t } = useLang();
   const [certs, setCerts] = useState<K8sCertInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [certSearch, setCertSearch] = useState('');
@@ -129,6 +145,11 @@ const K8sCertsPage = () => {
     } finally {
       setDeletingId(null);
     }
+  };
+
+  const handleExport = () => {
+    const filename = `rocketmq-k8s-certs-${new Date().toISOString().slice(0, 10)}.csv`;
+    downloadCsv(filename, buildCsv(CERT_EXPORT_COLUMNS, filteredCerts));
   };
 
   const certColumns: ColumnsType<K8sCertInfo> = [
@@ -276,9 +297,19 @@ const K8sCertsPage = () => {
             ]}
           />
         </Space>
-        <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>
-          新增证书
-        </Button>
+        <Space>
+          <Button
+            icon={<DownloadOutlined />}
+            aria-label={t('certs.exportCsv')}
+            disabled={filteredCerts.length === 0}
+            onClick={handleExport}
+          >
+            {t('certs.exportCsv')}
+          </Button>
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>
+            新增证书
+          </Button>
+        </Space>
       </Flex>
       <Card styles={{ body: { padding: 0 } }}>
         <Table


### PR DESCRIPTION
## Summary

Adds an **Export CSV** button to the K8s certificate page (`web/src/pages/cluster/certs.tsx`). Clicking it downloads the **currently filtered** certificate inventory (`filteredCerts`, i.e. the rows matching the existing search box and type filter) as `rocketmq-k8s-certs-YYYY-MM-DD.csv`.

The exported columns match the page table's actual fields:

`ID, K8s ID, Cluster, Type, Issuer, Not Before, Not After, Days Remaining, Status`

The export is metadata only — `certPem`/`keyPem` private key material is deliberately never included (covered by a test that seeds PEM content and asserts it does not appear in the CSV). The button is disabled when no certificate matches the current filters.

## Why

Operators need an offline, shareable view of the Kubernetes certificate inventory (e.g. for expiry reviews or audits). The page already supports searching and type filtering, so exporting exactly what the filters show lets users capture a precise subset without exposing private key material.

## Testing

- Local: `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` → exit 0.
- Server (Node 20): `./node_modules/.bin/vitest run src/pages/cluster/__tests__/K8sCertsPage.test.tsx` → 10 passed, including:
  - `exports the filtered certificate metadata as CSV`
  - `never exports PEM private key material`
  - `disables the CSV export button when no certificate matches`
