### PR TITLE
feat(message): locate queue positions by timestamp

### DIFF
--- a/docs/queue-timestamp-navigation.md
+++ b/docs/queue-timestamp-navigation.md
@@ -1,0 +1,39 @@
+# 按时间定位队列消息
+
+## 适用场景
+
+已知故障发生时间和受影响 Broker／队列，但不知道消息 offset 时，可在消息页面的队列浏览中按时间定位。普通 Topic 查询有扫描与结果数量上限，高流量 Topic 中的目标消息可能不在返回的 200 条结果中；队列定位直接使用 Broker 的时间索引，不扫描消息体。
+
+## 操作步骤
+
+1. 选择 Apache 实例及 Topic，加载队列。
+2. 在 `Locate time (local)` 中选择故障时间。控件显示浏览器当地时间，请确认操作系统时区；请求发送对应的 Unix 毫秒时间戳。
+3. 点击目标队列的 `Locate`。列表刷新该队列的可读范围，并将滑块移到查询到的附近位置。
+4. 点击原有查看按钮，检查消息的实际存储时间；必要时继续调整 offset。
+
+时间索引返回的是附近位置，不承诺消息的存储时间与输入时间相等。早于保留数据的时间定位到首个可读位置；超过快照范围的结果定位到最后一个可读位置。空队列没有可查看消息，并显示提示。
+
+## 接口契约
+
+```http
+GET /api/messages/queue-position?instanceId=instance-a&topic=orders&brokerName=broker-a&queueId=2&timestamp=1788825600000
+```
+
+返回 `brokerName`、`queueId`、`minOffset`、`maxOffset` 和 `offset`。`maxOffset` 是不包含在内的上界，空队列的 `offset` 为 null。时间戳 0 是合法输入；负数队列编号、负数时间戳及缺少坐标返回 400。队列不在当前可读路由中返回 404；Broker 查询失败或返回不可用边界时返回 502，不伪报定位成功。
+
+定位复用实例绑定的 Apache 客户端与凭据，沿用实例解析器的云实例限制。整个请求只读取路由、边界与时间索引，不更新任何消费组位点，不拉取消息体。队列保留期清理仍可发生在定位与查看之间；若查看时消息已经过期，应重新定位。
+
+切换 Topic、切换实例或重新加载队列会使旧定位结果失效。一个队列的定位请求不会释放重新加载后同名队列的新请求；失败时保留原位置，允许重试。
+
+## 验证与回滚
+
+后端 `QueueTimestampLookupTest` 通过真实 HTTP 绑定、服务校验及 Provider 组合调用，在 SDK 边界模拟空队列、过期边界、时间索引失败、无路由和连接异常。前端覆盖接口参数、位置更新、查看衔接、空队列、失败重试及异步请求归属。
+
+```bash
+cd server
+mvn -B -ntp -Dtest=QueueTimestampLookupTest,RocketMQMessageProviderTest,MessageServiceTest,MessageControllerTest test
+cd ../web
+npx vitest run src/components/__tests__/QueueTimestamp.test.tsx src/components/__tests__/QueueBrowser.test.tsx src/api/message.test.ts
+```
+
+无迁移，直接替换；没有新增依赖、配置或数据库字段。回滚本提交恢复原有队列浏览入口。协议采用 [RocketMQ 5.5.0 DefaultMQPullConsumerImpl](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultMQPullConsumerImpl.java) 的 `searchOffset` 调用。

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageController.java
@@ -82,6 +82,15 @@ public class MessageController {
         return Result.ok(messageService.getQueueOffsets(instanceId, topic));
     }
 
+    @GetMapping("/queue-position")
+    public Result<QueueTimestampVO> locateQueueByTime(@RequestParam String instanceId,
+                                                      @RequestParam String topic,
+                                                      @RequestParam String brokerName,
+                                                      @RequestParam int queueId,
+                                                      @RequestParam long timestamp) {
+        return Result.ok(messageService.locateQueueByTime(instanceId, topic, brokerName, queueId, timestamp));
+    }
+
     @GetMapping("/queue-message")
     public Result<MessageRecordVO> pullMessageAtOffset(@RequestParam String instanceId,
                                                        @RequestParam String topic,

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProvider.java
@@ -34,6 +34,8 @@ public interface MessageProvider {
 
     List<QueueOffsetVO> getQueueOffsets(String instanceId, String topic);
 
+    QueueTimestampVO locateQueueByTime(String instanceId, String topic, String brokerName, int queueId, long timestamp);
+
     MessageRecordVO pullMessageAtOffset(String instanceId, String topic, String brokerName, int queueId, long offset);
 
     default DirectConsumeMessageResultVO consumeMessageDirectly(DirectConsumeMessageDTO request) {

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProviderStub.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProviderStub.java
@@ -57,4 +57,10 @@ public class MessageProviderStub implements MessageProvider {
     private BusinessException unsupported() {
         return new BusinessException(501, "Message query provider is not configured");
     }
+
+    @Override
+    public QueueTimestampVO locateQueueByTime(String instanceId, String topic, String brokerName,
+                                              int queueId, long timestamp) {
+        throw unsupported();
+    }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -104,6 +104,17 @@ public class MessageService {
         return messageProvider.getQueueOffsets(instanceId, topic);
     }
 
+    public QueueTimestampVO locateQueueByTime(String instanceId, String topic, String brokerName,
+                                               int queueId, long timestamp) {
+        if (!StringUtils.hasText(instanceId) || !StringUtils.hasText(topic) || !StringUtils.hasText(brokerName)) {
+            throw new BusinessException(400, "instanceId, topic and brokerName are required");
+        }
+        if (queueId < 0 || timestamp < 0) {
+            throw new BusinessException(400, "queueId and timestamp must not be negative");
+        }
+        return messageProvider.locateQueueByTime(instanceId, topic, brokerName, queueId, timestamp);
+    }
+
     public MessageRecordVO pullMessageAtOffset(String instanceId, String topic, String brokerName,
                                                 int queueId, long offset) {
         if (!StringUtils.hasText(topic)) {

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueueTimestampVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueueTimestampVO.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+/** A queue-bound snapshot and an approximate readable position; null offset means an empty queue. */
+public record QueueTimestampVO(String brokerName, int queueId, long minOffset, long maxOffset, Long offset) {
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -39,6 +39,7 @@ import org.apache.rocketmq.studio.instance.message.DirectConsumeMessageDTO;
 import org.apache.rocketmq.studio.instance.message.DirectConsumeMessageResultVO;
 import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
 import org.apache.rocketmq.studio.instance.message.QueueOffsetVO;
+import org.apache.rocketmq.studio.instance.message.QueueTimestampVO;
 import org.apache.rocketmq.studio.instance.message.TraceNodeVO;
 import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
@@ -226,6 +227,40 @@ public class RocketMQMessageProvider implements MessageProvider {
                 throw new BusinessException(502, "Failed to get queue offsets: " + e.getMessage());
             }
             return result;
+        });
+    }
+
+    @Override
+    public QueueTimestampVO locateQueueByTime(String instanceId, String topic, String brokerName,
+                                              int queueId, long timestamp) {
+        return runtimeAdminClientResolver.executePullConsumer(instanceId, consumer -> {
+            try {
+                MessageQueue queue = new MessageQueue(topic, brokerName, queueId);
+                Set<MessageQueue> queues = consumer.fetchSubscribeMessageQueues(topic);
+                if (queues == null || !queues.contains(queue)) {
+                    throw new BusinessException(404, "Queue is not present in the topic's readable route");
+                }
+                long minOffset = consumer.minOffset(queue);
+                long maxOffset = consumer.maxOffset(queue);
+                if (minOffset < 0 || maxOffset < minOffset) {
+                    throw new BusinessException(502, "Broker returned unavailable queue bounds");
+                }
+                if (minOffset == maxOffset) {
+                    return new QueueTimestampVO(brokerName, queueId, minOffset, maxOffset, null);
+                }
+                long searchedOffset = consumer.searchOffset(queue, timestamp);
+                if (searchedOffset < 0) {
+                    throw new BusinessException(502, "Broker could not locate a queue offset for the timestamp");
+                }
+                // Time lookup is approximate. Keep the result within the readable snapshot,
+                // including when the requested time is outside the retained message range.
+                long offset = Math.max(minOffset, Math.min(searchedOffset, maxOffset - 1));
+                return new QueueTimestampVO(brokerName, queueId, minOffset, maxOffset, offset);
+            } catch (BusinessException exception) {
+                throw exception;
+            } catch (Exception exception) {
+                throw new BusinessException(502, "Failed to locate queue by time: " + exception.getMessage());
+            }
         });
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueueTimestampLookupTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueueTimestampLookupTest.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.cluster.broker.MqClientPool;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.exception.GlobalExceptionHandler;
+import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
+import org.apache.rocketmq.studio.provider.apache.RocketMQMessageProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** Exercises HTTP binding, service validation and provider lookup together, with only the SDK boundary mocked. */
+class QueueTimestampLookupTest {
+    private final MessageQueue queue = new MessageQueue("orders", "broker-a", 2);
+    private final DefaultMQPullConsumer consumer = mock(DefaultMQPullConsumer.class);
+    private final RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() {
+        when(resolver.executePullConsumer(eq("instance-a"), any())).thenAnswer(invocation -> {
+            MqClientPool.ClientAction<DefaultMQPullConsumer, Object> action = invocation.getArgument(1);
+            return action.apply(consumer);
+        });
+        MessageService service = new MessageService(new RocketMQMessageProvider(resolver),
+                mock(InstanceProviderRegistry.class), mock(QueryHistoryService.class), mock(OperationAuditService.class));
+        mvc = MockMvcBuilders.standaloneSetup(new MessageController(service))
+                .setControllerAdvice(new GlobalExceptionHandler()).build();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"15, 15", "0, 10", "20, 19", "30, 19"})
+    void locatesWithinRetainedQueueBoundsWithoutReadingBodiesOrChangingConsumption(long brokerOffset,
+                                                                                  long expectedOffset) throws Exception {
+        readableQueue(10, 20);
+        when(consumer.searchOffset(queue, 1788825600000L)).thenReturn(brokerOffset);
+
+        mvc.perform(request()).andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.brokerName").value("broker-a"))
+                .andExpect(jsonPath("$.data.queueId").value(2))
+                .andExpect(jsonPath("$.data.minOffset").value(10))
+                .andExpect(jsonPath("$.data.maxOffset").value(20))
+                .andExpect(jsonPath("$.data.offset").value(expectedOffset));
+
+        verify(consumer).fetchSubscribeMessageQueues("orders");
+        verify(consumer).minOffset(queue);
+        verify(consumer).maxOffset(queue);
+        verify(consumer).searchOffset(queue, 1788825600000L);
+        verifyNoMoreInteractions(consumer);
+    }
+
+    @Test
+    void returnsEmptyQueueSnapshotWithoutSearching() throws Exception {
+        readableQueue(20, 20);
+        mvc.perform(request()).andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.minOffset").value(20))
+                .andExpect(jsonPath("$.data.maxOffset").value(20))
+                .andExpect(jsonPath("$.data.offset").doesNotExist());
+        verify(consumer, never()).searchOffset(any(), anyLong());
+    }
+
+    @Test
+    void acceptsEpochWithoutTreatingItAsMissing() throws Exception {
+        readableQueue(0, 1);
+        when(consumer.searchOffset(queue, 0)).thenReturn(0L);
+        mvc.perform(request("timestamp", "0"))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.data.offset").value(0));
+        verify(consumer).searchOffset(queue, 0);
+    }
+
+    @Test
+    void rejectsQueueRemovedFromReadableRoute() throws Exception {
+        when(consumer.fetchSubscribeMessageQueues("orders"))
+                .thenReturn(Set.of(new MessageQueue("orders", "broker-b", 2)));
+        mvc.perform(request()).andExpect(status().isNotFound());
+        verify(consumer, never()).minOffset(any());
+    }
+
+    @Test
+    void rejectsMissingTopicRoute() throws Exception {
+        when(consumer.fetchSubscribeMessageQueues("orders")).thenReturn(null);
+        mvc.perform(request()).andExpect(status().isNotFound());
+        verify(consumer, never()).searchOffset(any(), anyLong());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"-1, 20", "20, 10"})
+    void reportsUnavailableBoundsInsteadOfSuggestingAnOffset(long min, long max) throws Exception {
+        readableQueue(min, max);
+        mvc.perform(request()).andExpect(status().isBadGateway());
+        verify(consumer, never()).searchOffset(any(), anyLong());
+    }
+
+    @Test
+    void doesNotConvertFailedLookupIntoFirstRetainedOffset() throws Exception {
+        readableQueue(10, 20);
+        when(consumer.searchOffset(queue, 1788825600000L)).thenReturn(-1L);
+        mvc.perform(request()).andExpect(status().isBadGateway());
+    }
+
+    @Test
+    void reportsBrokerConnectionFailure() throws Exception {
+        when(consumer.fetchSubscribeMessageQueues("orders")).thenThrow(new MQClientException("Connection failed", null));
+        mvc.perform(request()).andExpect(status().isBadGateway())
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.startsWith(
+                        "Failed to locate queue by time: Connection failed")));
+    }
+
+    @Test
+    void preservesInstanceResolverRejectionBeforeContactingBroker() throws Exception {
+        when(resolver.executePullConsumer(eq("instance-a"), any()))
+                .thenThrow(new BusinessException(400, "Only Apache instances support this operation"));
+        mvc.perform(request()).andExpect(status().isBadRequest());
+        verifyNoInteractions(consumer);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"queueId, -1", "timestamp, -1", "timestamp, invalid", "instanceId, ''", "topic, ''", "brokerName, ''"})
+    void rejectsInvalidCoordinatesBeforeResolvingAnInstance(String field, String value) throws Exception {
+        mvc.perform(request(field, value)).andExpect(status().isBadRequest());
+        verifyNoInteractions(consumer);
+        verify(resolver, never()).executePullConsumer(any(), any());
+    }
+
+    private void readableQueue(long min, long max) throws Exception {
+        when(consumer.fetchSubscribeMessageQueues("orders")).thenReturn(Set.of(queue));
+        when(consumer.minOffset(queue)).thenReturn(min);
+        when(consumer.maxOffset(queue)).thenReturn(max);
+    }
+
+    private MockHttpServletRequestBuilder request() {
+        return request("timestamp", "1788825600000");
+    }
+
+    private MockHttpServletRequestBuilder request(String field, String value) {
+        var parameters = new org.springframework.util.LinkedMultiValueMap<String, String>();
+        parameters.set("instanceId", "instance-a");
+        parameters.set("topic", "orders");
+        parameters.set("brokerName", "broker-a");
+        parameters.set("queueId", "2");
+        parameters.set("timestamp", "1788825600000");
+        parameters.set(field, value);
+        return get("/api/messages/queue-position").params(parameters);
+    }
+}

--- a/web/src/api/message.test.ts
+++ b/web/src/api/message.test.ts
@@ -21,6 +21,7 @@ import client from './client';
 import {
   consumeMessageDirectly,
   getMessageTrace,
+  locateQueueByTime,
   queryMessagePage,
   queryMessages,
 } from './message';
@@ -28,6 +29,22 @@ import {
 const mock = new MockAdapter(client);
 
 describe('message API', () => {
+  it('passes queue identity and epoch milliseconds to the time lookup endpoint', async () => {
+    const params = {
+      instanceId: 'instance-a',
+      topic: 'orders',
+      brokerName: 'broker-a',
+      queueId: 2,
+      timestamp: 0,
+    };
+    const position = { brokerName: 'broker-a', queueId: 2, minOffset: 0, maxOffset: 1, offset: 0 };
+    mock.onGet('/messages/queue-position').reply((config) => {
+      expect(config.params).toEqual(params);
+      return [200, { code: 200, data: position }];
+    });
+    await expect(locateQueueByTime(params)).resolves.toEqual(position);
+  });
+
   beforeEach(() => {
     mock.reset();
     vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -269,6 +269,21 @@ export async function pullMessageAtOffset(params: {
   return res.data.data;
 }
 
+export interface QueueTimestamp extends QueueOffset {
+  offset: number | null;
+}
+
+export async function locateQueueByTime(params: {
+  instanceId: string;
+  topic: string;
+  brokerName: string;
+  queueId: number;
+  timestamp: number;
+}) {
+  const res = await client.get<{ data: QueueTimestamp }>('/messages/queue-position', { params });
+  return res.data.data;
+}
+
 export async function listDLQMessages(params: {
   instanceId: string;
   groupName: string;

--- a/web/src/components/QueueBrowser.tsx
+++ b/web/src/components/QueueBrowser.tsx
@@ -18,6 +18,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Button,
   Card,
+  DatePicker,
   Descriptions,
   Empty,
   Flex,
@@ -32,8 +33,9 @@ import {
   message,
 } from 'antd';
 import { CloseOutlined, SearchOutlined } from '@ant-design/icons';
+import dayjs from 'dayjs';
 import type { MessageRecord, QueueOffset } from '../api/message';
-import { getQueueOffsets, pullMessageAtOffset } from '../api/message';
+import { getQueueOffsets, locateQueueByTime, pullMessageAtOffset } from '../api/message';
 
 const { Text, Paragraph } = Typography;
 
@@ -61,11 +63,21 @@ export const useQueueBrowser = (instanceId?: string) => {
   const [offsets, setOffsets] = useState<Record<string, number>>({});
   const [pulling, setPulling] = useState<Set<string>>(() => new Set());
   const [entries, setEntries] = useState<PulledEntry[]>([]);
+  const [timestamp, setTimestampValue] = useState<number | null>(null);
+  const [locating, setLocating] = useState<Set<string>>(() => new Set());
+  const locateRequestsRef = useRef(new Map<string, symbol>());
   const requestSeqRef = useRef(0);
   const loadingRef = useRef(false);
   const pullingRef = useRef(new Set<string>());
 
+  const setTimestamp = (value: number | null) => {
+    setTimestampValue(value);
+    locateRequestsRef.current.clear();
+    setLocating(new Set());
+  };
+
   useEffect(() => {
+    const sequence = requestSeqRef;
     const requestId = ++requestSeqRef.current;
     void Promise.resolve().then(() => {
       if (requestId !== requestSeqRef.current) return;
@@ -76,7 +88,12 @@ export const useQueueBrowser = (instanceId?: string) => {
       setLoading(false);
       pullingRef.current.clear();
       setPulling(new Set());
+      locateRequestsRef.current.clear();
+      setLocating(new Set());
     });
+    return () => {
+      sequence.current++;
+    };
   }, [instanceId, topic]);
 
   const loadQueues = useCallback(async () => {
@@ -87,6 +104,8 @@ export const useQueueBrowser = (instanceId?: string) => {
     setQueues([]);
     setOffsets({});
     setEntries([]);
+    locateRequestsRef.current.clear();
+    setLocating(new Set());
     try {
       const result = await getQueueOffsets({ instanceId, topic });
       if (requestId !== requestSeqRef.current) return;
@@ -140,6 +159,43 @@ export const useQueueBrowser = (instanceId?: string) => {
     }
   };
 
+  const handleLocate = async (queue: QueueOffset) => {
+    if (!instanceId || !topic || timestamp === null) return;
+    const key = `${queue.brokerName}-${queue.queueId}`;
+    if (locateRequestsRef.current.has(key)) return;
+    const requestId = requestSeqRef.current;
+    const token = Symbol(key);
+    locateRequestsRef.current.set(key, token);
+    setLocating(new Set(locateRequestsRef.current.keys()));
+    try {
+      const result = await locateQueueByTime({
+        instanceId,
+        topic,
+        brokerName: queue.brokerName,
+        queueId: queue.queueId,
+        timestamp,
+      });
+      if (requestId !== requestSeqRef.current || locateRequestsRef.current.get(key) !== token)
+        return;
+      setQueues((previous) =>
+        previous.map((item) => (`${item.brokerName}-${item.queueId}` === key ? result : item)),
+      );
+      setOffsets((previous) => ({ ...previous, [key]: result.offset ?? result.minOffset }));
+      setEntries((previous) => previous.filter((entry) => entry.key !== key));
+      if (result.offset === null) message.info('This queue is empty; no message can be located.');
+    } catch (error) {
+      if (requestId === requestSeqRef.current && locateRequestsRef.current.get(key) === token) {
+        message.error(error instanceof Error ? error.message : 'Failed to locate queue by time');
+      }
+    } finally {
+      // An old request must not release a newer request for the same queue after a reload.
+      if (locateRequestsRef.current.get(key) === token) {
+        locateRequestsRef.current.delete(key);
+        setLocating(new Set(locateRequestsRef.current.keys()));
+      }
+    }
+  };
+
   const closeEntry = (key: string) => {
     setEntries((prev) => prev.filter((entry) => entry.key !== key));
   };
@@ -155,6 +211,10 @@ export const useQueueBrowser = (instanceId?: string) => {
     entries,
     loadQueues,
     handlePull,
+    timestamp,
+    setTimestamp,
+    locating,
+    handleLocate,
     closeEntry,
   };
 };
@@ -174,7 +234,7 @@ export const QueueBrowserControls = ({
   topicOptions,
   topicLoading,
 }: ControlsProps) => (
-  <Flex gap={12} align="center">
+  <Flex gap={12} align="center" wrap>
     <Select
       showSearch
       allowClear
@@ -194,6 +254,16 @@ export const QueueBrowserControls = ({
     >
       加载队列
     </Button>
+    <Tooltip title="Choose a local time, then locate an approximate offset in a queue. Use View to inspect its stored time.">
+      <DatePicker
+        showTime
+        aria-label="Queue lookup time"
+        placeholder="Locate time (local)"
+        value={state.timestamp === null ? null : dayjs(state.timestamp)}
+        onChange={(value) => state.setTimestamp(value?.valueOf() ?? null)}
+        disabled={!instanceId || !state.topic}
+      />
+    </Tooltip>
   </Flex>
 );
 
@@ -210,14 +280,15 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
         style={{ padding: '32px 0' }}
       />
     ) : (
-      <Flex gap={16} align="flex-start">
+      <Flex gap={16} align="flex-start" wrap>
         {/* 左侧：队列表格 */}
-        <div style={{ width: '50%', flexShrink: 0 }}>
+        <div style={{ flex: '1 1 550px', minWidth: 0 }}>
           <Table<QueueOffset>
             rowKey={(r) => `${r.brokerName}-${r.queueId}`}
             dataSource={state.queues}
             size="small"
             pagination={false}
+            scroll={{ x: 550 }}
             columns={[
               {
                 title: 'Broker',
@@ -275,19 +346,32 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
               {
                 title: '操作',
                 key: 'action',
-                width: 70,
+                width: 150,
                 align: 'center',
                 render: (_: unknown, record: QueueOffset) => {
                   const key = `${record.brokerName}-${record.queueId}`;
                   return (
-                    <Button
-                      size="small"
-                      type="primary"
-                      loading={state.pulling.has(key)}
-                      onClick={() => void state.handlePull(record)}
-                    >
-                      查看
-                    </Button>
+                    <Space size={4}>
+                      <Button
+                        size="small"
+                        disabled={state.timestamp === null || state.pulling.has(key)}
+                        loading={state.locating.has(key)}
+                        onClick={() => void state.handleLocate(record)}
+                        aria-label={`Locate ${record.brokerName} queue ${record.queueId} by time`}
+                      >
+                        Locate
+                      </Button>
+                      <Button
+                        size="small"
+                        type="primary"
+                        aria-label={`View ${record.brokerName} queue ${record.queueId}`}
+                        loading={state.pulling.has(key)}
+                        disabled={state.locating.has(key) || record.maxOffset <= record.minOffset}
+                        onClick={() => void state.handlePull(record)}
+                      >
+                        查看
+                      </Button>
+                    </Space>
                   );
                 },
               },
@@ -300,7 +384,7 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
         </div>
 
         {/* 右侧：消息详情（2 列，可多条并存） */}
-        <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ flex: '1 1 320px', minWidth: 0 }}>
           {state.entries.length === 0 ? (
             <Empty
               image={Empty.PRESENTED_IMAGE_SIMPLE}

--- a/web/src/components/__tests__/QueueBrowser.test.tsx
+++ b/web/src/components/__tests__/QueueBrowser.test.tsx
@@ -24,6 +24,7 @@ import { formatTimeMs, useQueueBrowser } from '../QueueBrowser';
 
 vi.mock('../../api/message', () => ({
   getQueueOffsets: vi.fn(),
+  locateQueueByTime: vi.fn(),
   pullMessageAtOffset: vi.fn(),
 }));
 

--- a/web/src/components/__tests__/QueueTimestamp.test.tsx
+++ b/web/src/components/__tests__/QueueTimestamp.test.tsx
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { message } from 'antd';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getQueueOffsets, locateQueueByTime, pullMessageAtOffset } from '../../api/message';
+import type { QueueTimestamp } from '../../api/message';
+import { QueueBrowserControls, QueueBrowserResults, useQueueBrowser } from '../QueueBrowser';
+
+vi.mock('../../api/message', () => ({
+  getQueueOffsets: vi.fn(),
+  locateQueueByTime: vi.fn(),
+  pullMessageAtOffset: vi.fn(),
+}));
+
+const queue = { brokerName: 'broker-a', queueId: 2, minOffset: 0, maxOffset: 100 };
+const position = { ...queue, minOffset: 10, maxOffset: 110, offset: 42 };
+const deferred = () => {
+  let resolve!: (value: QueueTimestamp) => void;
+  const promise = new Promise<QueueTimestamp>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+
+async function browser() {
+  const hook = renderHook(({ instanceId }) => useQueueBrowser(instanceId), {
+    initialProps: { instanceId: 'instance-a' },
+  });
+  await act(async () => hook.result.current.setTopic('orders'));
+  await act(async () => hook.result.current.loadQueues());
+  await act(async () => hook.result.current.setTimestamp(1788825600000));
+  return hook;
+}
+
+describe('queue timestamp navigation', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+    vi.mocked(getQueueOffsets).mockResolvedValue([queue]);
+    vi.mocked(locateQueueByTime).mockResolvedValue(position);
+    vi.spyOn(message, 'info').mockImplementation(() => undefined as never);
+    vi.spyOn(message, 'error').mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('updates the queue snapshot and uses the located offset on the next View', async () => {
+    const { result } = await browser();
+    await act(async () => result.current.handleLocate(queue));
+    expect(locateQueueByTime).toHaveBeenCalledWith({
+      instanceId: 'instance-a',
+      topic: 'orders',
+      brokerName: 'broker-a',
+      queueId: 2,
+      timestamp: 1788825600000,
+    });
+    expect(result.current.queues).toEqual([position]);
+    expect(result.current.offsets['broker-a-2']).toBe(42);
+    expect(pullMessageAtOffset).not.toHaveBeenCalled();
+    await act(async () => result.current.handlePull(queue));
+    expect(pullMessageAtOffset).toHaveBeenCalledWith(expect.objectContaining({ offset: 42 }));
+  });
+
+  it('reports an empty queue and removes its previous readable range', async () => {
+    vi.mocked(locateQueueByTime).mockResolvedValue({
+      ...queue,
+      minOffset: 100,
+      maxOffset: 100,
+      offset: null,
+    });
+    const { result } = await browser();
+    await act(async () => result.current.handleLocate(queue));
+    expect(result.current.offsets['broker-a-2']).toBe(100);
+    expect(message.info).toHaveBeenCalledWith('This queue is empty; no message can be located.');
+    render(<QueueBrowserResults state={result.current} />);
+    expect(screen.getByRole('button', { name: 'View broker-a queue 2' })).toBeDisabled();
+  });
+
+  it('retains the previous position on a failed lookup and permits retry', async () => {
+    vi.mocked(locateQueueByTime).mockRejectedValueOnce(new Error('Broker unavailable'));
+    const { result } = await browser();
+    await act(async () => result.current.handleLocate(queue));
+    expect(result.current.offsets['broker-a-2']).toBe(99);
+    expect(result.current.locating.size).toBe(0);
+    expect(message.error).toHaveBeenCalledWith('Broker unavailable');
+    await act(async () => result.current.handleLocate(queue));
+    expect(result.current.offsets['broker-a-2']).toBe(42);
+  });
+
+  it('discards a lookup completed after changing instances', async () => {
+    const pending = deferred();
+    vi.mocked(locateQueueByTime).mockReturnValueOnce(pending.promise);
+    const { result, rerender } = await browser();
+    act(() => {
+      void result.current.handleLocate(queue);
+    });
+    await act(async () => rerender({ instanceId: 'instance-b' }));
+    await act(async () => pending.resolve(position));
+    expect(result.current.queues).toEqual([]);
+    expect(result.current.offsets).toEqual({});
+    expect(result.current.locating.size).toBe(0);
+  });
+
+  it('ignores the previous timestamp result when the operator changes the time', async () => {
+    const pending = deferred();
+    vi.mocked(locateQueueByTime).mockReturnValueOnce(pending.promise);
+    const { result } = await browser();
+    act(() => {
+      void result.current.handleLocate(queue);
+    });
+    act(() => result.current.setTimestamp(0));
+    await act(async () => pending.resolve(position));
+    expect(result.current.offsets['broker-a-2']).toBe(99);
+    await act(async () => result.current.handleLocate(queue));
+    expect(locateQueueByTime).toHaveBeenLastCalledWith(expect.objectContaining({ timestamp: 0 }));
+    expect(result.current.offsets['broker-a-2']).toBe(42);
+  });
+
+  it('does not let an old completion release a new lookup after reloading the same queue', async () => {
+    const old = deferred();
+    const current = deferred();
+    vi.mocked(locateQueueByTime)
+      .mockReturnValueOnce(old.promise)
+      .mockReturnValueOnce(current.promise);
+    const { result } = await browser();
+    act(() => {
+      void result.current.handleLocate(queue);
+    });
+    act(() => {
+      void result.current.handleLocate(queue);
+    });
+    expect(locateQueueByTime).toHaveBeenCalledTimes(1);
+    await act(async () => result.current.loadQueues());
+    act(() => {
+      void result.current.handleLocate(queue);
+    });
+    await act(async () => old.resolve({ ...position, offset: 11 }));
+    expect(result.current.locating.has('broker-a-2')).toBe(true);
+    expect(result.current.offsets['broker-a-2']).toBe(99);
+    act(() => {
+      void result.current.handleLocate(queue);
+    });
+    expect(locateQueueByTime).toHaveBeenCalledTimes(2);
+    await act(async () => current.resolve(position));
+    expect(result.current.offsets['broker-a-2']).toBe(42);
+    expect(result.current.locating.size).toBe(0);
+  });
+
+  it('offers a labelled local-time picker and dispatches the row action', async () => {
+    const { result } = await browser();
+    render(
+      <>
+        <QueueBrowserControls instanceId="instance-a" state={result.current} topicOptions={[]} />
+        <QueueBrowserResults state={result.current} />
+      </>,
+    );
+    expect(screen.getByRole('textbox', { name: 'Queue lookup time' })).toBeEnabled();
+    await act(async () =>
+      fireEvent.click(screen.getByRole('button', { name: 'Locate broker-a queue 2 by time' })),
+    );
+    expect(locateQueueByTime).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 变更目的

在消息队列浏览中支持按故障时间定位 offset。现有页面只能拖动 offset；普通 Topic 查询受扫描预算与 200 条结果上限限制，已知故障时间时很难直接找到高流量队列中的目标消息。

选择当地时间后，点击目标队列的 `Locate`，界面刷新可读范围并移动到 Broker 时间索引给出的附近位置。继续使用原有查看操作核对消息实际存储时间。时间查找是近似定位，不承诺输入时间与消息时间完全相等。

## 实现范围

- 新增只读 `GET /api/messages/queue-position`，从 HTTP 参数绑定、服务校验到实例绑定 Apache 客户端完整接通。
- 验证当前可读路由，读取队列边界，调用 SDK `searchOffset`；结果限制在可读快照范围，空队列返回 null offset，查询失败返回明确错误。
- 前端使用当地时间选择器，将毫秒时间戳发送给接口；支持失败重试，丢弃切换实例、Topic、时间或重新加载后的旧请求结果。一个旧请求的完成不会释放新请求的锁。
- 定位只读路由与时间索引，不拉取消息体或修改消费组位点；新增按钮所在布局在宽度不足时换行。
- 新增中文操作、接口、并发与回滚说明。

已核对原功能 #2545、队列筛选 #4050、导航 #3459 和问题 #3400。后两者仅处理队列列表搜索、排序和空队列筛选，本 PR 不重复其范围。

## 本地验证

基线 `d6dee7d7ccfcf4886f02466ec51452a6928b2cc8`，Java 21、Node 24.18.0；验证日期 2026-09-08。

```bash
cd server
mvn -B -ntp -Dtest=QueueTimestampLookupTest,RocketMQMessageProviderTest,MessageServiceTest,MessageControllerTest verify
cd ../web
npx vitest run src/components/__tests__/QueueTimestamp.test.tsx src/components/__tests__/QueueBrowser.test.tsx src/api/message.test.ts src/pages/instance/__tests__/MessagePageAsyncState.test.tsx src/pages/instance/__tests__/MessagePage.test.tsx
npm run build
```

- 后端 83 个测试通过，包含 19 个新 HTTP／服务／Provider 组合测试；Checkstyle、打包通过。
- JaCoCo 0.8.13：新增生产定位逻辑（Controller、Service、Provider）26/26 行，22/22 分支覆盖。
- 前端 52 个测试通过，TypeScript、Vite 构建通过；修改文件 ESLint 0 错误，仅保留 `QueueBrowser.tsx` 原有的两个 Fast Refresh 警告。
- Playwright 使用真实本地页面和受控 API 响应验证：`2026-09-08 08:00:00` 被发送为 `1788825600000`，队列滑块更新到返回的 offset 42；1200px 窗口没有页面水平溢出。此项是浏览器交互验证，不是真实 RocketMQ 集群 E2E。
- `git diff --check` 通过；13 个文件，632 行新增、14 行删除，共 646 行。

同一原样上游基线全量后端测试存在 3 个既有失败（AuthCorsIntegrationTest 两项、AliyunInstanceProviderTest 一项），依赖扫描也存在既有漏洞。本 PR 未添加依赖且相关验证没有新增失败，不能宣称项目级全量测试或漏洞门槛通过。未执行真实集群压力、容量与混沌验证。

无迁移，直接替换；无新增配置或数据库字段。回滚本提交即可。提交含 `[skip ci]`，按本任务要求仅在本地执行验证。
