### PR TITLE
feat(acl): export the ACL user inventory as CSV

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1047,6 +1047,7 @@ const translations: Record<string, Record<Lang, string>> = {
   'acl.allDecisions': { zh: '全部决策', en: 'All Decisions' },
   'acl.totalRules': { zh: '共 {n} 条规则', en: '{n} rules total' },
   'acl.totalUsers': { zh: '共 {n} 个用户', en: '{n} users total' },
+  'acl.exportCsv': { zh: '导出 CSV', en: 'Export CSV' },
   'acl.editRule': { zh: '编辑规则', en: 'Edit Rule' },
   'acl.save': { zh: '保存', en: 'Save' },
   'acl.add': { zh: '添加', en: 'Add' },

--- a/web/src/pages/instance/__tests__/AclPage.test.tsx
+++ b/web/src/pages/instance/__tests__/AclPage.test.tsx
@@ -961,4 +961,81 @@ describe('ACL page', () => {
       expect.objectContaining({ accessKey: 'new-svc' }),
     );
   });
+
+  it('exports the full ACL user inventory as CSV without credentials', async () => {
+    vi.mocked(aclService.listAclUsers).mockResolvedValue([
+      {
+        id: 11,
+        username: 'remote-admin',
+        accessKey: 'secret-ak-11',
+        secretKey: 'secret-sk-11',
+        admin: true,
+        clusters: ['cluster-a', 'cluster-b'],
+        gmtCreate: '2026-07-23T00:00:00Z',
+      },
+      {
+        id: 12,
+        username: 'plain-user',
+        accessKey: 'secret-ak-12',
+        secretKey: 'secret-sk-12',
+        admin: false,
+        clusters: [],
+        gmtCreate: null,
+      },
+    ]);
+    const createObjectURL = vi.fn((blob: Blob | MediaSource) => {
+      expect(blob).toBeInstanceOf(Blob);
+      return 'blob:acl-users';
+    });
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+      writable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      writable: true,
+      value: revokeObjectURL,
+    });
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    try {
+      const user = userEvent.setup();
+      renderWithProviders(<AclPage />);
+
+      await user.click(await screen.findByText('用户管理'));
+      await user.click(screen.getByRole('button', { name: '导出 CSV' }));
+
+      await waitFor(() => expect(aclService.listAclUsers).toHaveBeenCalledTimes(1));
+      expect(aclService.listAclUsers).toHaveBeenCalledWith({ instanceId: undefined });
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      const blob = createObjectURL.mock.calls[0][0] as Blob;
+      const csv = await blob.text();
+      expect(csv).toBe(
+        [
+          '"Username","Admin","Clusters","Created"',
+          '"remote-admin","true","cluster-a, cluster-b","2026-07-23T00:00:00Z"',
+          '"plain-user","false","",""',
+        ].join('\n'),
+      );
+      expect(csv).not.toContain('secret-ak');
+      expect(csv).not.toContain('secret-sk');
+      expect(
+        document.querySelector('a[download^="rocketmq-acl-users-"]'),
+      ).not.toBeInTheDocument();
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:acl-users');
+    } finally {
+      clickSpy.mockRestore();
+    }
+  });
+
+  it('shows an error toast when the full ACL user export fails', async () => {
+    vi.mocked(aclService.listAclUsers).mockRejectedValue(new Error('backend down'));
+    const user = userEvent.setup();
+    renderWithProviders(<AclPage />);
+
+    await user.click(await screen.findByText('用户管理'));
+    await user.click(screen.getByRole('button', { name: '导出 CSV' }));
+
+    await waitFor(() => expect(aclService.listAclUsers).toHaveBeenCalledTimes(1));
+    expect((await screen.findAllByText('获取数据失败')).length).toBeGreaterThan(0);
+  });
 });

--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -46,6 +46,7 @@ import {
   Eye,
   EyeSlash,
   Key,
+  DownloadSimple,
 } from '@phosphor-icons/react';
 import { EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
@@ -62,6 +63,7 @@ import {
   getAclUserCredentials,
   examineBrokerClusterAclConfig,
   listAclRules,
+  listAclUsers,
   pageAclUsers,
   updateAclRule,
   updateAclUser,
@@ -70,6 +72,7 @@ import type { AclRule, AclUser, AclClusterConfig, PlainAccessConfig } from '../.
 import { useInstanceFilter } from '../../hooks/useInstanceFilter';
 import { tableScrollX } from '../../utils/table';
 import { analyzeAclRisk, type AclRiskIssue } from '../../utils/aclRiskDiagnostics';
+import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 
 type AclEntityId = AclRule['id'];
 type AclRuleFormValues = Pick<
@@ -95,6 +98,14 @@ const normalizeRule = (rule: AclRule): AclRule => ({
 });
 
 type NormalizedAclUser = AclUser & { accessKey: string; secretKey: string };
+
+// Credentials (accessKey/secretKey) are deliberately never exported.
+const ACL_USER_EXPORT_COLUMNS: CsvColumn<NormalizedAclUser>[] = [
+  { header: 'Username', value: (user) => user.username },
+  { header: 'Admin', value: (user) => (user.admin ? 'true' : 'false') },
+  { header: 'Clusters', value: (user) => user.clusters.join(', ') },
+  { header: 'Created', value: (user) => user.gmtCreate ?? '' },
+];
 
 const normalizeUser = (user: AclUser): NormalizedAclUser => ({
   ...user,
@@ -140,6 +151,7 @@ const AclPageContent = ({
   const [userKeyword, setUserKeyword] = useState('');
   const [ruleSubmitting, setRuleSubmitting] = useState(false);
   const [userSubmitting, setUserSubmitting] = useState(false);
+  const [exportingUsers, setExportingUsers] = useState(false);
   const [activeTab, setActiveTab] = useState('rules');
   const [ruleRefreshKey, setRuleRefreshKey] = useState(0);
   const [userRefreshKey, setUserRefreshKey] = useState(0);
@@ -258,6 +270,23 @@ const AclPageContent = ({
   /* ─── Rule helpers ─── */
   const isAdmin = (principal: string) =>
     users.find((u) => u.username === principal)?.admin ?? false;
+
+  const handleExportUsers = async () => {
+    if (exportingUsers) return;
+    setExportingUsers(true);
+    try {
+      // listAclUsers returns the full user inventory (not paginated), so the
+      // export always contains every user of the selected instance.
+      const allUsers = await listAclUsers({ instanceId: selectedInstanceId });
+      const rows = allUsers.map(normalizeUser);
+      const filename = `rocketmq-acl-users-${new Date().toISOString().slice(0, 10)}.csv`;
+      downloadCsv(filename, buildCsv(ACL_USER_EXPORT_COLUMNS, rows));
+    } catch {
+      message.error(t('common.fetchDataFailed'));
+    } finally {
+      setExportingUsers(false);
+    }
+  };
 
   const actionTagColor: Record<string, string> = {
     PUB: 'blue',
@@ -1238,6 +1267,14 @@ const AclPageContent = ({
                         allowClear
                         style={{ width: 240 }}
                       />
+                      <Button
+                        icon={<DownloadSimple size={14} />}
+                        loading={exportingUsers}
+                        disabled={exportingUsers}
+                        onClick={() => void handleExportUsers()}
+                      >
+                        {t('acl.exportCsv')}
+                      </Button>
                     </Space>
                   </div>
 


### PR DESCRIPTION
## Summary

Adds an "Export CSV" (导出 CSV) button to the user management tab of the ACL page. Because the backend exposes a full, non-paginated user list endpoint (`listAclUsers`), the button fetches the complete user inventory of the selected instance on click and downloads it as `rocketmq-acl-users-YYYY-MM-DD.csv`.

Exported columns mirror the user table fields: Username, Admin, Clusters, Created. Credentials are never exported — `accessKey`/`secretKey` are intentionally excluded from the CSV columns.

## Why

Operators need an offline, complete ACL user inventory for audits and migration planning. Exporting the full list via `listAclUsers` (instead of only the currently paginated page) guarantees the CSV matches the whole inventory; excluding credential fields keeps the export safe to share.

## Testing

- Local: `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` → exit 0
- Server (Node 20): `./node_modules/.bin/vitest run src/pages/instance/__tests__/AclPage.test.tsx` → 25 passed
  - exports the full ACL user inventory as CSV without credentials
  - shows an error toast when the full ACL user export fails
