### PR TITLE
[Studio] feat: add user credential security insights

### DIFF
--- a/web/src/components/StudioUserSecurityPanel.tsx
+++ b/web/src/components/StudioUserSecurityPanel.tsx
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Alert, Flex, Progress, Space, Statistic, Tag, Typography, theme } from 'antd';
+import { CheckCircle, WarningCircle, XCircle } from '@phosphor-icons/react';
+import type { StudioUser } from '../api/studioUsers';
+import {
+  analyzeStudioUsers,
+  evaluateStudioPassword,
+  type StudioPasswordCheck,
+} from '../utils/studioUserSecurity';
+
+const { Text } = Typography;
+
+interface StudioPasswordStrengthPanelProps {
+  password?: string;
+  username?: string | null;
+  currentPassword?: string | null;
+}
+
+interface StudioUserSecurityOverviewProps {
+  users: StudioUser[];
+  total: number;
+  loading?: boolean;
+}
+
+const checkIcon = (check: StudioPasswordCheck) => {
+  if (check.passed) return <CheckCircle size={16} color="#52c41a" weight="fill" />;
+  if (check.severity === 'error') return <XCircle size={16} color="#ff4d4f" weight="fill" />;
+  return <WarningCircle size={16} color="#faad14" weight="fill" />;
+};
+
+const checkColor = (check: StudioPasswordCheck) => {
+  if (check.passed) return 'success';
+  return check.severity === 'error' ? 'error' : 'warning';
+};
+
+export const StudioPasswordStrengthPanel = ({
+  password,
+  username,
+  currentPassword,
+}: StudioPasswordStrengthPanelProps) => {
+  const { token } = theme.useToken();
+  const evaluation = evaluateStudioPassword(password, { username, currentPassword });
+  const visibleChecks = evaluation.checks.filter(
+    (check) =>
+      !check.passed ||
+      ['MIN_LENGTH', 'LONG_LENGTH', 'MIXED_CASE', 'DIGIT', 'SYMBOL'].includes(check.code),
+  );
+
+  return (
+    <div
+      data-testid="studio-password-strength"
+      style={{
+        border: `1px solid ${token.colorBorderSecondary}`,
+        background: token.colorFillQuaternary,
+        borderRadius: 8,
+        padding: 12,
+        marginTop: 8,
+      }}
+    >
+      <Flex justify="space-between" align="center" gap={12} wrap>
+        <Space size={8}>
+          <Text strong>密码强度</Text>
+          <Tag color={evaluation.color}>{evaluation.label}</Tag>
+        </Space>
+        <Text type="secondary">{evaluation.score}/100</Text>
+      </Flex>
+      <Progress
+        percent={evaluation.score}
+        showInfo={false}
+        strokeColor={evaluation.level === 'empty' ? token.colorFillSecondary : evaluation.color}
+        trailColor={token.colorFillSecondary}
+        style={{ margin: '8px 0 10px' }}
+      />
+      {evaluation.level === 'empty' ? (
+        <Text type="secondary">输入密码后显示强度检查结果。</Text>
+      ) : (
+        <Flex gap="8px 10px" wrap>
+          {visibleChecks.map((check) => (
+            <Tag
+              key={check.code}
+              color={checkColor(check)}
+              icon={checkIcon(check)}
+              style={{ display: 'inline-flex', alignItems: 'center', gap: 4, marginInlineEnd: 0 }}
+            >
+              {check.label}
+            </Tag>
+          ))}
+        </Flex>
+      )}
+      {evaluation.suggestions.length > 0 && (
+        <ul style={{ margin: '10px 0 0', paddingInlineStart: 20, color: token.colorTextSecondary }}>
+          {evaluation.suggestions.map((suggestion) => (
+            <li key={suggestion}>{suggestion}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+const statusAlertType = (statusColor: 'success' | 'warning' | 'error') =>
+  statusColor === 'success' ? 'success' : statusColor === 'error' ? 'error' : 'warning';
+
+const riskColor = (severity: string) => {
+  if (severity === 'critical') return 'error';
+  if (severity === 'warning') return 'warning';
+  return 'default';
+};
+
+export const StudioUserSecurityOverview = ({
+  users,
+  total,
+  loading = false,
+}: StudioUserSecurityOverviewProps) => {
+  const { token } = theme.useToken();
+  const summary = analyzeStudioUsers(users, total);
+  const scopeText = summary.totalMayExceedInspected
+    ? `当前页 ${summary.inspectedCount} / 总计 ${summary.totalCount}`
+    : `共 ${summary.inspectedCount} 个账号`;
+
+  return (
+    <div
+      data-testid="studio-user-security-overview"
+      style={{
+        border: `1px solid ${token.colorBorderSecondary}`,
+        borderRadius: 8,
+        padding: 16,
+        marginBottom: 16,
+        background: token.colorBgContainer,
+      }}
+    >
+      <Flex justify="space-between" align="flex-start" gap={16} wrap>
+        <div style={{ minWidth: 220 }}>
+          <Space size={8} wrap>
+            <Text strong>当前页账号安全摘要</Text>
+            <Tag color={summary.statusColor}>{summary.statusText}</Tag>
+            <Text type="secondary">{scopeText}</Text>
+          </Space>
+          <Progress
+            percent={summary.score}
+            size="small"
+            status={summary.status === 'critical' ? 'exception' : 'normal'}
+            strokeColor={
+              summary.status === 'healthy'
+                ? token.colorSuccess
+                : summary.status === 'warning'
+                  ? token.colorWarning
+                  : token.colorError
+            }
+            style={{ maxWidth: 360, marginTop: 10 }}
+          />
+        </div>
+        <Flex gap={20} wrap>
+          <Statistic title="启用账号" value={summary.enabledCount} loading={loading} />
+          <Statistic title="管理员" value={summary.adminCount} loading={loading} />
+          <Statistic title="可用管理员" value={summary.activeAdminCount} loading={loading} />
+          <Statistic title="密码需轮换" value={summary.stalePasswordCount} loading={loading} />
+          <Statistic
+            title="改密时间未知"
+            value={summary.unknownPasswordAgeCount}
+            loading={loading}
+          />
+        </Flex>
+      </Flex>
+      <Alert
+        showIcon
+        type={statusAlertType(summary.statusColor)}
+        message={
+          summary.risks.length === 0
+            ? '当前页未发现账号安全风险'
+            : summary.risks.map((risk) => risk.title).join('；')
+        }
+        description={
+          summary.risks.length === 0 ? (
+            summary.recommendations[0]
+          ) : (
+            <Space direction="vertical" size={6} style={{ width: '100%' }}>
+              {summary.risks.slice(0, 4).map((risk) => (
+                <Flex key={risk.code} gap={8} wrap>
+                  <Tag color={riskColor(risk.severity)} style={{ marginInlineEnd: 0 }}>
+                    {risk.count}
+                  </Tag>
+                  <Text>{risk.description}</Text>
+                  {risk.users.length > 0 && (
+                    <Text type="secondary">涉及账号：{risk.users.join(', ')}</Text>
+                  )}
+                </Flex>
+              ))}
+            </Space>
+          )
+        }
+        style={{ marginTop: 12 }}
+      />
+    </div>
+  );
+};

--- a/web/src/pages/studio/UserManagement.tsx
+++ b/web/src/pages/studio/UserManagement.tsx
@@ -45,6 +45,12 @@ import {
 } from '../../api/studioUsers';
 import useAuthStore from '../../stores/authStore';
 import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
+import {
+  StudioPasswordStrengthPanel,
+  StudioUserSecurityOverview,
+} from '../../components/StudioUserSecurityPanel';
+import { getStudioUserPasswordRotation } from '../../utils/studioUserSecurity';
+import { tableScrollX } from '../../utils/table';
 
 interface CreateFormValues {
   username: string;
@@ -75,6 +81,7 @@ const STUDIO_USER_EXPORT_COLUMNS: CsvColumn<StudioUser>[] = [
 const UserManagementPage = () => {
   const navigate = useNavigate();
   const admin = useAuthStore((state) => state.admin);
+  const userName = useAuthStore((state) => state.user);
   const userId = useAuthStore((state) => state.userId);
   const clearAuth = useAuthStore((state) => state.logout);
   const [users, setUsers] = useState<StudioUser[]>([]);
@@ -92,6 +99,10 @@ const UserManagementPage = () => {
   const [mutatingUserIds, setMutatingUserIds] = useState<Set<number>>(() => new Set());
   const [createForm] = Form.useForm<CreateFormValues>();
   const [passwordForm] = Form.useForm<PasswordFormValues>();
+  const createUsername = Form.useWatch('username', createForm);
+  const createPassword = Form.useWatch('password', createForm);
+  const currentPassword = Form.useWatch('currentPassword', passwordForm);
+  const newPassword = Form.useWatch('newPassword', passwordForm);
   const requestSeqRef = useRef(0);
   const mutatingUserIdsRef = useRef(new Set<number>());
 
@@ -200,6 +211,14 @@ const UserManagementPage = () => {
     }
   };
   const openCreateUserModal = () => setCreateOpen(true);
+  const closeCreateUserModal = () => {
+    setCreateOpen(false);
+    createForm.resetFields();
+  };
+  const closePasswordModal = () => {
+    setPasswordTarget(null);
+    passwordForm.resetFields();
+  };
   const handleExportUsers = useCallback(async () => {
     if (!admin) return;
     setUserExporting(true);
@@ -220,24 +239,48 @@ const UserManagementPage = () => {
     }
     setUserExporting(false);
   }, [admin, roleFilter, search, statusFilter]);
+
+  const renderPasswordRotationStatus = (record: StudioUser) => {
+    const rotation = getStudioUserPasswordRotation(record);
+    const suffix = rotation.daysSinceChange === null ? '' : `（${rotation.daysSinceChange} 天前）`;
+    return (
+      <Space direction="vertical" size={0}>
+        <Tag color={rotation.color} style={{ marginInlineEnd: 0 }}>
+          {rotation.label}
+        </Tag>
+        <span style={{ color: '#8c8c8c', fontSize: 12 }}>{suffix || '缺少改密时间'}</span>
+      </Space>
+    );
+  };
+
   const columns: ColumnsType<StudioUser> = [
-    { title: '用户名', dataIndex: 'username' },
+    { title: '用户名', dataIndex: 'username', width: 180 },
     { title: '用户 ID', dataIndex: 'id', width: 100 },
     {
       title: '权限',
       dataIndex: 'admin',
+      width: 120,
       render: (value: boolean) => (value ? <Tag color="blue">管理员</Tag> : <Tag>普通用户</Tag>),
     },
     {
       title: '状态',
       dataIndex: 'enabled',
+      width: 120,
       render: (value: boolean) =>
         value ? <Tag color="green">已启用</Tag> : <Tag color="default">已禁用</Tag>,
     },
-    { title: '创建时间', dataIndex: 'gmtCreate', render: dateTime },
+    {
+      title: '密码状态',
+      dataIndex: 'passwordChangedAt',
+      width: 150,
+      render: (_: string, record) => renderPasswordRotationStatus(record),
+    },
+    { title: '改密时间', dataIndex: 'passwordChangedAt', width: 190, render: dateTime },
+    { title: '创建时间', dataIndex: 'gmtCreate', width: 190, render: dateTime },
     {
       title: '操作',
       key: 'actions',
+      width: 180,
       render: (_, record) => (
         <Space>
           <Button size="small" icon={<Key size={14} />} onClick={() => setPasswordTarget(record)}>
@@ -291,7 +334,7 @@ const UserManagementPage = () => {
           onClick={() =>
             setPasswordTarget({
               id: userId ?? 0,
-              username: '',
+              username: userName ?? '',
               admin: !!admin,
               enabled: true,
               passwordChangedAt: '',
@@ -305,6 +348,7 @@ const UserManagementPage = () => {
       </Card>
       {admin && (
         <Card>
+          <StudioUserSecurityOverview users={users} total={total} loading={loading} />
           <Flex gap={12} wrap style={{ marginBottom: 16 }}>
             <Input.Search
               allowClear
@@ -368,6 +412,7 @@ const UserManagementPage = () => {
                 }
               },
             }}
+            scroll={{ x: tableScrollX(columns) }}
           />
         </Card>
       )}
@@ -376,7 +421,7 @@ const UserManagementPage = () => {
         title="新建 Studio 用户"
         open={createOpen}
         onOk={() => void createUser()}
-        onCancel={() => setCreateOpen(false)}
+        onCancel={closeCreateUserModal}
       >
         <Form form={createForm} layout="vertical" initialValues={{ admin: false }}>
           <Form.Item name="username" label="用户名" rules={[{ required: true }, { max: 128 }]}>
@@ -389,6 +434,10 @@ const UserManagementPage = () => {
           >
             <Input.Password autoComplete="new-password" />
           </Form.Item>
+          <StudioPasswordStrengthPanel
+            username={typeof createUsername === 'string' ? createUsername : ''}
+            password={typeof createPassword === 'string' ? createPassword : ''}
+          />
           <Form.Item name="admin" label="管理员权限" valuePropName="checked">
             <Switch checkedChildren="管理员" unCheckedChildren="普通用户" />
           </Form.Item>
@@ -403,10 +452,7 @@ const UserManagementPage = () => {
         }
         open={passwordTarget !== null}
         onOk={() => void updatePassword()}
-        onCancel={() => {
-          setPasswordTarget(null);
-          passwordForm.resetFields();
-        }}
+        onCancel={closePasswordModal}
       >
         <Form form={passwordForm} layout="vertical">
           {passwordTarget?.id === userId && (
@@ -421,6 +467,11 @@ const UserManagementPage = () => {
           >
             <Input.Password autoComplete="new-password" />
           </Form.Item>
+          <StudioPasswordStrengthPanel
+            username={passwordTarget?.username}
+            currentPassword={typeof currentPassword === 'string' ? currentPassword : ''}
+            password={typeof newPassword === 'string' ? newPassword : ''}
+          />
         </Form>
       </Modal>
     </div>

--- a/web/src/pages/studio/__tests__/UserManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/UserManagement.test.tsx
@@ -21,6 +21,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent, { type UserEvent } from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import {
+  createStudioUser,
   listAllStudioUsers as downloadStudioUsers,
   listStudioUsers,
   setStudioUserEnabled,
@@ -29,7 +30,7 @@ import {
 import { downloadCsv } from '../../../utils/download';
 import UserManagementPage from '../UserManagement';
 
-type MockAuthState = { admin: boolean; userId: number; logout: () => void };
+type MockAuthState = { admin: boolean; user: string; userId: number; logout: () => void };
 vi.mock('../../../api/studioUsers', () => ({
   createStudioUser: vi.fn(),
   listAllStudioUsers: vi.fn(),
@@ -40,7 +41,7 @@ vi.mock('../../../api/studioUsers', () => ({
 
 vi.mock('../../../stores/authStore', () => ({
   default: (selector: (state: MockAuthState) => unknown) =>
-    selector({ admin: true, userId: 1, logout: vi.fn() }),
+    selector({ admin: true, user: 'admin', userId: 1, logout: vi.fn() }),
 }));
 
 vi.mock('../../../utils/download', async () => {
@@ -124,6 +125,45 @@ describe('UserManagementPage', () => {
       pageSize: 20,
     });
     expect(screen.getByText('共 21 个用户')).toBeInTheDocument();
+    expect(screen.getByText('当前页账号安全摘要')).toBeInTheDocument();
+    expect(screen.getAllByText('密码状态').length).toBeGreaterThan(0);
+    expect(screen.getByText('正常')).toBeInTheDocument();
+  });
+
+  it('renders account security risks from the visible user page', async () => {
+    vi.mocked(listStudioUsers).mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          username: 'root-admin',
+          admin: true,
+          enabled: true,
+          passwordChangedAt: '2025-01-01T00:00:00Z',
+          gmtCreate: '2025-01-01T00:00:00Z',
+          gmtModified: '2025-01-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          username: 'disabled-admin',
+          admin: true,
+          enabled: false,
+          passwordChangedAt: '',
+          gmtCreate: '2026-01-01T00:00:00Z',
+          gmtModified: '2026-01-01T00:00:00Z',
+        },
+      ],
+      total: 2,
+      page: 1,
+      size: 20,
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('root-admin')).toBeInTheDocument();
+    expect(screen.getByText('账号安全存在高风险')).toBeInTheDocument();
+    expect(screen.getByText(/管理员密码长期未轮换/)).toBeInTheDocument();
+    expect(screen.getByText('需轮换')).toBeInTheDocument();
+    expect(screen.getByText('未知')).toBeInTheDocument();
   });
 
   it('debounces username search and sends role and status filters', async () => {
@@ -158,6 +198,29 @@ describe('UserManagementPage', () => {
     expect(exportedCsv).toContain('"operator"');
     expect(exportedCsv).toContain('"User"');
     expect(exportedCsv).toContain('"Enabled"');
+  });
+
+  it('shows password strength guidance while creating a user', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    vi.mocked(createStudioUser).mockResolvedValue({
+      id: 10,
+      username: 'operator',
+      admin: false,
+      enabled: true,
+      passwordChangedAt: '2026-09-01T00:00:00',
+      gmtCreate: '2026-09-01T00:00:00',
+      gmtModified: '2026-09-01T00:00:00',
+    });
+    renderPage();
+    await screen.findByText('operator');
+
+    await user.click(screen.getByRole('button', { name: '新建用户' }));
+    expect(screen.getByTestId('studio-password-strength')).toHaveTextContent('待输入');
+    await user.type(screen.getByLabelText('用户名'), 'operator');
+    await user.type(screen.getByLabelText('初始密码'), 'operator123');
+
+    expect(screen.getByTestId('studio-password-strength')).toHaveTextContent('弱');
+    expect(screen.getByText('不包含用户名')).toBeInTheDocument();
   });
 
   it('does not overlap status updates for the same user', async () => {

--- a/web/src/utils/studioUserSecurity.test.ts
+++ b/web/src/utils/studioUserSecurity.test.ts
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { StudioUser } from '../api/studioUsers';
+import {
+  analyzeStudioUsers,
+  evaluateStudioPassword,
+  getStudioUserPasswordRotation,
+} from './studioUserSecurity';
+
+const now = new Date('2026-09-07T00:00:00Z');
+
+const user = (overrides: Partial<StudioUser>): StudioUser => ({
+  id: 1,
+  username: 'operator',
+  admin: false,
+  enabled: true,
+  passwordChangedAt: '2026-08-01T00:00:00Z',
+  gmtCreate: '2026-08-01T00:00:00Z',
+  gmtModified: '2026-08-01T00:00:00Z',
+  ...overrides,
+});
+
+const failedCodes = (password: string, context = {}) =>
+  evaluateStudioPassword(password, context).failedChecks.map((check) => check.code);
+
+describe('studio user password evaluation', () => {
+  it('scores a long mixed password as strong', () => {
+    const result = evaluateStudioPassword('Ops#2026-ClusterSafe', { username: 'operator' });
+
+    expect(result.level).toBe('strong');
+    expect(result.score).toBeGreaterThanOrEqual(75);
+    expect(result.failedChecks.map((check) => check.code)).not.toEqual(
+      expect.arrayContaining(['MIN_LENGTH', 'NO_COMMON_WORD', 'NO_USERNAME']),
+    );
+  });
+
+  it('flags common short passwords', () => {
+    const result = evaluateStudioPassword('admin123');
+
+    expect(result.level).toBe('weak');
+    expect(result.failedChecks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'LONG_LENGTH' }),
+        expect.objectContaining({ code: 'MIXED_CASE' }),
+        expect.objectContaining({ code: 'SYMBOL' }),
+        expect.objectContaining({ code: 'NO_COMMON_WORD' }),
+        expect.objectContaining({ code: 'NO_SEQUENCE' }),
+      ]),
+    );
+    expect(result.suggestions.length).toBeGreaterThan(0);
+  });
+
+  it('detects username reuse and current password reuse', () => {
+    expect(
+      failedCodes('operator#2026A', {
+        username: 'operator',
+        currentPassword: 'operator#2026A',
+      }),
+    ).toEqual(expect.arrayContaining(['NO_USERNAME', 'NOT_CURRENT_PASSWORD']));
+  });
+
+  it('detects repeated characters', () => {
+    expect(failedCodes('AAAbbb2026!')).toContain('NO_REPEATED_CHARS');
+  });
+});
+
+describe('studio user password rotation', () => {
+  it('marks recent password changes as fresh', () => {
+    expect(
+      getStudioUserPasswordRotation(user({ passwordChangedAt: '2026-08-01T00:00:00Z' }), now),
+    ).toMatchObject({
+      status: 'fresh',
+      label: '正常',
+      daysSinceChange: 37,
+    });
+  });
+
+  it('marks old password changes as stale', () => {
+    expect(
+      getStudioUserPasswordRotation(user({ passwordChangedAt: '2025-12-01T00:00:00Z' }), now),
+    ).toMatchObject({
+      status: 'stale',
+      label: '需轮换',
+    });
+  });
+
+  it('marks invalid password change timestamps as unknown', () => {
+    expect(getStudioUserPasswordRotation(user({ passwordChangedAt: '' }), now)).toMatchObject({
+      status: 'unknown',
+      label: '未知',
+      daysSinceChange: null,
+    });
+  });
+});
+
+describe('studio user security summary', () => {
+  it('keeps a small recent account set healthy', () => {
+    const summary = analyzeStudioUsers(
+      [
+        user({ id: 1, username: 'admin-a', admin: true }),
+        user({ id: 2, username: 'admin-b', admin: true }),
+        user({ id: 3, username: 'reader-a' }),
+      ],
+      3,
+      now,
+    );
+
+    expect(summary.status).toBe('healthy');
+    expect(summary.risks).toEqual([]);
+  });
+
+  it('reports stale admin passwords as critical', () => {
+    const summary = analyzeStudioUsers(
+      [
+        user({
+          id: 1,
+          username: 'root-admin',
+          admin: true,
+          passwordChangedAt: '2025-12-01T00:00:00Z',
+        }),
+        user({ id: 2, username: 'operator-a' }),
+      ],
+      2,
+      now,
+    );
+
+    expect(summary.status).toBe('critical');
+    expect(summary.stalePasswordCount).toBe(1);
+    expect(summary.staleAdminPasswordCount).toBe(1);
+    expect(summary.risks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'STALE_ADMIN_PASSWORD', severity: 'critical' }),
+        expect.objectContaining({ code: 'ONLY_ONE_ACTIVE_ADMIN', severity: 'warning' }),
+      ]),
+    );
+  });
+
+  it('reports unknown password ages', () => {
+    const summary = analyzeStudioUsers(
+      [
+        user({
+          id: 1,
+          username: 'disabled-admin',
+          admin: true,
+          enabled: false,
+          passwordChangedAt: '',
+        }),
+        user({ id: 2, username: 'operator-a', passwordChangedAt: 'not-a-date' }),
+      ],
+      10,
+      now,
+    );
+
+    expect(summary.status).toBe('warning');
+    expect(summary.totalMayExceedInspected).toBe(true);
+    expect(summary.unknownPasswordAgeCount).toBe(2);
+    expect(summary.risks.map((risk) => risk.code)).toContain('UNKNOWN_PASSWORD_AGE');
+  });
+});

--- a/web/src/utils/studioUserSecurity.ts
+++ b/web/src/utils/studioUserSecurity.ts
@@ -1,0 +1,486 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { StudioUser } from '../api/studioUsers';
+
+export type StudioPasswordLevel = 'empty' | 'weak' | 'fair' | 'strong';
+export type StudioPasswordCheckSeverity = 'success' | 'warning' | 'error';
+
+export type StudioPasswordCheckCode =
+  | 'MIN_LENGTH'
+  | 'LONG_LENGTH'
+  | 'MIXED_CASE'
+  | 'DIGIT'
+  | 'SYMBOL'
+  | 'NO_COMMON_WORD'
+  | 'NO_SEQUENCE'
+  | 'NO_REPEATED_CHARS'
+  | 'NO_USERNAME'
+  | 'NOT_CURRENT_PASSWORD';
+
+export interface StudioPasswordCheck {
+  code: StudioPasswordCheckCode;
+  label: string;
+  passed: boolean;
+  severity: StudioPasswordCheckSeverity;
+  detail: string;
+}
+
+export interface StudioPasswordEvaluationContext {
+  username?: string | null;
+  currentPassword?: string | null;
+}
+
+export interface StudioPasswordEvaluation {
+  score: number;
+  level: StudioPasswordLevel;
+  label: string;
+  color: string;
+  checks: StudioPasswordCheck[];
+  failedChecks: StudioPasswordCheck[];
+  suggestions: string[];
+}
+
+export type StudioUserSecurityStatus = 'healthy' | 'warning' | 'critical';
+export type StudioUserSecurityRiskSeverity = Exclude<StudioUserSecurityStatus, 'healthy'> | 'info';
+
+export type StudioUserSecurityRiskCode =
+  | 'NO_VISIBLE_USERS'
+  | 'STALE_PASSWORD'
+  | 'UNKNOWN_PASSWORD_AGE'
+  | 'STALE_ADMIN_PASSWORD'
+  | 'ONLY_ONE_ACTIVE_ADMIN';
+
+export interface StudioUserSecurityRisk {
+  code: StudioUserSecurityRiskCode;
+  severity: StudioUserSecurityRiskSeverity;
+  title: string;
+  description: string;
+  count: number;
+  users: string[];
+  recommendation: string;
+}
+
+export type StudioUserPasswordRotationStatus = 'fresh' | 'stale' | 'unknown';
+
+export interface StudioUserPasswordRotation {
+  status: StudioUserPasswordRotationStatus;
+  label: string;
+  color: string;
+  daysSinceChange: number | null;
+}
+
+export interface StudioUserSecuritySummary {
+  status: StudioUserSecurityStatus;
+  statusText: string;
+  statusColor: 'success' | 'warning' | 'error';
+  score: number;
+  inspectedCount: number;
+  totalCount: number;
+  totalMayExceedInspected: boolean;
+  adminCount: number;
+  activeAdminCount: number;
+  enabledCount: number;
+  disabledCount: number;
+  stalePasswordCount: number;
+  staleAdminPasswordCount: number;
+  unknownPasswordAgeCount: number;
+  risks: StudioUserSecurityRisk[];
+  recommendations: string[];
+}
+
+const MIN_PASSWORD_LENGTH = 8;
+const STRONG_PASSWORD_LENGTH = 12;
+const PASSWORD_ROTATION_DAYS = 180;
+const PASSWORD_ROTATION_MS = PASSWORD_ROTATION_DAYS * 24 * 60 * 60 * 1000;
+const LISTED_USER_LIMIT = 5;
+const COMMON_PASSWORD_PARTS = [
+  'password',
+  'admin',
+  'root',
+  'rocketmq',
+  'welcome',
+  'qwerty',
+  'letmein',
+  'test123',
+  'abc123',
+  '123456',
+  '111111',
+  '000000',
+];
+const SEQUENCE_ALPHABETS = ['abcdefghijklmnopqrstuvwxyz', '0123456789', 'qwertyuiop', 'asdfghjkl'];
+
+const clampScore = (value: number) => Math.max(0, Math.min(100, Math.round(value)));
+
+const normalizeText = (value?: string | null) => (value ?? '').trim();
+
+const normalizePassword = (value?: string | null) => value ?? '';
+
+const includesUsername = (password: string, username?: string | null) => {
+  const normalizedUsername = normalizeText(username).toLowerCase();
+  return normalizedUsername.length >= 3 && password.toLowerCase().includes(normalizedUsername);
+};
+
+const hasCommonPasswordPart = (password: string) => {
+  const normalized = password.toLowerCase();
+  return COMMON_PASSWORD_PARTS.some((part) => normalized.includes(part));
+};
+
+const hasRepeatedRun = (password: string) => /(.)\1{2,}/.test(password);
+
+const reverseText = (value: string) => value.split('').reverse().join('');
+
+const hasSequence = (password: string) => {
+  const normalized = password.toLowerCase();
+  if (normalized.length < 4) return false;
+
+  for (let size = 4; size >= 3; size -= 1) {
+    for (let index = 0; index <= normalized.length - size; index += 1) {
+      const token = normalized.slice(index, index + size);
+      if (
+        SEQUENCE_ALPHABETS.some(
+          (alphabet) => alphabet.includes(token) || reverseText(alphabet).includes(token),
+        )
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+const characterClassCount = (password: string) =>
+  [
+    /[a-z]/.test(password),
+    /[A-Z]/.test(password),
+    /\d/.test(password),
+    /[^A-Za-z0-9]/.test(password),
+  ].filter(Boolean).length;
+
+const uniqueCharacterCount = (password: string) => new Set(password.split('')).size;
+
+const check = (
+  code: StudioPasswordCheckCode,
+  label: string,
+  passed: boolean,
+  severity: StudioPasswordCheckSeverity,
+  detail: string,
+): StudioPasswordCheck => ({ code, label, passed, severity, detail });
+
+const passwordLevel = (password: string, score: number): StudioPasswordLevel => {
+  if (!password) return 'empty';
+  if (score >= 75) return 'strong';
+  if (score >= 50) return 'fair';
+  return 'weak';
+};
+
+const passwordLevelMeta: Record<StudioPasswordLevel, { label: string; color: string }> = {
+  empty: { label: '待输入', color: 'default' },
+  weak: { label: '弱', color: '#ff4d4f' },
+  fair: { label: '中等', color: '#faad14' },
+  strong: { label: '强', color: '#52c41a' },
+};
+
+export function evaluateStudioPassword(
+  passwordValue: string | undefined,
+  context: StudioPasswordEvaluationContext = {},
+): StudioPasswordEvaluation {
+  const password = normalizePassword(passwordValue);
+  const classCount = characterClassCount(password);
+  const longEnough = password.length >= STRONG_PASSWORD_LENGTH;
+  const hasDigit = /\d/.test(password);
+  const hasSymbol = /[^A-Za-z0-9]/.test(password);
+  const hasMixedCase = /[a-z]/.test(password) && /[A-Z]/.test(password);
+  const repeatedRun = hasRepeatedRun(password);
+  const sequence = hasSequence(password);
+  const commonPart = password.length > 0 && hasCommonPasswordPart(password);
+  const usernameIncluded = password.length > 0 && includesUsername(password, context.username);
+  const currentPassword = normalizePassword(context.currentPassword);
+  const sameAsCurrent = Boolean(currentPassword) && password === currentPassword;
+
+  let score = 0;
+  if (password.length >= MIN_PASSWORD_LENGTH) score += 24;
+  if (password.length >= STRONG_PASSWORD_LENGTH) score += 16;
+  if (password.length >= 16) score += 8;
+  score += classCount * 10;
+  if (uniqueCharacterCount(password) >= 8) score += 8;
+  if (uniqueCharacterCount(password) >= 12) score += 4;
+  if (longEnough && classCount >= 3) score += 10;
+
+  if (password.length > 0 && password.length < MIN_PASSWORD_LENGTH) score -= 18;
+  if (commonPart) score -= 24;
+  if (sequence) score -= 14;
+  if (repeatedRun) score -= 14;
+  if (usernameIncluded) score -= 18;
+  if (sameAsCurrent) score -= 24;
+
+  const normalizedScore = password ? clampScore(score) : 0;
+  const checks: StudioPasswordCheck[] = [
+    check(
+      'MIN_LENGTH',
+      '至少 8 位',
+      password.length >= MIN_PASSWORD_LENGTH,
+      'error',
+      '当前前端和服务端基础规则均要求密码不少于 8 位。',
+    ),
+    check(
+      'LONG_LENGTH',
+      '建议 12 位以上',
+      longEnough,
+      'warning',
+      '更长的密码能显著降低被穷举的风险。',
+    ),
+    check('MIXED_CASE', '包含大小写字母', hasMixedCase, 'warning', '避免只使用单一字母形式。'),
+    check('DIGIT', '包含数字', hasDigit, 'warning', '混合数字能增加密码组合空间。'),
+    check('SYMBOL', '包含符号', hasSymbol, 'warning', '符号可减少常见词典命中概率。'),
+    check(
+      'NO_COMMON_WORD',
+      '避开常见弱口令',
+      !commonPart,
+      'error',
+      '不要包含 admin、password、rocketmq、123456 等常见片段。',
+    ),
+    check('NO_SEQUENCE', '避开连续序列', !sequence, 'warning', '连续键盘或数字序列容易被猜测。'),
+    check(
+      'NO_REPEATED_CHARS',
+      '避开重复字符',
+      !repeatedRun,
+      'warning',
+      '连续重复字符会降低密码强度。',
+    ),
+    check(
+      'NO_USERNAME',
+      '不包含用户名',
+      !usernameIncluded,
+      'error',
+      '密码不应直接包含账号名或账号名前缀。',
+    ),
+    check(
+      'NOT_CURRENT_PASSWORD',
+      '不同于当前密码',
+      !sameAsCurrent,
+      'error',
+      '修改自己的密码时，新密码不能和当前密码完全一致。',
+    ),
+  ];
+  const failedChecks = checks.filter((item) => !item.passed);
+  const level = passwordLevel(password, normalizedScore);
+  const levelMeta = passwordLevelMeta[level];
+
+  return {
+    score: normalizedScore,
+    level,
+    label: levelMeta.label,
+    color: levelMeta.color,
+    checks,
+    failedChecks,
+    suggestions: failedChecks.slice(0, 4).map((item) => item.detail),
+  };
+}
+
+const parseTimestamp = (value?: string | null) => {
+  const normalized = normalizeText(value);
+  if (!normalized) return null;
+  const timestamp = Date.parse(normalized);
+  return Number.isFinite(timestamp) ? timestamp : null;
+};
+
+const userNames = (users: StudioUser[]) =>
+  users
+    .map((user) => user.username || `#${user.id}`)
+    .slice(0, LISTED_USER_LIMIT)
+    .sort((left, right) => left.localeCompare(right));
+
+const risk = (
+  code: StudioUserSecurityRiskCode,
+  severity: StudioUserSecurityRiskSeverity,
+  title: string,
+  description: string,
+  users: StudioUser[],
+  recommendation: string,
+): StudioUserSecurityRisk => ({
+  code,
+  severity,
+  title,
+  description,
+  count: users.length,
+  users: userNames(users),
+  recommendation,
+});
+
+export function getStudioUserPasswordRotation(
+  user: StudioUser,
+  now: Date = new Date(),
+): StudioUserPasswordRotation {
+  const changedAt = parseTimestamp(user.passwordChangedAt);
+  if (changedAt === null) {
+    return {
+      status: 'unknown',
+      label: '未知',
+      color: 'default',
+      daysSinceChange: null,
+    };
+  }
+
+  const ageMs = Math.max(0, now.getTime() - changedAt);
+  const daysSinceChange = Math.floor(ageMs / (24 * 60 * 60 * 1000));
+  if (ageMs > PASSWORD_ROTATION_MS) {
+    return {
+      status: 'stale',
+      label: '需轮换',
+      color: 'warning',
+      daysSinceChange,
+    };
+  }
+
+  return {
+    status: 'fresh',
+    label: '正常',
+    color: 'success',
+    daysSinceChange,
+  };
+}
+
+const statusMeta: Record<
+  StudioUserSecurityStatus,
+  { text: string; color: 'success' | 'warning' | 'error' }
+> = {
+  healthy: { text: '账号安全状态正常', color: 'success' },
+  warning: { text: '账号安全需要关注', color: 'warning' },
+  critical: { text: '账号安全存在高风险', color: 'error' },
+};
+
+export function analyzeStudioUsers(
+  users: StudioUser[],
+  totalCount = users.length,
+  now: Date = new Date(),
+): StudioUserSecuritySummary {
+  const inspectedCount = users.length;
+  const enabledUsers = users.filter((user) => user.enabled);
+  const disabledUsers = users.filter((user) => !user.enabled);
+  const adminUsers = users.filter((user) => user.admin);
+  const activeAdmins = adminUsers.filter((user) => user.enabled);
+  const stalePasswordUsers = users.filter(
+    (user) => getStudioUserPasswordRotation(user, now).status === 'stale',
+  );
+  const staleAdminPasswordUsers = stalePasswordUsers.filter((user) => user.admin && user.enabled);
+  const unknownPasswordAgeUsers = users.filter(
+    (user) => getStudioUserPasswordRotation(user, now).status === 'unknown',
+  );
+  const risks: StudioUserSecurityRisk[] = [];
+
+  if (inspectedCount === 0) {
+    risks.push(
+      risk(
+        'NO_VISIBLE_USERS',
+        'info',
+        '当前筛选条件下没有账号',
+        '用户列表为空，无法从当前页面评估账号状态。',
+        [],
+        '清除筛选条件或刷新列表后再检查账号安全状态。',
+      ),
+    );
+  }
+
+  if (stalePasswordUsers.length > 0) {
+    risks.push(
+      risk(
+        'STALE_PASSWORD',
+        'warning',
+        '存在长期未轮换密码',
+        `密码超过 ${PASSWORD_ROTATION_DAYS} 天未变更的账号需要安排轮换。`,
+        stalePasswordUsers,
+        '优先联系账号负责人完成密码轮换，或由管理员重置密码。',
+      ),
+    );
+  }
+
+  if (staleAdminPasswordUsers.length > 0) {
+    risks.push(
+      risk(
+        'STALE_ADMIN_PASSWORD',
+        'critical',
+        '管理员密码长期未轮换',
+        '具备管理员权限的账号长期未改密会扩大控制台误操作和凭据泄露风险。',
+        staleAdminPasswordUsers,
+        '先处理管理员账号，完成轮换后再复查普通账号。',
+      ),
+    );
+  }
+
+  if (unknownPasswordAgeUsers.length > 0) {
+    risks.push(
+      risk(
+        'UNKNOWN_PASSWORD_AGE',
+        'warning',
+        '部分账号缺少改密时间',
+        '这些账号无法判断密码轮换周期，通常来自旧数据或后端未返回改密字段。',
+        unknownPasswordAgeUsers,
+        '补齐 passwordChangedAt 数据，或在下次登录后触发一次改密。',
+      ),
+    );
+  }
+
+  if (inspectedCount > 1 && activeAdmins.length === 1) {
+    risks.push(
+      risk(
+        'ONLY_ONE_ACTIVE_ADMIN',
+        'warning',
+        '仅有一个可用管理员',
+        '当前页只看到一个启用的管理员账号，管理员失效时可能影响控制台维护。',
+        activeAdmins,
+        '确认完整账号列表中至少有两个可用管理员，避免单点账号风险。',
+      ),
+    );
+  }
+
+  const criticalRisks = risks.filter((item) => item.severity === 'critical').length;
+  const warningRisks = risks.filter((item) => item.severity === 'warning').length;
+  const score = clampScore(
+    100 -
+      staleAdminPasswordUsers.length * 18 -
+      stalePasswordUsers.length * 10 -
+      unknownPasswordAgeUsers.length * 8 -
+      warningRisks * 6 -
+      criticalRisks * 12,
+  );
+  const status: StudioUserSecurityStatus =
+    criticalRisks > 0 ? 'critical' : warningRisks > 0 ? 'warning' : 'healthy';
+  const meta = statusMeta[status];
+
+  return {
+    status,
+    statusText: meta.text,
+    statusColor: meta.color,
+    score,
+    inspectedCount,
+    totalCount,
+    totalMayExceedInspected: totalCount > inspectedCount,
+    adminCount: adminUsers.length,
+    activeAdminCount: activeAdmins.length,
+    enabledCount: enabledUsers.length,
+    disabledCount: disabledUsers.length,
+    stalePasswordCount: stalePasswordUsers.length,
+    staleAdminPasswordCount: staleAdminPasswordUsers.length,
+    unknownPasswordAgeCount: unknownPasswordAgeUsers.length,
+    risks,
+    recommendations:
+      risks.length > 0
+        ? Array.from(new Set(risks.map((item) => item.recommendation)))
+        : ['保持用户列表定期复查，并对管理员账号执行更短周期的密码轮换。'],
+  };
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR adds user credential security insights to RocketMQ Studio.

The Studio user management page now shows password strength guidance when creating or resetting users, summarizes visible account security risks, and highlights password rotation status from existing user metadata. This helps administrators spot weak passwords, stale administrator credentials, unknown password age, and single active administrator risk before changing account state.

## Brief changelog

- Add a Studio user security analyzer for password strength, password rotation, and account risk summaries.
- Add a reusable credential security panel for password forms and the user list overview.
- Show password rotation status and password changed time in the Studio user table.
- Add focused unit tests and page rendering tests for the new security insights.

## Verifying this change

- `npm run test -- --run src/utils/studioUserSecurity.test.ts src/pages/studio/__tests__/UserManagement.test.tsx`
- `git diff --check`
- `npm run lint -- src/utils/studioUserSecurity.ts src/utils/studioUserSecurity.test.ts src/components/StudioUserSecurityPanel.tsx src/pages/studio/UserManagement.tsx src/pages/studio/__tests__/UserManagement.test.tsx`
- `npm run build`