### PR TITLE
feat(message): send FIFO and scheduled messages from topic dialogs

### DIFF
--- a/docs/typed-message-sending.md
+++ b/docs/typed-message-sending.md
@@ -1,0 +1,46 @@
+# FIFO 与定时消息发送
+
+## 解决的问题
+
+Studio 可以创建 FIFO 和 DELAY Topic，但原发送表单只能构造普通消息。RocketMQ 5.x 根据消息系统属性判断类型：FIFO 需要消息组，定时消息需要投递时间。把这些字段放进自定义属性会被客户端拒绝，因为它们属于保留属性。
+
+## 使用方式
+
+在 Apache 实例的 Topic 列表中打开原有发送对话框，填写消息体、Tag、Key 和业务属性。
+
+| Topic 类型 | 新增输入及行为 |
+| --- | --- |
+| NORMAL | 无新增必填项，沿用普通发送 |
+| FIFO | 必填 `Message group`，按组选择固定队列并设置 Broker 识别的消息组属性 |
+| DELAY | 必填未来的 `Delivery time (local)`，将当地时间转换成绝对毫秒时间戳 |
+| TRANSACTION | 显示专用事务生产者说明并禁用发送，避免把普通消息误用于事务 Topic |
+
+不同消息组可能分配到同一个队列。同组的队列一致性依赖当时的路由列表；Broker 扩缩容可能改变哈希映射。多个操作者或生产者并发发送时，本工具不提供应用级全局顺序，应由业务生产者协调顺序。
+
+定时发送的最大间隔、投递精度及 Broker 定时能力由集群配置决定。本工具只要求时间在未来，不硬编码集群的最大延迟。发送成功表示 Broker 接受消息，不表示定时时间已经到达或消费已经完成。
+
+## 请求兼容
+
+`POST /api/topics/send` 增加三个可选字段：
+
+```json
+{
+  "instanceId": "instance-a",
+  "topic": "order-events",
+  "body": "event payload",
+  "messageType": "FIFO",
+  "messageGroup": "order-123"
+}
+```
+
+DELAY 请求使用 `messageType: "DELAY"` 和 `deliveryTimestamp`，不携带 `messageGroup`。省略 `messageType` 时保持 NORMAL；混用组和定时时间、缺少必填字段或使用已过期时间返回 400，并记录失败审计。事务和 Lite 消息需要对应的专用生产者，此接口不伪造事务提交或 Lite 协议。实际 Topic 类型仍由 Broker 校验。
+
+实现复用现有客户端池、实例凭据、消息大小限制及发送确认检查。FIFO 失败时不会降级为随机队列重发；消息已经发送成功后，审计存储失败也不会把成功变成可重试的发送错误。
+
+## 验证与回滚
+
+`TypedMessageSendTest` 直接调用 RocketMQ 的 `TopicMessageType.parseFromMessageProperty` 验证消息类型，并使用真实哈希选择器验证同组位置。另覆盖时间属性、旧请求、错误参数、发送失败和成功后的审计异常。HTTP 契约与 Topic 页面测试验证参数绑定、必填项和消息类型互斥。
+
+无迁移，直接替换。没有新增依赖、配置或数据库字段；回滚本提交恢复原发送入口。回滚不会撤销 Broker 已接受的消息，已发送的定时消息仍按 Broker 状态执行。
+
+协议依据：[RocketMQ 5.5.0 TopicMessageType](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/common/src/main/java/org/apache/rocketmq/common/attribute/TopicMessageType.java) 与 [Message](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/common/src/main/java/org/apache/rocketmq/common/message/Message.java)，核验日期 2026-09-08。

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/SendMessageDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/SendMessageDTO.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.instance.topic;
 
 import jakarta.validation.constraints.NotBlank;
+import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -37,4 +38,7 @@ public class SendMessageDTO {
     private String key;
     private String body;
     private Map<String, String> properties;
+    private TopicType messageType;
+    private String messageGroup;
+    private Long deliveryTimestamp;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -23,9 +23,12 @@ import org.apache.rocketmq.remoting.protocol.body.ConsumerConnection;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
 import org.apache.rocketmq.client.producer.SendResult;
 import org.apache.rocketmq.client.producer.SendStatus;
+import org.apache.rocketmq.client.producer.selector.SelectMessageQueueByHash;
 import org.apache.rocketmq.common.TopicConfig;
 import org.apache.rocketmq.common.TopicAttributes;
 import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageAccessor;
+import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.ResponseCode;
@@ -459,6 +462,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
         String tag = request.getTag() != null ? request.getTag() : "";
         String key = request.getKey() != null ? request.getKey() : "";
         String body = request.getBody() != null ? request.getBody() : "";
+        TopicType messageType = request.getMessageType() == null ? TopicType.NORMAL : request.getMessageType();
         byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
         if (bodyBytes.length > MAX_MESSAGE_SIZE) {
             String message = "Message body size " + bodyBytes.length
@@ -477,7 +481,14 @@ public class RocketMQAdminClientImpl implements AdminClient {
                 }
             }
 
-            SendResult sendResult = producer.send(msg);
+            if (messageType == TopicType.DELAY) {
+                msg.setDeliverTimeMs(request.getDeliveryTimestamp());
+            } else if (messageType == TopicType.FIFO) {
+                MessageAccessor.putProperty(msg, MessageConst.PROPERTY_SHARDING_KEY, request.getMessageGroup());
+            }
+            SendResult sendResult = messageType == TopicType.FIFO
+                    ? producer.send(msg, new SelectMessageQueueByHash(), request.getMessageGroup())
+                    : producer.send(msg);
             if (sendResult == null || sendResult.getSendStatus() != SendStatus.SEND_OK) {
                 String status = sendResult == null ? "null" : String.valueOf(sendResult.getSendStatus());
                 throw new BusinessException(502, "Message send did not succeed: " + status);
@@ -486,7 +497,9 @@ public class RocketMQAdminClientImpl implements AdminClient {
             // The message is already delivered by now; an audit write failure must not turn a
             // successful send into an error, or callers would retry and duplicate the message.
             recordAudit("SEND_MESSAGE", topic,
-                    "tag=" + tag + ", key=" + key + ", msgId=" + sendResult.getMsgId(), "SUCCESS");
+                    "tag=" + tag + ", key=" + key + ", msgId=" + sendResult.getMsgId()
+                            + ", messageType=" + messageType + ", messageGroup=" + request.getMessageGroup()
+                            + ", deliveryTimestamp=" + request.getDeliveryTimestamp(), "SUCCESS");
 
             return SendMessageVO.builder()
                     .msgId(sendResult.getMsgId())
@@ -495,6 +508,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
                     .build();
         };
         try {
+            validateSendOptions(request, messageType);
             return StringUtils.hasText(request.getInstanceId())
                     ? runtimeAdminClientResolver.executeProducer(request.getInstanceId(), sendAction)
                     : clientPool.withProducer(namesrvAddr(), null, null, sendAction);
@@ -504,6 +518,29 @@ public class RocketMQAdminClientImpl implements AdminClient {
         } catch (Exception e) {
             recordAudit("SEND_MESSAGE", request.getTopic(), e.getMessage(), "FAILED");
             throw new BusinessException(500, "Failed to send message: " + e.getMessage());
+        }
+    }
+
+    private void validateSendOptions(SendMessageDTO request, TopicType messageType) {
+        if (messageType == TopicType.TRANSACTION) {
+            throw new BusinessException(400, "Transaction messages require an application transaction producer");
+        }
+        if (messageType == TopicType.LITE) {
+            throw new BusinessException(400, "Lite messages require a Lite topic producer");
+        }
+        if (messageType == TopicType.FIFO) {
+            if (!StringUtils.hasText(request.getMessageGroup())) {
+                throw new BusinessException(400, "messageGroup is required for FIFO messages");
+            }
+        } else if (request.getMessageGroup() != null) {
+            throw new BusinessException(400, "messageGroup is only supported for FIFO messages");
+        }
+        if (messageType == TopicType.DELAY) {
+            if (request.getDeliveryTimestamp() == null || request.getDeliveryTimestamp() <= System.currentTimeMillis()) {
+                throw new BusinessException(400, "deliveryTimestamp must be in the future for DELAY messages");
+            }
+        } else if (request.getDeliveryTimestamp() != null) {
+            throw new BusinessException(400, "deliveryTimestamp is only supported for DELAY messages");
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/TopicControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/TopicControllerTest.java
@@ -336,6 +336,22 @@ class TopicControllerTest {
     }
 
     @Test
+    void sendMessageShouldBindTypedDeliveryOptions() throws Exception {
+        mockMvc.perform(post("/api/topics/send").contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"instanceId":"instance-a","topic":"orders","body":"event",
+                                 "messageType":"DELAY","deliveryTimestamp":1788825600123}
+                                """))
+                .andExpect(status().isOk());
+        ArgumentCaptor<SendMessageDTO> request = ArgumentCaptor.forClass(SendMessageDTO.class);
+        verify(metadataService).sendMessage(request.capture());
+        assertThat(request.getValue().getMessageType().name()).isEqualTo("DELAY");
+        assertThat(request.getValue().getDeliveryTimestamp()).isEqualTo(1788825600123L);
+        assertThat(request.getValue().getInstanceId()).isEqualTo("instance-a");
+        assertThat(request.getValue().getMessageGroup()).isNull();
+    }
+
+    @Test
     void deleteTopicShouldReturnSuccess() throws Exception {
         mockMvc.perform(post("/api/topics/delete")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/TypedMessageSendTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/TypedMessageSendTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.apache;
+
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.MessageQueueSelector;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.producer.SendStatus;
+import org.apache.rocketmq.common.attribute.TopicMessageType;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageConst;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.MqClientPool;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.domain.enums.TopicType;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.instance.topic.SendMessageDTO;
+import org.apache.rocketmq.studio.ops.audit.AuditService;
+import org.apache.rocketmq.studio.persistence.mapper.RmqGroupMapper;
+import org.apache.rocketmq.studio.persistence.mapper.RmqTopicMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class TypedMessageSendTest {
+    private final RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+    private final DefaultMQProducer producer = mock(DefaultMQProducer.class);
+    private final MqClientPool pool = mock(MqClientPool.class);
+    private final AuditService audit = mock(AuditService.class);
+    private final RocketMQAdminClientImpl client = new RocketMQAdminClientImpl(mock(MqAdminExtFactory.class),
+            mock(RocketMQProperties.class), mock(RmqTopicMapper.class), mock(RmqGroupMapper.class), audit, resolver, pool);
+
+    @BeforeEach
+    void setUp() {
+        when(resolver.executeProducer(eq("instance-a"), any())).thenAnswer(invocation ->
+                invocation.<MqClientPool.ClientAction<DefaultMQProducer, Object>>getArgument(1).apply(producer));
+    }
+
+    @Test
+    void sendsFifoWithBrokerRecognizedGroupAndStableQueueSelector() throws Exception {
+        when(producer.send(any(Message.class), any(MessageQueueSelector.class), eq("order-123"))).thenReturn(success());
+        SendMessageDTO request = request(TopicType.FIFO);
+        request.setMessageGroup("order-123");
+
+        assertThat(client.sendMessage(request).getMsgId()).isEqualTo("sent-message");
+        ArgumentCaptor<Message> message = ArgumentCaptor.forClass(Message.class);
+        ArgumentCaptor<MessageQueueSelector> selector = ArgumentCaptor.forClass(MessageQueueSelector.class);
+        verify(producer).send(message.capture(), selector.capture(), eq("order-123"));
+        assertThat(TopicMessageType.parseFromMessageProperty(message.getValue().getProperties())).isEqualTo(TopicMessageType.FIFO);
+        assertThat(message.getValue().getProperty(MessageConst.PROPERTY_SHARDING_KEY)).isEqualTo("order-123");
+        assertEnvelope(message.getValue());
+
+        List<MessageQueue> queues = List.of(new MessageQueue("orders", "broker-a", 0),
+                new MessageQueue("orders", "broker-a", 1), new MessageQueue("orders", "broker-b", 0));
+        Message anotherBody = new Message("orders", "next-event".getBytes(StandardCharsets.UTF_8));
+        assertThat(selector.getValue().select(queues, message.getValue(), "order-123"))
+                .isEqualTo(selector.getValue().select(queues, anotherBody, "order-123"));
+        verify(producer, never()).send(any(Message.class));
+        verifyNoInteractions(pool);
+    }
+
+    @Test
+    void sendsDelayUsingAnAbsoluteBrokerTimerProperty() throws Exception {
+        when(producer.send(any(Message.class))).thenReturn(success());
+        SendMessageDTO request = request(TopicType.DELAY);
+        long delivery = System.currentTimeMillis() + 3_600_000;
+        request.setDeliveryTimestamp(delivery);
+
+        client.sendMessage(request);
+        ArgumentCaptor<Message> message = ArgumentCaptor.forClass(Message.class);
+        verify(producer).send(message.capture());
+        assertThat(TopicMessageType.parseFromMessageProperty(message.getValue().getProperties())).isEqualTo(TopicMessageType.DELAY);
+        assertThat(message.getValue().getDeliverTimeMs()).isEqualTo(delivery);
+        assertEnvelope(message.getValue());
+        verify(audit).record(eq("SEND_MESSAGE"), eq("MESSAGE"), eq("orders"), isNull(),
+                contains("deliveryTimestamp=" + delivery), eq("SUCCESS"));
+    }
+
+    @Test
+    void preservesLegacyOrdinaryRequestsWithoutAType() throws Exception {
+        when(producer.send(any(Message.class))).thenReturn(success());
+        client.sendMessage(request(null));
+        ArgumentCaptor<Message> message = ArgumentCaptor.forClass(Message.class);
+        verify(producer).send(message.capture());
+        assertThat(TopicMessageType.parseFromMessageProperty(message.getValue().getProperties())).isEqualTo(TopicMessageType.NORMAL);
+        assertEnvelope(message.getValue());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "FIFO, , , messageGroup is required",
+        "FIFO, ' ', , messageGroup is required",
+        "FIFO, order-123, 1, deliveryTimestamp is only supported",
+        "DELAY, , , deliveryTimestamp must be in the future",
+        "DELAY, , 0, deliveryTimestamp must be in the future",
+        "DELAY, order-123, 1, messageGroup is only supported",
+        "NORMAL, order-123, , messageGroup is only supported",
+        "NORMAL, , 1, deliveryTimestamp is only supported",
+        "TRANSACTION, , , Transaction messages require",
+        "LITE, , , Lite messages require"
+    })
+    void rejectsIncompleteOrConflictingTypedOptionsBeforeAcquiringProducer(TopicType type, String group,
+                                                                           Long delivery, String error) {
+        SendMessageDTO request = request(type);
+        request.setMessageGroup(group);
+        request.setDeliveryTimestamp(delivery);
+        assertThatThrownBy(() -> client.sendMessage(request)).isInstanceOf(BusinessException.class)
+                .hasMessageContaining(error)
+                .satisfies(exception -> assertThat(((BusinessException) exception).getCode()).isEqualTo(400));
+        verify(resolver, never()).executeProducer(any(), any());
+        verifyNoInteractions(producer, pool);
+        verify(audit).record(eq("SEND_MESSAGE"), eq("MESSAGE"), eq("orders"), isNull(), contains(error), eq("FAILED"));
+    }
+
+    @Test
+    void reportsOrderedSendFailureWithoutFallingBackToRandomQueueSend() throws Exception {
+        SendResult failure = success();
+        failure.setSendStatus(SendStatus.FLUSH_DISK_TIMEOUT);
+        when(producer.send(any(Message.class), any(MessageQueueSelector.class), any())).thenReturn(failure);
+        SendMessageDTO request = request(TopicType.FIFO);
+        request.setMessageGroup("order-123");
+        assertThatThrownBy(() -> client.sendMessage(request)).isInstanceOf(BusinessException.class)
+                .hasMessageContaining("FLUSH_DISK_TIMEOUT");
+        verify(producer, never()).send(any(Message.class));
+        verify(audit).record(eq("SEND_MESSAGE"), eq("MESSAGE"), eq("orders"), isNull(),
+                contains("FLUSH_DISK_TIMEOUT"), eq("FAILED"));
+    }
+
+    @Test
+    void doesNotReturnFailureAfterOrderedMessageWasDeliveredButAuditStorageFailed() throws Exception {
+        when(producer.send(any(Message.class), any(MessageQueueSelector.class), any())).thenReturn(success());
+        doThrow(new IllegalStateException("Audit unavailable")).when(audit)
+                .record(anyString(), anyString(), anyString(), any(), anyString(), anyString());
+        SendMessageDTO request = request(TopicType.FIFO);
+        request.setMessageGroup("order-123");
+        assertThat(client.sendMessage(request).getMsgId()).isEqualTo("sent-message");
+    }
+
+    private SendMessageDTO request(TopicType type) {
+        return SendMessageDTO.builder().instanceId("instance-a").topic("orders").messageType(type)
+                .tag("created").key("order-123").body("event payload").properties(Map.of("traceId", "trace-1")).build();
+    }
+
+    private void assertEnvelope(Message message) {
+        assertThat(message.getTopic()).isEqualTo("orders");
+        assertThat(message.getTags()).isEqualTo("created");
+        assertThat(message.getKeys()).isEqualTo("order-123");
+        assertThat(message.getUserProperty("traceId")).isEqualTo("trace-1");
+        assertThat(new String(message.getBody(), StandardCharsets.UTF_8)).isEqualTo("event payload");
+    }
+
+    private SendResult success() {
+        SendResult result = new SendResult();
+        result.setSendStatus(SendStatus.SEND_OK);
+        result.setMsgId("sent-message");
+        result.setOffsetMsgId("physical-message");
+        return result;
+    }
+}

--- a/web/src/api/metadata.ts
+++ b/web/src/api/metadata.ts
@@ -281,6 +281,9 @@ export interface SendTopicMessageRequest {
   key?: string;
   body: string;
   properties?: Record<string, string>;
+  messageType?: 'NORMAL' | 'FIFO' | 'DELAY' | 'TRANSACTION';
+  messageGroup?: string;
+  deliveryTimestamp?: number;
 }
 
 export interface SendTopicMessageResult {

--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -20,6 +20,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { App, Modal } from 'antd';
+import dayjs from 'dayjs';
 import { LangProvider } from '../../../i18n/LangContext';
 import type { BrokerRoute, Topic } from '../../../api/metadata';
 import { parseMessageProperties } from '../../../utils/messageProperties';
@@ -858,6 +859,85 @@ describe('TopicPage', () => {
     await waitFor(() =>
       expect(screen.getByText(/发送前预检未通过：属性名重复/)).toBeInTheDocument(),
     );
+    expect(topicServiceMocks.sendTopicMessage).not.toHaveBeenCalled();
+  });
+
+  it('requires a FIFO message group and sends it through the existing modal', async () => {
+    const user = userEvent.setup();
+    mockTopicsList([{ ...buildTopics(1)[0], type: 'FIFO' }]);
+    renderWithProviders();
+    await screen.findByText('topic-01');
+    await user.click(
+      document.querySelector('.ant-table-tbody button:has(.anticon-send)') as HTMLElement,
+    );
+    const dialog = await getSendDialog();
+    fireEvent.change(dialog.querySelector('textarea') as HTMLTextAreaElement, {
+      target: { value: 'event' },
+    });
+    await user.click(dialog.querySelector('.ant-modal-footer .ant-btn-primary') as HTMLElement);
+    expect(await within(dialog).findByText('Message group is required')).toBeInTheDocument();
+    expect(topicServiceMocks.sendTopicMessage).not.toHaveBeenCalled();
+    await user.type(within(dialog).getByLabelText('Message group'), 'order-123');
+    await user.click(dialog.querySelector('.ant-modal-footer .ant-btn-primary') as HTMLElement);
+    await waitFor(() =>
+      expect(topicServiceMocks.sendTopicMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageType: 'FIFO',
+          messageGroup: 'order-123',
+          topic: 'topic-01',
+          body: 'event',
+        }),
+      ),
+    );
+    expect(topicServiceMocks.sendTopicMessage.mock.calls[0][0]).not.toHaveProperty(
+      'deliveryTimestamp',
+    );
+  });
+
+  it('validates a DELAY delivery time and submits its epoch milliseconds', async () => {
+    const user = userEvent.setup();
+    const delivery = dayjs().add(1, 'hour').startOf('second');
+    mockTopicsList([{ ...buildTopics(1)[0], type: 'DELAY' }]);
+    renderWithProviders();
+    await screen.findByText('topic-01');
+    await user.click(
+      document.querySelector('.ant-table-tbody button:has(.anticon-send)') as HTMLElement,
+    );
+    const dialog = await getSendDialog();
+    fireEvent.change(dialog.querySelector('textarea') as HTMLTextAreaElement, {
+      target: { value: 'event' },
+    });
+    await user.click(dialog.querySelector('.ant-modal-footer .ant-btn-primary') as HTMLElement);
+    expect(await within(dialog).findByText('Delivery time is required')).toBeInTheDocument();
+    const input = within(dialog).getByLabelText('Delivery time (local)');
+    await user.type(input, delivery.format('YYYY-MM-DD HH:mm:ss'));
+    await user.keyboard('{Enter}');
+    await user.click(dialog.querySelector('.ant-modal-footer .ant-btn-primary') as HTMLElement);
+    await waitFor(() =>
+      expect(topicServiceMocks.sendTopicMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageType: 'DELAY',
+          deliveryTimestamp: delivery.valueOf(),
+          body: 'event',
+        }),
+      ),
+    );
+    expect(topicServiceMocks.sendTopicMessage.mock.calls[0][0]).not.toHaveProperty('messageGroup');
+  });
+
+  it('explains why a transaction topic cannot use ordinary message sending', async () => {
+    const user = userEvent.setup();
+    mockTopicsList([{ ...buildTopics(1)[0], type: 'TRANSACTION' }]);
+    renderWithProviders();
+    await screen.findByText('topic-01');
+    await user.click(
+      document.querySelector('.ant-table-tbody button:has(.anticon-send)') as HTMLElement,
+    );
+    const dialog = await getSendDialog();
+    expect(
+      within(dialog).getByText('Transaction messages require an application transaction producer'),
+    ).toBeInTheDocument();
+    expect(dialog.querySelector('.ant-modal-footer .ant-btn-primary')).toBeDisabled();
     expect(topicServiceMocks.sendTopicMessage).not.toHaveBeenCalled();
   });
 

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -41,7 +41,9 @@ import {
   message,
   App,
   Progress,
+  DatePicker,
 } from 'antd';
+import type { Dayjs } from 'dayjs';
 import type { TableColumnsType } from 'antd';
 import {
   PlusOutlined,
@@ -164,6 +166,8 @@ type SendMessageFormValues = {
   body: string;
   propsText?: string;
   properties?: MessagePropertyInput[];
+  messageGroup?: string;
+  deliveryTime?: Dayjs;
 };
 
 const visibleTopics = (
@@ -632,6 +636,7 @@ const TopicPage = () => {
     } else if (key === 'send') {
       setSendTopic(topic);
       setPropsMode('form');
+      sendForm.resetFields();
       sendForm.setFieldsValue({ topic: topic.name, tag: '', key: '', body: '', properties: [] });
       setSendModalOpen(true);
     } else if (key === 'delete') {
@@ -1353,6 +1358,7 @@ const TopicPage = () => {
 
   // ─── Send message modal submit ────────────────────────────────
   const handleSend = async () => {
+    if (sendTopic?.type === 'TRANSACTION') return;
     let values: SendMessageFormValues;
     try {
       values = await sendForm.validateFields();
@@ -1384,6 +1390,12 @@ const TopicPage = () => {
         key: payloadPreview.normalized.key,
         body: payloadPreview.normalized.body,
         properties: payloadPreview.properties,
+        ...(sendTopic?.type === 'FIFO'
+          ? { messageType: 'FIFO' as const, messageGroup: values.messageGroup }
+          : {}),
+        ...(sendTopic?.type === 'DELAY'
+          ? { messageType: 'DELAY' as const, deliveryTimestamp: values.deliveryTime?.valueOf() }
+          : {}),
       });
       // Keep the modal open for consecutive sends
       message.success(`消息发送成功！MsgId: ${result.msgId}`);
@@ -1836,6 +1848,7 @@ const TopicPage = () => {
         okText="发送"
         cancelText="取消"
         confirmLoading={sending}
+        okButtonProps={{ disabled: sendTopic?.type === 'TRANSACTION' }}
         width={640}
         destroyOnHidden
       >
@@ -1848,6 +1861,44 @@ const TopicPage = () => {
           <Form.Item label="Topic" name="topic" rules={[{ required: true }]}>
             <Input disabled />
           </Form.Item>
+
+          {sendTopic?.type === 'FIFO' && (
+            <Form.Item
+              label="Message group"
+              name="messageGroup"
+              extra="Use the same group for messages that must share a queue."
+              rules={[{ required: true, whitespace: true, message: 'Message group is required' }]}
+            >
+              <Input placeholder="For example: order-123" />
+            </Form.Item>
+          )}
+          {sendTopic?.type === 'DELAY' && (
+            <Form.Item
+              label="Delivery time (local)"
+              name="deliveryTime"
+              extra="Choose a future time. The broker controls the maximum delay and delivery precision."
+              rules={[
+                { required: true, message: 'Delivery time is required' },
+                {
+                  validator: (_, value: Dayjs | undefined) =>
+                    !value || value.valueOf() > Date.now()
+                      ? Promise.resolve()
+                      : Promise.reject(new Error('Delivery time must be in the future')),
+                },
+              ]}
+            >
+              <DatePicker showTime style={{ width: '100%' }} />
+            </Form.Item>
+          )}
+          {sendTopic?.type === 'TRANSACTION' && (
+            <Alert
+              type="info"
+              showIcon
+              message="Transaction messages require an application transaction producer"
+              description="Use a producer that can commit, roll back and answer broker transaction checks."
+              style={{ marginBottom: 16 }}
+            />
+          )}
 
           <Row gutter={16}>
             <Col span={12}>


### PR DESCRIPTION
## 变更目的

让现有消息发送对话框可以向 FIFO 和 DELAY Topic 发送对应类型的消息。

Studio 已支持创建这两类 Topic，但发送接口只构造普通消息。Broker 通过系统属性判断消息类型，而这些保留属性无法通过现有自定义属性入口设置，因此创建出的类型化 Topic 无法用该表单正确发送。

## 修改内容

- FIFO 表单新增必填消息组，后端设置 `SHARDING_KEY`，使用 SDK `SelectMessageQueueByHash` 按组选择队列。
- DELAY 表单新增未来投递时间，发送 Unix 毫秒时间戳，由 `Message.setDeliverTimeMs` 写入 Broker 定时属性。
- 缺省类型保持 NORMAL，旧请求兼容；缺少必填项、类型选项冲突及过去时间在取得 Producer 前返回 400 并记录失败审计。
- 事务 Topic 显示应用事务生产者说明并禁止普通发送；该接口也明确拒绝 Lite 类型，避免伪造专用协议。
- 保留消息体大小限制、实例凭据、发送状态检查及成功后的审计异常处理。FIFO 失败不会降级到随机队列发送。
- 新增中文操作、协议边界、兼容及回滚说明。

## 价值与去重

已核对 #1982、#1983：它们修复 Topic 创建时的 `message.type` 配置属性。本 PR 处理消息本身的生产协议与表单输入，范围不同。检索既有 Issue/PR 未发现同范围的 FIFO／定时发送实现。

协议直接依据 [RocketMQ 5.5.0 TopicMessageType](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/common/src/main/java/org/apache/rocketmq/common/attribute/TopicMessageType.java) 和 [Message](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/common/src/main/java/org/apache/rocketmq/common/message/Message.java)。测试调用实际 `parseFromMessageProperty`，确认生成的消息被识别为 FIFO、DELAY 和 NORMAL。

## 本地验证

基线 `d6dee7d7ccfcf4886f02466ec51452a6928b2cc8`，Java 21、Node 24.18.0，2026-09-08。

```bash
cd server
mvn -B -ntp -Dtest=TypedMessageSendTest,RocketMQAdminClientImplTest,TopicControllerTest,MetadataServiceTest verify
cd ../web
npx vitest run src/pages/instance/__tests__/TopicPage.test.tsx src/api/metadata.test.ts
npm run build
```

- 后端 114 个测试通过，Checkstyle 与打包通过，包含 15 个类型化发送测试及新增 HTTP 参数绑定测试。
- JaCoCo：选项校验与发送主体 39/39 行、34/34 分支；含既有外层异常处理的整体发送路径 57/60 行（95%）。
- 前端 31 个测试通过；TypeScript、Vite 构建和修改文件 ESLint 均通过。
- Playwright 在同一次脚本中拦截本地 `/api/topics/send` 并返回测试响应，确认表单生成 `messageType=FIFO`、`messageGroup=order-123` 和原始消息体，没有向真实 Broker 发送消息。
- `git diff --check` 通过；8 个文件，433 行新增、2 行删除，共 435 行。

同一原样上游基线的全量后端仍有 3 个既有失败（AuthCorsIntegrationTest 两项、AliyunInstanceProviderTest 一项），依赖扫描也有既有漏洞。本 PR 没有新增依赖，相关测试没有新增失败；不将增量结果称为项目级全量验收。未执行真实集群 E2E、压力、容量或混沌验证。

## 行为边界

FIFO 的队列映射依赖当时路由；不承诺多个操作者并发发送时的应用级全局顺序。定时能力、最大间隔和投递精度由 Broker 决定，实际 Topic 类型仍由 Broker 校验。发送确认表示 Broker 接受消息，不表示已经消费。

无迁移，直接替换；没有新增配置或数据库字段。回滚本提交即可，已被 Broker 接受的消息不受代码回滚影响。提交含 `[skip ci]`，验证在本地执行。
