### PR TITLE
feat(message): copy message properties as JSON

### DIFF
--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -356,4 +356,51 @@ describe('Message page query history', () => {
       );
     });
   });
+it('copies message properties as JSON from the detail modal', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      writable: true,
+      value: { writeText },
+    });
+    messageServiceMocks.queryMessages.mockResolvedValue([
+      { ...createMessage('MID-PROPS'), properties: { KEYS: 'abc', TAGS: 'vip' } },
+    ]);
+    renderWithProviders(<MessagePage />);
+
+    await user.click(screen.getByText('按 Message ID'));
+    await user.click(lastElement(screen.getAllByRole('combobox')));
+    await user.click(lastElement(await screen.findAllByText('order-create')));
+    await user.type(screen.getByPlaceholderText('输入 Message ID'), 'MID-PROPS');
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+
+    expect(await screen.findByText('MID-PROPS')).toBeInTheDocument();
+    await user.click(screen.getAllByRole('button', { name: /详情/ })[0]);
+
+    const copyButton = await screen.findByRole('button', { name: /复制属性 JSON/ });
+    await user.click(copyButton);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const copied = JSON.parse(vi.mocked(writeText).mock.calls[0][0]);
+    expect(copied).toEqual({ KEYS: 'abc', TAGS: 'vip' });
+  });
+
+  it('disables the properties copy action when a message has no properties', async () => {
+    const user = userEvent.setup();
+    messageServiceMocks.queryMessages.mockResolvedValue([createMessage('MID-NO-PROPS')]);
+    renderWithProviders(<MessagePage />);
+
+    await user.click(screen.getByText('按 Message ID'));
+    await user.click(lastElement(screen.getAllByRole('combobox')));
+    await user.click(lastElement(await screen.findAllByText('order-create')));
+    await user.type(screen.getByPlaceholderText('输入 Message ID'), 'MID-NO-PROPS');
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+
+    expect(await screen.findByText('MID-NO-PROPS')).toBeInTheDocument();
+    await user.click(screen.getAllByRole('button', { name: /详情/ })[0]);
+
+    expect(await screen.findByRole('button', { name: /复制属性 JSON/ })).toBeDisabled();
+    expect(screen.getByText('该消息无属性')).toBeInTheDocument();
+  });
 });
+

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -40,6 +40,7 @@ import {
 import {
   SearchOutlined,
   ReloadOutlined,
+  CopyOutlined,
   SendOutlined,
   EyeOutlined,
   NodeIndexOutlined,
@@ -151,6 +152,29 @@ const formatDurationMs = (value: number | null): string => {
   if (value >= 60000) return `${(value / 60000).toFixed(1)} min`;
   if (value >= 1000) return `${(value / 1000).toFixed(2)} s`;
   return `${value} ms`;
+};
+
+
+const copyMessageProperties = async (record: MessageRecord) => {
+  const text = JSON.stringify(record.properties ?? {}, null, 2);
+  try {
+    await navigator.clipboard.writeText(text);
+    message.success('消息属性已复制为 JSON');
+  } catch {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const copied = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    if (copied) {
+      message.success('消息属性已复制为 JSON');
+    } else {
+      message.error('复制失败，请手动复制');
+    }
+  }
 };
 
 const getQueryValidationError = (mode: QueryMode, params: MessageQuery): string | null => {
@@ -903,6 +927,19 @@ const MessagePageContent = ({
               <span style={{ fontFamily: 'monospace' }}>{formatTimeMs(selectedMsg.storeTime)}</span>
             </Descriptions.Item>
           </Descriptions>
+          <Flex gap={8} align="center" style={{ marginBottom: 16 }}>
+            <Button
+              size="small"
+              icon={<CopyOutlined />}
+              disabled={Object.keys(selectedMsg.properties ?? {}).length === 0}
+              onClick={() => void copyMessageProperties(selectedMsg)}
+            >
+              复制属性 JSON
+            </Button>
+            {Object.keys(selectedMsg.properties ?? {}).length === 0 ? (
+              <Typography.Text type="secondary">该消息无属性</Typography.Text>
+            ) : null}
+          </Flex>
           <Typography.Title level={5} style={{ marginBottom: 8 }}>
             消息体
           </Typography.Title>


### PR DESCRIPTION
## Summary

Add a "复制属性 JSON" (copy properties as JSON) action to the message detail
modal on the Message page. It serializes the selected message's `properties`
object with `JSON.stringify(..., null, 2)` and writes it to the clipboard via
`navigator.clipboard.writeText`, with a `textarea` + `document.execCommand`
fallback for non-secure contexts. The button is disabled (with a "该消息无属性"
hint) when the message has no properties.

## Why

Operators inspecting a message currently have no way to grab its properties
as a machine-readable payload; the message body is copyable but the
key/value properties are not rendered on the detail view. This makes pasting
properties into a ticket or script one click instead of retyping them.

## Testing

- `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` — passes (exit 0)
- `./node_modules/.bin/vitest run src/pages/instance/__tests__/MessagePage.test.tsx`
  (Node 20 build server) — **12/12 passed**, including two new cases:
  - clicking the action writes `{"KEYS":"abc","TAGS":"vip"}` to the clipboard;
  - the action is disabled and shows the no-properties hint for messages with
    an empty `properties` object.
