### PR TITLE
feat(ai): export the active conversation as Markdown

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -939,6 +939,7 @@ const translations: Record<string, Record<Lang, string>> = {
 
   // ─── AI Page ───
   'ai.title': { zh: 'AI 交互', en: 'AI Chat' },
+  'ai.exportMarkdown': { zh: '导出 Markdown', en: 'Export Markdown' },
   'ai.commonCommands': { zh: '常用指令', en: 'Common Commands' },
   'ai.mockProviderDisabled': {
     zh: 'Mock 模式已禁用 AI Provider 调用',

--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -536,4 +536,79 @@ describe('AiPage tool runner', () => {
     expect(await screen.findByText('工具参数必须是有效的 JSON 对象')).toBeInTheDocument();
     expect(executeTool).not.toHaveBeenCalled();
   });
+
+  it('exports the active conversation as Markdown in message order', async () => {
+    useAiChatHistoryStore.setState({
+      histories: {
+        mock: { conversations: [], activeConversationId: null },
+        real: {
+          conversations: [
+            {
+              id: 'conv-1',
+              messages: [
+                { id: 'm1', role: 'user', text: 'How many brokers?' },
+                { id: 'm2', role: 'ai', text: '**3** brokers.' },
+                { id: 'm3', role: 'user', text: 'Show details.' },
+              ],
+              updatedAt: 0,
+            },
+          ],
+          activeConversationId: 'conv-1',
+        },
+      },
+    });
+    const createObjectURL = vi.fn((blob: Blob | MediaSource) => {
+      expect(blob).toBeInstanceOf(Blob);
+      return 'blob:ai-conversation';
+    });
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+      writable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      writable: true,
+      value: revokeObjectURL,
+    });
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    try {
+      const user = userEvent.setup();
+      renderPage();
+
+      await screen.findByText('How many brokers?');
+      await user.click(screen.getByRole('button', { name: '导出 Markdown' }));
+
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      const blob = createObjectURL.mock.calls[0][0] as Blob;
+      expect(blob.type).toBe('text/markdown;charset=utf-8');
+      await expect(blob.text()).resolves.toBe(
+        [
+          '## User',
+          '',
+          'How many brokers?',
+          '',
+          '## Assistant',
+          '',
+          '**3** brokers.',
+          '',
+          '## User',
+          '',
+          'Show details.',
+        ].join('\n'),
+      );
+      const anchor = clickSpy.mock.instances[0] as unknown as HTMLAnchorElement;
+      expect(anchor.download).toMatch(/^rocketmq-ai-conversation-.*\.md$/);
+      expect(document.querySelector('a[download^="rocketmq-ai-conversation-"]')).toBeNull();
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:ai-conversation');
+    } finally {
+      clickSpy.mockRestore();
+    }
+  });
+
+  it('disables the Markdown export button for an empty conversation', async () => {
+    renderPage();
+
+    await screen.findByRole('button', { name: '工具' });
+    expect(screen.getByRole('button', { name: '导出 Markdown' })).toBeDisabled();
+  });
 });

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -48,6 +48,7 @@ import {
   SlidersHorizontal,
   Sparkle,
   Stop,
+  DownloadSimple,
 } from '@phosphor-icons/react';
 import type { ColumnsType } from 'antd/es/table';
 import { useLang } from '../../i18n/LangContext';
@@ -63,9 +64,11 @@ import {
   getRecentAiChatConversations,
   flushAiChatHistoryPersistence,
   type AiChatDataMode,
+  type AiChatMessage,
   useAiChatHistoryStore,
 } from '../../stores/aiChatHistoryStore';
 import { getChatDraft, shouldOpenChatHistory, type ChatMode } from './chatDraft';
+import { downloadBlob } from '../../utils/download';
 
 const { Text } = Typography;
 
@@ -123,6 +126,11 @@ const quickActions = [
   '消息轨迹查询',
   '扩缩容评估',
 ];
+
+const buildConversationMarkdown = (messages: AiChatMessage[]) =>
+  messages
+    .map((msg) => `${msg.role === 'user' ? '## User' : '## Assistant'}\n\n${msg.text ?? ''}`)
+    .join('\n\n');
 
 const GLOBAL_TOOL_SCOPE = '__global__';
 const ENGINE_OPTIONS = [
@@ -459,6 +467,13 @@ const AiPage = () => {
   );
   const messages = useMemo(() => activeConversation?.messages ?? [], [activeConversation]);
   const legacyMessageTimestamp = activeConversation?.updatedAt || undefined;
+
+  const handleExportMarkdown = () => {
+    const markdown = buildConversationMarkdown(messages);
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const filename = `rocketmq-ai-conversation-${timestamp}.md`;
+    downloadBlob(new Blob([markdown], { type: 'text/markdown;charset=utf-8' }), filename);
+  };
   const updateMessages = useAiChatHistoryStore((state) => state.setMessages);
   const startConversation = useAiChatHistoryStore((state) => state.startConversation);
   const selectConversation = useAiChatHistoryStore((state) => state.selectConversation);
@@ -1112,6 +1127,14 @@ const AiPage = () => {
                     >
                       <Sparkle size={17} />
                       <span>Prompt 增强</span>
+                    </button>
+                    <button
+                      className="tool-btn"
+                      onClick={handleExportMarkdown}
+                      disabled={messages.length === 0}
+                    >
+                      <DownloadSimple size={17} />
+                      <span>{t('ai.exportMarkdown')}</span>
                     </button>
                   </div>
                 </div>


### PR DESCRIPTION
# Export the active AI conversation as Markdown

## Summary
Adds an "Export Markdown" (`ai.exportMarkdown`, zh/en via `web/src/i18n/translations.ts`) button to the AI chat page's bottom tool bar. Clicking it renders the currently active conversation's messages in order — user messages under `## User` and AI responses under `## Assistant` — and downloads them as a Markdown file named `rocketmq-ai-conversation-<timestamp>.md` (ISO timestamp with `:`/`.` replaced by `-`). The button is disabled when the active conversation has no messages. The download reuses `downloadBlob` from `web/src/utils/download.ts`.

## Why
AI answers currently live only inside the in-app conversation history. Being able to export the active conversation as a portable Markdown document lets operators share conclusions, attach them to incidents/runbooks, and keep an offline record without copying text by hand.

## Testing
- Local typecheck: `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` → exit 0.
- Server (Node 20): `./node_modules/.bin/vitest run src/pages/ai/__tests__/AiPage.test.tsx` → **19 passed** (17 existing + 2 new).
  - `exports the active conversation as Markdown in message order` — asserts the downloaded blob is `text/markdown;charset=utf-8`, contains `## User` / `## Assistant` sections in message order, and the anchor uses the `rocketmq-ai-conversation-*.md` filename.
  - `disables the Markdown export button for an empty conversation`.
