### PR TITLE
fix(consumer): preserve broker policies when recreating groups

### DIFF
--- a/docs/consumer-group-recreation.md
+++ b/docs/consumer-group-recreation.md
@@ -1,0 +1,46 @@
+# 消费组重建与配置保留
+
+Studio 的 Apache 消费组创建接口支持对同名消费组重复执行，CSV 导入也使用这条路径。重建用于恢复或同步资源，不应自动恢复消费、取消顺序消费或覆盖 Broker 独立配置。
+
+## 原有问题
+
+旧实现为每次创建构造同一份默认 `SubscriptionGroupConfig`，随后发送给所有目标 Broker。已有消费组的 `consumeEnable=false` 会变成 `true`，`consumeMessageOrderly=true` 会变成 `false`，重试队列数、消费超时、Broker 偏好等也会恢复默认值。
+
+这会直接影响已暂停的消费流量和顺序消费行为。只修复页面的重复点击无法解决从 CSV 重新导入、脚本重复创建或恢复已有组的场景。
+
+另一个同领域问题出现在配置更新：Broker 返回的属性名称是 `priority.factor` 等存储键，而更新接口接受 `+priority.factor` 或 `-priority.factor` 这样的修改操作。直接回传存储属性会使原本合法的重试次数修改被 Broker 拒绝。
+
+## 修复行为
+
+每个 Broker 使用自己的消费组配置作为更新基础，保留其消费开关、顺序消费、广播开关、重试队列数、超时和其他协议字段。不会把某个 Broker 的设置复制给整个集群。
+
+| 请求或状态 | 行为 |
+| --- | --- |
+| 已有组，创建请求带正数重试次数 | 仅替换重试次数，保留其他配置 |
+| 已有组，创建请求没有重试次数 | 保留已有值，包括通过设置接口配置的 0 次 |
+| Broker 明确返回组不存在 | 使用现有新建默认值，并应用请求中的正数重试次数 |
+| 权限不足、连接失败或超时 | 返回失败，不将不可读取的配置当成不存在 |
+| 已有 Broker 属性 | 发送空属性修改集合，由 Broker 保留已有属性 |
+| 部分 Broker 完成后失败 | 审计记录已完成与总 Broker 数，不伪报全部成功 |
+
+创建接口的旧模型用 0 同时表示省略值，因此需要将重试次数明确设为 0 时，继续使用消费组设置接口。本次不改变该接口约定。
+
+数据库记录和返回结果使用实际写入的重试次数。各 Broker 原先存在差异、且请求未指定重试次数时，元数据采用按地址排序的首个 Broker 值，与逐 Broker 保留策略兼容。
+
+## 操作边界
+
+RocketMQ 的组配置读取接口在 Broker 启用自动创建时可能创建缺失组，因此整个流程不承诺只读预检或分布式原子性。网络故障也可能发生在某个 Broker 已接受更新之后；应根据审计结果检查实际状态并重试。
+
+属性处理依据 RocketMQ 5.5.0 的 [SubscriptionGroupManager](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/subscription/SubscriptionGroupManager.java)：空修改集合保留现有属性。测试直接调用对应 SDK 中的 `AttributeUtil` 验证协议行为。
+
+## 验证与兼容
+
+使用 Java 21，在 `server` 目录执行：
+
+```bash
+mvn -B -ntp -Dtest=ConsumerGroupRecreationTest,RocketMQAdminClientImplTest,MetadataServiceTest test
+```
+
+验证包括暂停且顺序消费的组重新创建、不同 Broker 的独立策略、0 次重试保留、明确缺失、权限错误、部分执行失败、属性修改协议以及既有创建和元数据服务测试。
+
+无迁移，直接替换。没有新增依赖、配置或数据库字段。回滚修复提交即可恢复原行为；已经被旧逻辑覆盖的 Broker 设置需要运营者依据原配置恢复，本次不会猜测原值。

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -570,6 +570,9 @@ public class RocketMQAdminClientImpl implements AdminClient {
                     if (command.consumeBroadcastEnable() != null) {
                         config.setConsumeBroadcastEnable(command.consumeBroadcastEnable());
                     }
+                    // Broker attributes use a +/- patch protocol. An empty patch preserves
+                    // existing attributes; replaying plain stored keys is not a valid update.
+                    config.setAttributes(Map.of());
                     admin.createAndUpdateSubscriptionGroupConfig(brokerAddr, config);
                     updatedBrokers++;
                     if (applied == null) {
@@ -616,6 +619,8 @@ public class RocketMQAdminClientImpl implements AdminClient {
 
     private ConsumerGroupVO createConsumerGroup(MQAdminExt admin, ConsumerGroupVO group) {
         String groupName = group.getName();
+        int totalBrokers = 0;
+        int updatedBrokers = 0;
 
         try {
             String groupClusterName = getClusterName(admin);
@@ -624,15 +629,22 @@ public class RocketMQAdminClientImpl implements AdminClient {
                 throw new BusinessException(500, "No broker available to create consumer group");
             }
 
-            SubscriptionGroupConfig config = new SubscriptionGroupConfig();
-            config.setGroupName(groupName);
-            config.setConsumeEnable(true);
-            config.setConsumeBroadcastEnable(true);
-            config.setRetryQueueNums(1);
-            config.setRetryMaxTimes(group.getRetryMaxTimes() > 0 ? group.getRetryMaxTimes() : 16);
-
-            for (String addr : brokerAddrs) {
+            totalBrokers = brokerAddrs.size();
+            SubscriptionGroupConfig applied = null;
+            for (String addr : brokerAddrs.stream().sorted().toList()) {
+                SubscriptionGroupConfig config = consumerGroupConfigForCreate(admin, addr, groupName);
+                // Re-creation is an upsert, not a reset of broker-side consumption policy.
+                // Zero is also the legacy VO's omitted value, so preserve existing retries
+                // unless a positive retry setting was supplied. The settings API supports zero.
+                if (group.getRetryMaxTimes() > 0) {
+                    config.setRetryMaxTimes(group.getRetryMaxTimes());
+                }
+                config.setAttributes(Map.of());
                 admin.createAndUpdateSubscriptionGroupConfig(addr, config);
+                updatedBrokers++;
+                if (applied == null) {
+                    applied = config;
+                }
             }
 
             // Persist to DB, upserting so re-creating an existing group stays scoped to the
@@ -652,7 +664,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
             entity.setInstanceId(metadataScope(group.getInstanceId()));
             entity.setConsumeType(group.getConsumeType() != null ? group.getConsumeType().name() : "CLUSTERING");
             entity.setMessageModel(group.getSubscriptionMode() != null ? group.getSubscriptionMode().name() : "Push");
-            entity.setMaxRetry(config.getRetryMaxTimes());
+            entity.setMaxRetry(applied.getRetryMaxTimes());
             entity.setStatus("ACTIVE");
             entity.setGmtModified(LocalDateTime.now());
             if (isNewGroup) {
@@ -662,17 +674,45 @@ public class RocketMQAdminClientImpl implements AdminClient {
             }
 
             recordAudit("CREATE_GROUP", groupName,
-                    "retryMaxTimes=" + config.getRetryMaxTimes(), "SUCCESS");
+                    "retryMaxTimes=" + applied.getRetryMaxTimes()
+                            + ", brokersUpdated=" + updatedBrokers + "/" + totalBrokers, "SUCCESS");
 
             group.setId(entity.getId());
+            group.setRetryMaxTimes(applied.getRetryMaxTimes());
             return group;
         } catch (BusinessException e) {
-            recordAudit("CREATE_GROUP", groupName, e.getMessage(), "FAILED");
+            recordAudit("CREATE_GROUP", groupName,
+                    "updated " + updatedBrokers + "/" + totalBrokers + " brokers before failure: " + e.getMessage(),
+                    "FAILED");
             throw e;
         } catch (Exception e) {
-            recordAudit("CREATE_GROUP", groupName, e.getMessage(), "FAILED");
+            recordAudit("CREATE_GROUP", groupName,
+                    "updated " + updatedBrokers + "/" + totalBrokers + " brokers before failure: " + e.getMessage(),
+                    "FAILED");
             throw classifyBrokerFailure(e, "create consumer group");
         }
+    }
+
+    private SubscriptionGroupConfig consumerGroupConfigForCreate(MQAdminExt admin, String address, String name)
+            throws Exception {
+        SubscriptionGroupConfig config;
+        try {
+            config = admin.examineSubscriptionGroupConfig(address, name);
+        } catch (MQBrokerException exception) {
+            if (exception.getResponseCode() != ResponseCode.SUBSCRIPTION_GROUP_NOT_EXIST) {
+                throw exception;
+            }
+            config = null;
+        }
+        if (config == null) {
+            config = new SubscriptionGroupConfig();
+            config.setGroupName(name);
+            config.setConsumeEnable(true);
+            config.setConsumeBroadcastEnable(true);
+            config.setRetryQueueNums(1);
+            config.setRetryMaxTimes(16);
+        }
+        return config;
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/ConsumerGroupRecreationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/ConsumerGroupRecreationTest.java
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.apache;
+
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.google.common.collect.ImmutableMap;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.common.SubscriptionGroupAttributes;
+import org.apache.rocketmq.common.attribute.AttributeUtil;
+import org.apache.rocketmq.remoting.exception.RemotingTimeoutException;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.MqClientPool;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupSettingsCommand;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.ops.audit.AuditService;
+import org.apache.rocketmq.studio.persistence.entity.RmqGroup;
+import org.apache.rocketmq.studio.persistence.mapper.RmqGroupMapper;
+import org.apache.rocketmq.studio.persistence.mapper.RmqTopicMapper;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ConsumerGroupRecreationTest {
+    private static final String BROKER = "10.0.0.1:10911";
+    private final DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+    private final RmqGroupMapper groups = mock(RmqGroupMapper.class);
+    private final AuditService audit = mock(AuditService.class);
+    private RocketMQAdminClientImpl client;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqGroup.class);
+        RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+        when(resolver.execute(eq("local"), any())).thenAnswer(invocation ->
+                invocation.<MqAdminExtFactory.AdminAction<Object>>getArgument(1).apply(admin));
+        client = new RocketMQAdminClientImpl(mock(MqAdminExtFactory.class), mock(RocketMQProperties.class),
+                mock(RmqTopicMapper.class), groups, audit, resolver, mock(MqClientPool.class));
+        when(admin.examineBrokerClusterInfo()).thenReturn(topology(Map.of("broker-a", BROKER)));
+    }
+
+    @Test
+    void recreatingAPausedOrderedGroupPreservesItsConsumptionPolicyTest() throws Exception {
+        SubscriptionGroupConfig existing = new SubscriptionGroupConfig();
+        existing.setGroupName("orders");
+        existing.setConsumeEnable(false);
+        existing.setConsumeBroadcastEnable(false);
+        existing.setConsumeMessageOrderly(true);
+        existing.setRetryQueueNums(4);
+        existing.setConsumeTimeoutMinute(45);
+        when(admin.examineSubscriptionGroupConfig(BROKER, "orders")).thenReturn(existing);
+
+        client.createConsumerGroup(request());
+
+        ArgumentCaptor<SubscriptionGroupConfig> applied = ArgumentCaptor.forClass(SubscriptionGroupConfig.class);
+        verify(admin).createAndUpdateSubscriptionGroupConfig(eq(BROKER), applied.capture());
+        assertThat(applied.getValue().isConsumeEnable()).isFalse();
+        assertThat(applied.getValue().isConsumeBroadcastEnable()).isFalse();
+        assertThat(applied.getValue().isConsumeMessageOrderly()).isTrue();
+        assertThat(applied.getValue().getRetryQueueNums()).isEqualTo(4);
+        assertThat(applied.getValue().getConsumeTimeoutMinute()).isEqualTo(45);
+    }
+
+    @Test
+    void omittedRetryPreservesExistingRetryPolicyAndMetadataTest() throws Exception {
+        SubscriptionGroupConfig existing = new SubscriptionGroupConfig();
+        existing.setGroupName("orders");
+        existing.setRetryMaxTimes(0);
+        existing.setConsumeFromMinEnable(false);
+        existing.setNotifyConsumerIdsChangedEnable(false);
+        existing.setBrokerId(2L);
+        existing.setWhichBrokerWhenConsumeSlowly(3L);
+        existing.setGroupSysFlag(8);
+        var retryPolicy = existing.getGroupRetryPolicy();
+        when(admin.examineSubscriptionGroupConfig(BROKER, "orders")).thenReturn(existing);
+        RmqGroup stored = new RmqGroup();
+        stored.setId(10L);
+        stored.setName("orders");
+        when(groups.selectOne(any())).thenReturn(stored);
+        ConsumerGroupVO request = request();
+        request.setRetryMaxTimes(0);
+
+        ConsumerGroupVO result = client.createConsumerGroup(request);
+
+        ArgumentCaptor<SubscriptionGroupConfig> applied = ArgumentCaptor.forClass(SubscriptionGroupConfig.class);
+        verify(admin).createAndUpdateSubscriptionGroupConfig(eq(BROKER), applied.capture());
+        assertThat(applied.getValue().getRetryMaxTimes()).isZero();
+        assertThat(applied.getValue().getGroupRetryPolicy()).isSameAs(retryPolicy);
+        assertThat(applied.getValue().isConsumeFromMinEnable()).isFalse();
+        assertThat(applied.getValue().isNotifyConsumerIdsChangedEnable()).isFalse();
+        assertThat(applied.getValue().getBrokerId()).isEqualTo(2L);
+        assertThat(applied.getValue().getWhichBrokerWhenConsumeSlowly()).isEqualTo(3L);
+        assertThat(applied.getValue().getGroupSysFlag()).isEqualTo(8);
+        assertThat(result.getRetryMaxTimes()).isZero();
+        assertThat(stored.getMaxRetry()).isZero();
+        verify(groups).updateById(stored);
+        verify(groups, never()).insert(any(RmqGroup.class));
+    }
+
+    @Test
+    void explicitRetryChangesOnlyTheRequestedSettingTest() throws Exception {
+        SubscriptionGroupConfig existing = new SubscriptionGroupConfig();
+        existing.setGroupName("orders");
+        existing.setRetryMaxTimes(40);
+        existing.setConsumeEnable(false);
+        existing.setRetryQueueNums(5);
+        when(admin.examineSubscriptionGroupConfig(BROKER, "orders")).thenReturn(existing);
+
+        ConsumerGroupVO result = client.createConsumerGroup(request());
+
+        assertThat(existing.getRetryMaxTimes()).isEqualTo(7);
+        assertThat(existing.isConsumeEnable()).isFalse();
+        assertThat(existing.getRetryQueueNums()).isEqualTo(5);
+        assertThat(result.getRetryMaxTimes()).isEqualTo(7);
+        ArgumentCaptor<RmqGroup> persisted = ArgumentCaptor.forClass(RmqGroup.class);
+        verify(groups).insert(persisted.capture());
+        assertThat(persisted.getValue().getMaxRetry()).isEqualTo(7);
+        assertThat(persisted.getValue().getInstanceId()).isEqualTo("local");
+    }
+
+    @Test
+    void preservesEachBrokerPolicyInsteadOfCopyingOneAcrossTheClusterTest() throws Exception {
+        String otherAddress = "10.0.0.2:10911";
+        when(admin.examineBrokerClusterInfo()).thenReturn(topology(Map.of("broker-a", BROKER,
+                "broker-b", otherAddress)));
+        SubscriptionGroupConfig paused = new SubscriptionGroupConfig();
+        paused.setGroupName("orders");
+        paused.setConsumeEnable(false);
+        paused.setRetryQueueNums(2);
+        SubscriptionGroupConfig running = new SubscriptionGroupConfig();
+        running.setGroupName("orders");
+        running.setConsumeEnable(true);
+        running.setRetryQueueNums(6);
+        when(admin.examineSubscriptionGroupConfig(BROKER, "orders")).thenReturn(paused);
+        when(admin.examineSubscriptionGroupConfig(otherAddress, "orders")).thenReturn(running);
+
+        client.createConsumerGroup(request());
+
+        verify(admin).createAndUpdateSubscriptionGroupConfig(BROKER, paused);
+        verify(admin).createAndUpdateSubscriptionGroupConfig(otherAddress, running);
+        assertThat(paused.isConsumeEnable()).isFalse();
+        assertThat(paused.getRetryQueueNums()).isEqualTo(2);
+        assertThat(running.isConsumeEnable()).isTrue();
+        assertThat(running.getRetryQueueNums()).isEqualTo(6);
+        verify(audit).record(eq("CREATE_GROUP"), eq("GROUP"), eq("orders"), eq(null),
+                contains("brokersUpdated=2/2"), eq("SUCCESS"));
+    }
+
+    @Test
+    void createsMissingGroupWhenBrokerAutoCreationIsDisabledTest() throws Exception {
+        when(admin.examineSubscriptionGroupConfig(BROKER, "orders"))
+                .thenThrow(new MQBrokerException(ResponseCode.SUBSCRIPTION_GROUP_NOT_EXIST, "Group not found"));
+        ConsumerGroupVO request = request();
+        request.setRetryMaxTimes(0);
+
+        ConsumerGroupVO result = client.createConsumerGroup(request);
+
+        ArgumentCaptor<SubscriptionGroupConfig> applied = ArgumentCaptor.forClass(SubscriptionGroupConfig.class);
+        verify(admin).createAndUpdateSubscriptionGroupConfig(eq(BROKER), applied.capture());
+        assertThat(applied.getValue().getGroupName()).isEqualTo("orders");
+        assertThat(applied.getValue().isConsumeEnable()).isTrue();
+        assertThat(applied.getValue().isConsumeBroadcastEnable()).isTrue();
+        assertThat(applied.getValue().getRetryQueueNums()).isEqualTo(1);
+        assertThat(applied.getValue().getRetryMaxTimes()).isEqualTo(16);
+        assertThat(result.getRetryMaxTimes()).isEqualTo(16);
+    }
+
+    @Test
+    void unavailableConfigurationIsNotTreatedAsAMissingGroupTest() throws Exception {
+        when(admin.examineSubscriptionGroupConfig(BROKER, "orders"))
+                .thenThrow(new MQBrokerException(ResponseCode.NO_PERMISSION, "Access denied"));
+
+        assertThatThrownBy(() -> client.createConsumerGroup(request())).isInstanceOf(BusinessException.class);
+
+        verify(admin, never()).createAndUpdateSubscriptionGroupConfig(anyString(), any());
+        verify(groups, never()).insert(any(RmqGroup.class));
+        verify(groups, never()).updateById(any(RmqGroup.class));
+        verify(audit).record(eq("CREATE_GROUP"), eq("GROUP"), eq("orders"), eq(null),
+                contains("updated 0/1"), eq("FAILED"));
+    }
+
+    @Test
+    void recordsPartialApplicationWhenALaterBrokerCannotBeReadTest() throws Exception {
+        String otherAddress = "10.0.0.2:10911";
+        when(admin.examineBrokerClusterInfo()).thenReturn(topology(Map.of("broker-a", BROKER,
+                "broker-b", otherAddress)));
+        SubscriptionGroupConfig existing = new SubscriptionGroupConfig();
+        existing.setGroupName("orders");
+        when(admin.examineSubscriptionGroupConfig(BROKER, "orders")).thenReturn(existing);
+        when(admin.examineSubscriptionGroupConfig(otherAddress, "orders"))
+                .thenThrow(new RemotingTimeoutException("Timed out reading group settings"));
+
+        assertThatThrownBy(() -> client.createConsumerGroup(request())).isInstanceOf(BusinessException.class);
+
+        verify(admin).createAndUpdateSubscriptionGroupConfig(BROKER, existing);
+        verify(admin, never()).createAndUpdateSubscriptionGroupConfig(eq(otherAddress), any());
+        verify(groups, never()).insert(any(RmqGroup.class));
+        verify(audit).record(eq("CREATE_GROUP"), eq("GROUP"), eq("orders"), eq(null),
+                contains("updated 1/2"), eq("FAILED"));
+    }
+
+    @Test
+    void reCreationUsesAnEmptyAttributePatchTest() throws Exception {
+        SubscriptionGroupConfig existing = new SubscriptionGroupConfig();
+        existing.setGroupName("orders");
+        existing.setAttributes(new HashMap<>(Map.of("priority.factor", "25")));
+        when(admin.examineSubscriptionGroupConfig(BROKER, "orders")).thenReturn(existing);
+        Map<String, String> storedAttributes = Map.copyOf(existing.getAttributes());
+        doAnswer(invocation -> {
+            SubscriptionGroupConfig update = invocation.getArgument(1);
+            assertThat(update.getAttributes()).isEmpty();
+            // Use the exact Broker patch interpreter, rather than treating the payload as a map replacement.
+            assertThat(AttributeUtil.alterCurrentAttributes(false, SubscriptionGroupAttributes.ALL,
+                    ImmutableMap.copyOf(storedAttributes), ImmutableMap.copyOf(update.getAttributes())))
+                    .isEqualTo(storedAttributes);
+            return null;
+        }).when(admin).createAndUpdateSubscriptionGroupConfig(eq(BROKER), any());
+
+        client.createConsumerGroup(request());
+
+        verify(admin).createAndUpdateSubscriptionGroupConfig(eq(BROKER), any());
+    }
+
+    @Test
+    void settingsUpdateDoesNotReplayStoredAttributeNamesAsPatchOperationsTest() throws Exception {
+        SubscriptionGroupConfig existing = new SubscriptionGroupConfig();
+        existing.setGroupName("orders");
+        existing.setConsumeEnable(false);
+        existing.setAttributes(new HashMap<>(Map.of("priority.factor", "25")));
+        when(admin.examineSubscriptionGroupConfig(BROKER, "orders")).thenReturn(existing);
+        Map<String, String> storedAttributes = Map.copyOf(existing.getAttributes());
+        doAnswer(invocation -> {
+            SubscriptionGroupConfig update = invocation.getArgument(1);
+            assertThat(AttributeUtil.alterCurrentAttributes(false, SubscriptionGroupAttributes.ALL,
+                    ImmutableMap.copyOf(storedAttributes), ImmutableMap.copyOf(update.getAttributes())))
+                    .isEqualTo(storedAttributes);
+            return null;
+        }).when(admin).createAndUpdateSubscriptionGroupConfig(eq(BROKER), any());
+
+        var result = client.updateConsumerGroupSettings("local", "orders",
+                new ConsumerGroupSettingsCommand(3, 0, null, null, null));
+
+        assertThat(result.getRetryMaxTimes()).isZero();
+        assertThat(result.getRetryQueueNums()).isEqualTo(3);
+        assertThat(result.isConsumeEnable()).isFalse();
+        verify(admin).createAndUpdateSubscriptionGroupConfig(eq(BROKER), any());
+    }
+
+    @Test
+    void missingBrokerDoesNotPersistARecreatedGroupTest() throws Exception {
+        when(admin.examineBrokerClusterInfo()).thenReturn(topology(Map.of()));
+
+        assertThatThrownBy(() -> client.createConsumerGroup(request()))
+                .isInstanceOf(BusinessException.class).hasMessage("No broker available to create consumer group");
+
+        verify(groups, never()).insert(any(RmqGroup.class));
+        verify(admin, never()).createAndUpdateSubscriptionGroupConfig(anyString(), any());
+        verify(audit).record(eq("CREATE_GROUP"), eq("GROUP"), eq("orders"), eq(null),
+                contains("updated 0/0"), eq("FAILED"));
+    }
+
+    @Test
+    void settingsUpdateStopsWhenTheGroupDisappearsOnALaterBrokerTest() throws Exception {
+        when(admin.examineBrokerClusterInfo()).thenReturn(topology(Map.of("broker-a", BROKER,
+                "broker-b", "10.0.0.2:10911")));
+        // Drive the first read by call order because this existing settings path does not sort brokers.
+        SubscriptionGroupConfig existing = new SubscriptionGroupConfig();
+        existing.setGroupName("orders");
+        when(admin.examineSubscriptionGroupConfig(anyString(), eq("orders")))
+                .thenReturn(existing, null);
+
+        assertThatThrownBy(() -> client.updateConsumerGroupSettings("local", "orders",
+                new ConsumerGroupSettingsCommand(2, 5, true, true, true)))
+                .isInstanceOf(BusinessException.class).hasMessage("Consumer group not found: orders");
+
+        verify(admin).createAndUpdateSubscriptionGroupConfig(anyString(), any());
+        verify(groups, never()).updateById(any(RmqGroup.class));
+        verify(audit).record(eq("UPDATE_GROUP_SETTINGS"), eq("GROUP"), eq("orders"), eq(null),
+                contains("updated 1/2"), eq("FAILED"));
+    }
+
+    @Test
+    void settingsWriteFailureIsReportedWithoutPersistingSuccessTest() throws Exception {
+        SubscriptionGroupConfig existing = new SubscriptionGroupConfig();
+        existing.setGroupName("orders");
+        when(admin.examineSubscriptionGroupConfig(BROKER, "orders")).thenReturn(existing);
+        doAnswer(invocation -> {
+            throw new RemotingTimeoutException("Broker did not confirm the update");
+        }).when(admin).createAndUpdateSubscriptionGroupConfig(eq(BROKER), any());
+
+        assertThatThrownBy(() -> client.updateConsumerGroupSettings("local", "orders",
+                new ConsumerGroupSettingsCommand(2, 5, null, null, null)))
+                .isInstanceOf(BusinessException.class).hasMessageContaining("Broker did not confirm");
+
+        verify(groups, never()).updateById(any(RmqGroup.class));
+        verify(audit).record(eq("UPDATE_GROUP_SETTINGS"), eq("GROUP"), eq("orders"), eq(null),
+                contains("updated 0/1"), eq("FAILED"));
+    }
+
+    private static ConsumerGroupVO request() {
+        ConsumerGroupVO group = new ConsumerGroupVO();
+        group.setName("orders");
+        group.setInstanceId("local");
+        group.setRetryMaxTimes(7);
+        return group;
+    }
+
+    private static ClusterInfo topology(Map<String, String> brokers) {
+        ClusterInfo info = new ClusterInfo();
+        info.setClusterAddrTable(new HashMap<>(Map.of("cluster-a", new HashSet<>(brokers.keySet()))));
+        HashMap<String, BrokerData> table = new HashMap<>();
+        brokers.forEach((name, address) -> {
+            BrokerData broker = new BrokerData();
+            broker.setBrokerName(name);
+            broker.setBrokerAddrs(new HashMap<>(Map.of(0L, address)));
+            table.put(name, broker);
+        });
+        info.setBrokerAddrTable(table);
+        return info;
+    }
+}


### PR DESCRIPTION
## 变更目的

修复重复创建或 CSV 重新导入消费组时覆盖 Broker 现有策略的问题，以及带已有属性的消费组无法正常修改设置的问题。

已有组设为 `consumeEnable=false`、`consumeMessageOrderly=true` 后，旧创建路径仍构造默认配置并覆盖所有 Broker，导致消费被恢复、顺序消费被关闭。原实现上的复现测试确认暂停标志从 false 变成 true。

## 修改内容

逐 Broker 获取现有配置，以各自配置为基础应用创建请求中的正数重试次数。请求省略重试次数时保留已有值；明确不存在时使用原有新建默认值。权限错误和超时直接传播，不当作组不存在处理。部分执行失败的审计包含已完成与总 Broker 数。

创建和配置更新发送空属性修改集合。Broker 返回 `priority.factor` 这样的存储键，而更新协议只接受带 `+`／`-` 的操作；空修改集合由 Broker 保留现有属性。测试直接使用 SDK 的 `AttributeUtil` 验证这一协议，不只校验 mock 调用。

新增 12 个测试覆盖已暂停顺序组、各 Broker 独立策略、0 次重试保留、明确缺失、权限错误、超时、部分失败、元数据和属性协议。新增中文操作与兼容说明。

## 验证

基线：`d6dee7d7ccfcf4886f02466ec51452a6928b2cc8`，Java 21。

```bash
mvn -B -ntp org.jacoco:jacoco-maven-plugin:0.8.13:prepare-agent \
  -Djacoco.destFile=target/group-recreation.exec \
  -Djacoco.dataFile=target/group-recreation.exec \
  -Dtest=ConsumerGroupRecreationTest,RocketMQAdminClientImplTest,MetadataServiceTest \
  verify org.jacoco:jacoco-maven-plugin:0.8.13:report
```

- 94 个相关测试通过，Checkstyle 和打包通过。
- JaCoCo：核心创建方法 52/52 行，新辅助方法 14/14 行，配置更新主体 50/54 行。
- `git diff --check` 通过；3 个文件，457 行新增、12 行删除，合计 469 行。
- 同一上游基线的全量后端测试为 2,110 项、3 个失败；已在原样上游检出复现 `AuthCorsIntegrationTest` 两项和 `AliyunInstanceProviderTest#getGroupProgressShouldMapLagRowsTest` 一项。本 PR 的相关验证没有新增失败。
- 未运行真实集群 E2E、压力或混沌验证。上游已有依赖漏洞未在本 PR 处理，不能宣称项目级漏洞门槛通过。

## 范围与兼容

已核对 #1013 的导入功能、#2512 的设置接口和已合并 #3991 的消费开关编辑。本 PR 修复现有创建路径的策略覆盖及属性协议，不重复添加设置功能。

协议依据：[RocketMQ 5.5.0 SubscriptionGroupManager](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/subscription/SubscriptionGroupManager.java)。读取接口在 Broker 启用自动创建时可能创建缺失组，流程不承诺只读预检或跨 Broker 原子性。已有配置被旧逻辑覆盖后，需要操作者依据原设置恢复。

无迁移，直接替换；无新增依赖、配置或数据库字段。回滚本提交即可。验证在本地执行，提交含 `[skip ci]` 以跳过 `push`／`pull_request` 自动工作流。
