### PR TITLE
feat(message): preview native queue filters without consuming offsets

### DIFF
--- a/docs/queue-filter-preview.md
+++ b/docs/queue-filter-preview.md
@@ -1,0 +1,40 @@
+# 队列消费过滤预览
+
+## 适用场景
+
+消息已经存在于队列，但消费者没有收到时，可以使用消费端的 TAG 或 SQL92 表达式检查消息是否匹配。此功能通过 RocketMQ 原生过滤器读取消息，不在浏览器中模拟 SQL 语义，也不修改消费组位点。
+
+## 操作步骤
+
+1. 在消息页面选择队列浏览，加载 Topic 的队列。
+2. 将队列滑块移到待检查范围的开始位置，点击对应行的 `Filter`。
+3. 选择 `Tag` 或 `SQL92`，填写表达式并确认起始 offset。
+4. 点击 `Preview from offset`；展开结果行查看消息体及属性。
+5. 当仍有后续位置时，点击 `Next batch` 继续。修改表达式或起始 offset 后，旧的继续位置会被清除。
+
+TAG 支持 `TagA || TagB` 和 `*`。SQL92 示例为 `amount > 100 AND region = 'east'`，要求 Broker 开启属性过滤能力。若 Broker 拒绝语法或能力请求，页面显示错误，不降级为无过滤查询。
+
+## 结果与边界
+
+每次请求只执行一次最多 20 条消息、3 秒超时的同步 pull；路由和边界读取另有各自 SDK 超时。一次没有匹配消息，不代表后续队列也没有匹配消息；`hasMore` 和 `nextOffset` 告知是否可以继续。
+
+若保留期清理使起点失效，服务端修正到当时的可读边界，并显示调整提示。`OFFSET_ILLEGAL` 的 Broker 修正位置也会显示给用户，需显式继续。没有前进的异常批次返回错误，避免反复读取同一位置。
+
+页面仅保留当前批次。关闭面板或切换实例、Topic 会取消浏览器请求，避免旧结果写入新页面；服务端已经开始的 RPC 仍受其超时约束，浏览器取消不等于远端调用立即终止。消息体和属性沿用现有显示截断规则，截断时明确提示。
+
+此预览复用 Studio 的实例绑定 Apache pull 客户端，不会以业务消费组身份执行消费，也不注册用户的订阅关系；只能帮助核对 Broker 过滤结果，不能代替对业务消费者在线状态、权限及订阅一致性的检查。
+
+## 接口与验证
+
+`GET /api/messages/queue-filter-preview` 接受 `instanceId`、`topic`、`brokerName`、`queueId`、`offset`、`expressionType` 和 `expression`。表达式类型为 TAG 或 SQL92，表达式最多 4096 个字符。响应包含消息列表、起点、继续位置、可读边界、是否可继续及是否修正位置。
+
+```bash
+cd server
+mvn -B -ntp -Dtest=QueueFilterPreviewTest,RocketMQMessageProviderTest,MessageServiceTest,MessageControllerTest verify
+cd ../web
+npx vitest run src/components/__tests__/QueueFilterPreview.test.tsx src/components/__tests__/QueueBrowser.test.tsx src/api/message.test.ts
+```
+
+后端测试组合真实 HTTP 校验、服务与 Provider，在 SDK 边界验证表达式、有限批次、空匹配继续、位点修正、过滤能力错误及中断。前端验证继续位置、修改表达式、取消请求、原队列入口和消息详情。
+
+无迁移，直接替换；没有新增依赖、配置或数据库字段。回滚本提交移除新增只读入口，不需要调整消费组状态。协议依据 [RocketMQ 5.5.0 DefaultMQPullConsumerImpl](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultMQPullConsumerImpl.java)，核验日期 2026-09-08。

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageController.java
@@ -16,9 +16,11 @@
  */
 package org.apache.rocketmq.studio.instance.message;
 
+import jakarta.validation.Valid;
 import org.apache.rocketmq.studio.common.domain.Result;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -89,6 +91,12 @@ public class MessageController {
                                                        @RequestParam int queueId,
                                                        @RequestParam long offset) {
         return Result.ok(messageService.pullMessageAtOffset(instanceId, topic, brokerName, queueId, offset));
+    }
+
+    @GetMapping("/queue-filter-preview")
+    public Result<QueueFilterPageVO> previewQueueFilter(
+            @Valid @ModelAttribute QueueFilterPreviewDTO request) {
+        return Result.ok(messageService.previewQueueFilter(request));
     }
 
     @PostMapping("/direct-consume")

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProvider.java
@@ -34,6 +34,8 @@ public interface MessageProvider {
 
     List<QueueOffsetVO> getQueueOffsets(String instanceId, String topic);
 
+    QueueFilterPageVO previewQueueFilter(QueueFilterPreviewDTO request);
+
     MessageRecordVO pullMessageAtOffset(String instanceId, String topic, String brokerName, int queueId, long offset);
 
     default DirectConsumeMessageResultVO consumeMessageDirectly(DirectConsumeMessageDTO request) {

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProviderStub.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProviderStub.java
@@ -57,4 +57,9 @@ public class MessageProviderStub implements MessageProvider {
     private BusinessException unsupported() {
         return new BusinessException(501, "Message query provider is not configured");
     }
+
+    @Override
+    public QueueFilterPageVO previewQueueFilter(QueueFilterPreviewDTO request) {
+        throw unsupported();
+    }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -104,6 +104,10 @@ public class MessageService {
         return messageProvider.getQueueOffsets(instanceId, topic);
     }
 
+    public QueueFilterPageVO previewQueueFilter(QueueFilterPreviewDTO request) {
+        return messageProvider.previewQueueFilter(request);
+    }
+
     public MessageRecordVO pullMessageAtOffset(String instanceId, String topic, String brokerName,
                                                 int queueId, long offset) {
         if (!StringUtils.hasText(topic)) {

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueueFilterPageVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueueFilterPageVO.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import java.util.List;
+
+/** One bounded broker pull, including its continuation even when no message matched. */
+public record QueueFilterPageVO(List<MessageRecordVO> items, long startOffset, long nextOffset,
+                               long minOffset, long maxOffset, boolean hasMore,
+                               boolean offsetAdjusted, String status) {
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueueFilterPreviewDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueueFilterPreviewDTO.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class QueueFilterPreviewDTO {
+    @NotBlank
+    private String instanceId;
+    @NotBlank
+    private String topic;
+    @NotBlank
+    private String brokerName;
+    @Min(0)
+    @NotNull
+    private Integer queueId;
+    @Min(0)
+    @NotNull
+    private Long offset;
+    @NotBlank
+    @Pattern(regexp = "TAG|SQL92")
+    private String expressionType = "TAG";
+    @NotBlank
+    @Size(max = 4096)
+    private String expression;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -20,6 +20,7 @@ import org.apache.rocketmq.client.QueryResult;
 import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
 import org.apache.rocketmq.client.consumer.PullResult;
 import org.apache.rocketmq.client.consumer.PullStatus;
+import org.apache.rocketmq.client.consumer.MessageSelector;
 import org.apache.rocketmq.client.trace.TraceConstants;
 import org.apache.rocketmq.common.message.MessageDecoder;
 import org.apache.rocketmq.common.message.MessageExt;
@@ -39,6 +40,8 @@ import org.apache.rocketmq.studio.instance.message.DirectConsumeMessageDTO;
 import org.apache.rocketmq.studio.instance.message.DirectConsumeMessageResultVO;
 import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
 import org.apache.rocketmq.studio.instance.message.QueueOffsetVO;
+import org.apache.rocketmq.studio.instance.message.QueueFilterPreviewDTO;
+import org.apache.rocketmq.studio.instance.message.QueueFilterPageVO;
 import org.apache.rocketmq.studio.instance.message.TraceNodeVO;
 import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
@@ -245,6 +248,57 @@ public class RocketMQMessageProvider implements MessageProvider {
                 log.warn("pullMessageAtOffset(topic={}, broker={}, queue={}, offset={}) failed: {}",
                         topic, brokerName, queueId, offset, e.getMessage());
                 throw new BusinessException(502, "Failed to pull message at offset: " + e.getMessage());
+            }
+        });
+    }
+
+    @Override
+    public QueueFilterPageVO previewQueueFilter(QueueFilterPreviewDTO request) {
+        MessageSelector selector = "SQL92".equals(request.getExpressionType())
+                ? MessageSelector.bySql(request.getExpression()) : MessageSelector.byTag(request.getExpression());
+        return runtimeAdminClientResolver.executePullConsumer(request.getInstanceId(), consumer -> {
+            try {
+                MessageQueue queue = new MessageQueue(request.getTopic(), request.getBrokerName(), request.getQueueId());
+                Set<MessageQueue> readable = consumer.fetchSubscribeMessageQueues(request.getTopic());
+                if (readable == null || !readable.contains(queue)) {
+                    throw new BusinessException(404, "Queue is not present in the topic's readable route");
+                }
+                long min = consumer.minOffset(queue);
+                long max = consumer.maxOffset(queue);
+                if (min < 0 || max < min) {
+                    throw new BusinessException(502, "Broker returned unavailable queue bounds");
+                }
+                long start = clampOffset(request.getOffset(), min, max);
+                if (start == max) {
+                    return new QueueFilterPageVO(List.of(), start, max, min, max, false,
+                            start != request.getOffset(), PullStatus.NO_NEW_MSG.name());
+                }
+                // A preview never commits offsets or loops over an unbounded queue. The next
+                // cursor is useful even for NO_MATCHED_MSG, so callers can continue explicitly.
+                PullResult pull = consumer.pull(queue, selector, start, 20, 3000L);
+                if (pull == null || pull.getPullStatus() == null || pull.getMinOffset() < 0
+                        || pull.getMaxOffset() < pull.getMinOffset()) {
+                    throw new BusinessException(502, "Broker returned an invalid filter preview result");
+                }
+                long next = clampOffset(pull.getNextBeginOffset(), pull.getMinOffset(), pull.getMaxOffset());
+                PullStatus status = pull.getPullStatus();
+                if (next == start && status != PullStatus.NO_NEW_MSG
+                        || next < start && status != PullStatus.OFFSET_ILLEGAL) {
+                    throw new BusinessException(502, "Broker filter preview did not advance the queue position");
+                }
+                List<MessageRecordVO> items = status == PullStatus.FOUND && pull.getMsgFoundList() != null
+                        ? pull.getMsgFoundList().stream().map(message -> toRecordVO(message, request.getBrokerName())).toList()
+                        : List.of();
+                return new QueueFilterPageVO(items, start, next, pull.getMinOffset(), pull.getMaxOffset(),
+                        next < pull.getMaxOffset() && status != PullStatus.NO_NEW_MSG,
+                        start != request.getOffset() || status == PullStatus.OFFSET_ILLEGAL, status.name());
+            } catch (BusinessException exception) {
+                throw exception;
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new BusinessException(502, "Queue filter preview was interrupted");
+            } catch (Exception exception) {
+                throw new BusinessException(502, "Failed to preview queue filter: " + exception.getMessage());
             }
         });
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueueFilterPreviewTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueueFilterPreviewTest.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.consumer.MessageSelector;
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.client.consumer.PullStatus;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.cluster.broker.MqClientPool;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.exception.GlobalExceptionHandler;
+import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
+import org.apache.rocketmq.studio.provider.apache.RocketMQMessageProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class QueueFilterPreviewTest {
+    private final DefaultMQPullConsumer consumer = mock(DefaultMQPullConsumer.class);
+    private final RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+    private final MessageQueue queue = new MessageQueue("orders", "broker-a", 0);
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        when(resolver.executePullConsumer(eq("instance-a"), any())).thenAnswer(invocation ->
+                invocation.<MqClientPool.ClientAction<DefaultMQPullConsumer, Object>>getArgument(1).apply(consumer));
+        when(consumer.fetchSubscribeMessageQueues("orders")).thenReturn(Set.of(queue));
+        when(consumer.minOffset(queue)).thenReturn(10L);
+        when(consumer.maxOffset(queue)).thenReturn(100L);
+        MessageService service = new MessageService(new RocketMQMessageProvider(resolver),
+                mock(InstanceProviderRegistry.class), mock(QueryHistoryService.class), mock(OperationAuditService.class));
+        mvc = MockMvcBuilders.standaloneSetup(new MessageController(service))
+                .setControllerAdvice(new GlobalExceptionHandler()).build();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"TAG, 'paid || shipped'", "SQL92, 'amount > 100'"})
+    void sendsTheNativeSelectorAndReturnsMatchingMessageDetails(String type, String expression) throws Exception {
+        MessageExt message = new MessageExt();
+        message.setTopic("orders");
+        message.setMsgId("matched-message");
+        message.setQueueId(0);
+        message.setQueueOffset(18);
+        message.setBody("event".getBytes(StandardCharsets.UTF_8));
+        message.setBornHost(new InetSocketAddress("127.0.0.1", 1000));
+        message.setStoreHost(new InetSocketAddress("127.0.0.1", 10911));
+        message.putUserProperty("amount", "200");
+        when(consumer.pull(eq(queue), any(MessageSelector.class), eq(10L), eq(20), eq(3000L)))
+                .thenReturn(new PullResult(PullStatus.FOUND, 30, 10, 100, List.of(message)));
+
+        mvc.perform(request(type, expression)).andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items[0].msgId").value("matched-message"))
+                .andExpect(jsonPath("$.data.items[0].properties.amount").value("200"))
+                .andExpect(jsonPath("$.data.items[0].queueOffset").value(18))
+                .andExpect(jsonPath("$.data.nextOffset").value(30))
+                .andExpect(jsonPath("$.data.hasMore").value(true));
+
+        ArgumentCaptor<MessageSelector> selector = ArgumentCaptor.forClass(MessageSelector.class);
+        verify(consumer).pull(eq(queue), selector.capture(), eq(10L), eq(20), eq(3000L));
+        assertThat(selector.getValue().getExpressionType()).isEqualTo(type);
+        assertThat(selector.getValue().getExpression()).isEqualTo(expression);
+        verify(consumer).fetchSubscribeMessageQueues("orders");
+        verify(consumer).minOffset(queue);
+        verify(consumer).maxOffset(queue);
+        verifyNoMoreInteractions(consumer);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"NO_MATCHED_MSG, 50, true", "NO_NEW_MSG, 100, false", "OFFSET_ILLEGAL, 20, true"})
+    void preservesContinuationEvenWhenTheBatchContainsNoMatches(PullStatus status, long next, boolean more) throws Exception {
+        when(consumer.pull(eq(queue), any(MessageSelector.class), eq(10L), eq(20), eq(3000L)))
+                .thenReturn(new PullResult(status, next, 10, 100, List.of()));
+        mvc.perform(request("TAG", "missing-tag")).andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items").isEmpty())
+                .andExpect(jsonPath("$.data.nextOffset").value(next))
+                .andExpect(jsonPath("$.data.hasMore").value(more))
+                .andExpect(jsonPath("$.data.offsetAdjusted").value(status == PullStatus.OFFSET_ILLEGAL));
+    }
+
+    @Test
+    void clampsExpiredInputBeforePullingAndReportsTheAdjustment() throws Exception {
+        when(consumer.pull(eq(queue), any(MessageSelector.class), eq(10L), eq(20), eq(3000L)))
+                .thenReturn(new PullResult(PullStatus.NO_MATCHED_MSG, 30, 10, 100, List.of()));
+        mvc.perform(requestWith("offset", "0")).andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.startOffset").value(10))
+                .andExpect(jsonPath("$.data.offsetAdjusted").value(true));
+    }
+
+    @Test
+    void returnsTheTailWithoutPullingWhenNoReadablePositionRemains() throws Exception {
+        mvc.perform(requestWith("offset", "100")).andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nextOffset").value(100))
+                .andExpect(jsonPath("$.data.hasMore").value(false));
+        verify(consumer, never()).pull(any(), any(MessageSelector.class), anyLong(), anyInt(), anyLong());
+    }
+
+    @Test
+    void rejectsAStaleQueueRoute() throws Exception {
+        when(consumer.fetchSubscribeMessageQueues("orders")).thenReturn(Set.of());
+        mvc.perform(request("TAG", "*")).andExpect(status().isNotFound());
+        verify(consumer, never()).pull(any(), any(MessageSelector.class), anyLong(), anyInt(), anyLong());
+    }
+
+    @Test
+    void reportsBrokerFilterRejectionInsteadOfSilentlyQueryingAllMessages() throws Exception {
+        when(consumer.pull(eq(queue), any(MessageSelector.class), eq(10L), eq(20), eq(3000L)))
+                .thenThrow(new MQBrokerException(1, "Property filtering is disabled"));
+        mvc.perform(request("SQL92", "amount > 100")).andExpect(status().isBadGateway())
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("Property filtering is disabled")));
+        verify(consumer, never()).pull(any(), any(String.class), anyLong(), anyInt());
+    }
+
+    @Test
+    void rejectsANonAdvancingBatchRatherThanOfferingAnEndlessNextButton() throws Exception {
+        when(consumer.pull(eq(queue), any(MessageSelector.class), eq(10L), eq(20), eq(3000L)))
+                .thenReturn(new PullResult(PullStatus.NO_MATCHED_MSG, 10, 10, 100, List.of()));
+        mvc.perform(request("TAG", "*")).andExpect(status().isBadGateway());
+    }
+
+    @Test
+    void preservesInterruptionWhenAFilterPullIsCancelled() throws Exception {
+        when(consumer.pull(eq(queue), any(MessageSelector.class), eq(10L), eq(20), eq(3000L)))
+                .thenThrow(new InterruptedException("Cancelled"));
+        try {
+            mvc.perform(request("TAG", "*")).andExpect(status().isBadGateway());
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"expressionType, JSON", "expression, ''", "queueId, -1", "offset, -1", "topic, ''"})
+    void validatesTheHttpContractBeforeResolvingAnInstance(String field, String value) throws Exception {
+        mvc.perform(requestWith(field, value)).andExpect(status().isBadRequest());
+        verify(resolver, never()).executePullConsumer(any(), any());
+    }
+
+    private MockHttpServletRequestBuilder request(String type, String expression) {
+        var parameters = parameters();
+        parameters.set("expressionType", type);
+        parameters.set("expression", expression);
+        return get("/api/messages/queue-filter-preview").params(parameters);
+    }
+
+    private MockHttpServletRequestBuilder requestWith(String field, String value) {
+        var parameters = parameters();
+        parameters.set(field, value);
+        return get("/api/messages/queue-filter-preview").params(parameters);
+    }
+
+    private LinkedMultiValueMap<String, String> parameters() {
+        var parameters = new LinkedMultiValueMap<String, String>();
+        parameters.set("instanceId", "instance-a");
+        parameters.set("topic", "orders");
+        parameters.set("brokerName", "broker-a");
+        parameters.set("queueId", "0");
+        parameters.set("offset", "10");
+        parameters.set("expressionType", "TAG");
+        parameters.set("expression", "*");
+        return parameters;
+    }
+}

--- a/web/src/api/message.test.ts
+++ b/web/src/api/message.test.ts
@@ -21,6 +21,7 @@ import client from './client';
 import {
   consumeMessageDirectly,
   getMessageTrace,
+  previewQueueFilter,
   queryMessagePage,
   queryMessages,
 } from './message';
@@ -28,6 +29,35 @@ import {
 const mock = new MockAdapter(client);
 
 describe('message API', () => {
+  it('forwards the filter expression, queue cursor and cancellation signal', async () => {
+    const params = {
+      instanceId: 'instance-a',
+      topic: 'orders',
+      brokerName: 'broker-a',
+      queueId: 0,
+      offset: 10,
+      expressionType: 'SQL92' as const,
+      expression: 'amount > 100',
+    };
+    const controller = new AbortController();
+    const page = {
+      items: [],
+      startOffset: 10,
+      nextOffset: 50,
+      minOffset: 10,
+      maxOffset: 100,
+      hasMore: true,
+      offsetAdjusted: false,
+      status: 'NO_MATCHED_MSG',
+    };
+    mock.onGet('/messages/queue-filter-preview').reply((config) => {
+      expect(config.params).toEqual(params);
+      expect(config.signal).toBe(controller.signal);
+      return [200, { code: 200, data: page }];
+    });
+    await expect(previewQueueFilter(params, controller.signal)).resolves.toEqual(page);
+  });
+
   beforeEach(() => {
     mock.reset();
     vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -2,6 +2,9 @@ import client from './client';
 
 // Matches mock/messages.ts
 export interface MessageRecord {
+  bodyEncoding?: string;
+  bodyTruncated?: boolean;
+  propertiesTruncated?: boolean;
   msgId: string;
   topic: string;
   tag: string | null;
@@ -249,6 +252,36 @@ export interface QueueOffset {
   queueId: number;
   minOffset: number;
   maxOffset: number;
+}
+
+export interface QueueFilterPage {
+  items: MessageRecord[];
+  startOffset: number;
+  nextOffset: number;
+  minOffset: number;
+  maxOffset: number;
+  hasMore: boolean;
+  offsetAdjusted: boolean;
+  status: string;
+}
+
+export async function previewQueueFilter(
+  params: {
+    instanceId: string;
+    topic: string;
+    brokerName: string;
+    queueId: number;
+    offset: number;
+    expressionType: 'TAG' | 'SQL92';
+    expression: string;
+  },
+  signal?: AbortSignal,
+) {
+  const response = await client.get<{ data: QueueFilterPage }>('/messages/queue-filter-preview', {
+    params,
+    signal,
+  });
+  return response.data.data;
 }
 
 export async function getQueueOffsets(params: { instanceId: string; topic: string }) {

--- a/web/src/components/QueueBrowser.tsx
+++ b/web/src/components/QueueBrowser.tsx
@@ -34,6 +34,7 @@ import {
 import { CloseOutlined, SearchOutlined } from '@ant-design/icons';
 import type { MessageRecord, QueueOffset } from '../api/message';
 import { getQueueOffsets, pullMessageAtOffset } from '../api/message';
+import QueueFilterPreview from './QueueFilterPreview';
 
 const { Text, Paragraph } = Typography;
 
@@ -61,6 +62,7 @@ export const useQueueBrowser = (instanceId?: string) => {
   const [offsets, setOffsets] = useState<Record<string, number>>({});
   const [pulling, setPulling] = useState<Set<string>>(() => new Set());
   const [entries, setEntries] = useState<PulledEntry[]>([]);
+  const [filterQueue, setFilterQueue] = useState<QueueOffset | null>(null);
   const requestSeqRef = useRef(0);
   const loadingRef = useRef(false);
   const pullingRef = useRef(new Set<string>());
@@ -72,6 +74,7 @@ export const useQueueBrowser = (instanceId?: string) => {
       setQueues([]);
       setOffsets({});
       setEntries([]);
+      setFilterQueue(null);
       loadingRef.current = false;
       setLoading(false);
       pullingRef.current.clear();
@@ -87,6 +90,7 @@ export const useQueueBrowser = (instanceId?: string) => {
     setQueues([]);
     setOffsets({});
     setEntries([]);
+    setFilterQueue(null);
     try {
       const result = await getQueueOffsets({ instanceId, topic });
       if (requestId !== requestSeqRef.current) return;
@@ -145,6 +149,9 @@ export const useQueueBrowser = (instanceId?: string) => {
   };
 
   return {
+    instanceId,
+    filterQueue,
+    setFilterQueue,
     topic,
     setTopic,
     queues,
@@ -280,14 +287,23 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
                 render: (_: unknown, record: QueueOffset) => {
                   const key = `${record.brokerName}-${record.queueId}`;
                   return (
-                    <Button
-                      size="small"
-                      type="primary"
-                      loading={state.pulling.has(key)}
-                      onClick={() => void state.handlePull(record)}
-                    >
-                      查看
-                    </Button>
+                    <Space direction="vertical" size={4}>
+                      <Button
+                        size="small"
+                        type="primary"
+                        loading={state.pulling.has(key)}
+                        onClick={() => void state.handlePull(record)}
+                      >
+                        查看
+                      </Button>
+                      <Button
+                        size="small"
+                        onClick={() => state.setFilterQueue(record)}
+                        aria-label={`Preview filter on ${record.brokerName} queue ${record.queueId}`}
+                      >
+                        Filter
+                      </Button>
+                    </Space>
                   );
                 },
               },
@@ -391,6 +407,19 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
           )}
         </div>
       </Flex>
+    )}
+    {state.filterQueue && state.instanceId && state.topic && (
+      <QueueFilterPreview
+        key={`${state.instanceId}:${state.topic}:${state.filterQueue.brokerName}:${state.filterQueue.queueId}`}
+        instanceId={state.instanceId}
+        topic={state.topic}
+        queue={state.filterQueue}
+        initialOffset={
+          state.offsets[`${state.filterQueue.brokerName}-${state.filterQueue.queueId}`] ??
+          state.filterQueue.minOffset
+        }
+        onClose={() => state.setFilterQueue(null)}
+      />
     )}
   </Card>
 );

--- a/web/src/components/QueueFilterPreview.tsx
+++ b/web/src/components/QueueFilterPreview.tsx
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Descriptions,
+  Drawer,
+  Flex,
+  Input,
+  InputNumber,
+  Select,
+  Table,
+  Typography,
+} from 'antd';
+import { previewQueueFilter } from '../api/message';
+import type { QueueFilterPage, QueueOffset, MessageRecord } from '../api/message';
+
+interface Props {
+  instanceId: string;
+  topic: string;
+  queue: QueueOffset;
+  initialOffset: number;
+  onClose: () => void;
+}
+
+export default function QueueFilterPreview({
+  instanceId,
+  topic,
+  queue,
+  initialOffset,
+  onClose,
+}: Props) {
+  const [offset, setOffset] = useState<number | null>(initialOffset);
+  const [expressionType, setExpressionType] = useState<'TAG' | 'SQL92'>('TAG');
+  const [expression, setExpression] = useState('*');
+  const [result, setResult] = useState<QueueFilterPage | null>(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const activeRequest = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const request = activeRequest;
+    return () => request.current?.abort();
+  }, []);
+
+  const resetResult = () => {
+    setResult(null);
+    setError('');
+  };
+  const scan = async (start: number | null) => {
+    if (start === null || !expression.trim() || activeRequest.current) return;
+    const controller = new AbortController();
+    activeRequest.current = controller;
+    setLoading(true);
+    setError('');
+    try {
+      const page = await previewQueueFilter(
+        {
+          instanceId,
+          topic,
+          brokerName: queue.brokerName,
+          queueId: queue.queueId,
+          offset: start,
+          expressionType,
+          expression,
+        },
+        controller.signal,
+      );
+      if (!controller.signal.aborted) setResult(page);
+    } catch (reason) {
+      if (!controller.signal.aborted)
+        setError(reason instanceof Error ? reason.message : 'Filter preview failed');
+    } finally {
+      activeRequest.current = null;
+      if (!controller.signal.aborted) setLoading(false);
+    }
+  };
+
+  return (
+    <Drawer
+      open
+      title={`Filter preview: ${queue.brokerName} / ${queue.queueId}`}
+      width={860}
+      onClose={onClose}
+    >
+      <Flex vertical gap={16}>
+        <Alert
+          type="info"
+          showIcon
+          message="Inspect broker-filtered messages without changing consumer offsets"
+          description="Each request reads one batch of up to 20 matching messages. Continue explicitly when more offsets remain. SQL92 requires broker property filtering support."
+        />
+        <Descriptions
+          size="small"
+          column={1}
+          items={[{ key: 'topic', label: 'Topic', children: topic }]}
+        />
+        <Flex gap={12} wrap align="center">
+          <Select
+            aria-label="Expression type"
+            value={expressionType}
+            disabled={loading}
+            style={{ width: 130 }}
+            options={[
+              { value: 'TAG', label: 'Tag' },
+              { value: 'SQL92', label: 'SQL92' },
+            ]}
+            onChange={(value) => {
+              setExpressionType(value);
+              setExpression('');
+              resetResult();
+            }}
+          />
+          <InputNumber
+            aria-label="Starting offset"
+            min={0}
+            precision={0}
+            value={offset}
+            disabled={loading}
+            style={{ width: 210 }}
+            onChange={(value) => {
+              setOffset(value);
+              resetResult();
+            }}
+          />
+        </Flex>
+        <Input.TextArea
+          aria-label="Filter expression"
+          rows={3}
+          value={expression}
+          maxLength={4096}
+          disabled={loading}
+          placeholder={
+            expressionType === 'TAG' ? 'TagA || TagB' : "amount > 100 AND region = 'east'"
+          }
+          onChange={(event) => {
+            setExpression(event.target.value);
+            resetResult();
+          }}
+        />
+        <Flex gap={8}>
+          <Button
+            type="primary"
+            aria-label="Preview from offset"
+            loading={loading}
+            disabled={offset === null || !expression.trim()}
+            onClick={() => void scan(offset)}
+          >
+            Preview from offset
+          </Button>
+          <Button
+            disabled={loading || !result?.hasMore}
+            onClick={() => result && void scan(result.nextOffset)}
+          >
+            Next batch
+          </Button>
+        </Flex>
+        {error && <Alert type="error" showIcon message={error} />}
+        {result && (
+          <>
+            {result.offsetAdjusted && (
+              <Alert
+                type="warning"
+                showIcon
+                message="Queue bounds changed or the requested offset is outside retention."
+                description={`The broker returned continuation offset ${result.nextOffset}. Inspect the range before continuing.`}
+              />
+            )}
+            <Typography.Text type="secondary">
+              {`Read from ${result.startOffset}; next offset ${result.nextOffset}; retained range [${result.minOffset}, ${result.maxOffset}).`}
+            </Typography.Text>
+            <Table<MessageRecord>
+              dataSource={result.items}
+              rowKey={(item) => `${item.queueOffset}:${item.msgId}`}
+              size="small"
+              pagination={false}
+              scroll={{ x: 650 }}
+              locale={{
+                emptyText: result.hasMore
+                  ? 'No matches in this batch. Continue to inspect later offsets.'
+                  : 'No matching messages; the queue scan has reached its end.',
+              }}
+              columns={[
+                { title: 'Offset', dataIndex: 'queueOffset', width: 110 },
+                { title: 'Message ID', dataIndex: 'msgId', ellipsis: true },
+                { title: 'Tag', dataIndex: 'tag', width: 140 },
+                {
+                  title: 'Stored at',
+                  dataIndex: 'storeTime',
+                  width: 190,
+                  render: (value: string | number) => new Date(value).toLocaleString(),
+                },
+              ]}
+              expandable={{
+                expandedRowRender: (item) => (
+                  <Flex vertical gap={8}>
+                    <Typography.Text strong>Properties</Typography.Text>
+                    <pre style={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', margin: 0 }}>
+                      {JSON.stringify(item.properties, null, 2)}
+                    </pre>
+                    <Typography.Text
+                      strong
+                    >{`Body (${item.bodyEncoding || 'UTF-8'})`}</Typography.Text>
+                    {(item.bodyTruncated || item.propertiesTruncated) && (
+                      <Alert
+                        type="warning"
+                        message="The displayed body or properties were truncated by the server."
+                      />
+                    )}
+                    <pre style={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', margin: 0 }}>
+                      {item.body}
+                    </pre>
+                  </Flex>
+                ),
+              }}
+            />
+          </>
+        )}
+      </Flex>
+    </Drawer>
+  );
+}

--- a/web/src/components/__tests__/QueueFilterPreview.test.tsx
+++ b/web/src/components/__tests__/QueueFilterPreview.test.tsx
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getQueueOffsets, previewQueueFilter } from '../../api/message';
+import type { QueueFilterPage, MessageRecord } from '../../api/message';
+import QueueFilterPreview from '../QueueFilterPreview';
+import { QueueBrowserResults, useQueueBrowser } from '../QueueBrowser';
+
+vi.mock('../../api/message', () => ({
+  getQueueOffsets: vi.fn(),
+  previewQueueFilter: vi.fn(),
+  pullMessageAtOffset: vi.fn(),
+}));
+
+const queue = { brokerName: 'broker-a', queueId: 0, minOffset: 10, maxOffset: 100 };
+const emptyBatch: QueueFilterPage = {
+  items: [],
+  startOffset: 10,
+  nextOffset: 50,
+  minOffset: 10,
+  maxOffset: 100,
+  hasMore: true,
+  offsetAdjusted: false,
+  status: 'NO_MATCHED_MSG',
+};
+const matched: MessageRecord = {
+  msgId: 'message-a',
+  topic: 'orders',
+  tag: 'paid',
+  key: null,
+  brokerName: 'broker-a',
+  queueId: 0,
+  queueOffset: 55,
+  body: 'event payload',
+  storeTime: '2026-09-08T00:00:00Z',
+  bornHost: '127.0.0.1',
+  storeHost: '127.0.0.1',
+  properties: { amount: '200' },
+  size: 13,
+};
+
+function BrowserHarness() {
+  const state = useQueueBrowser('instance-a');
+  return (
+    <>
+      <button onClick={() => state.setTopic('orders')}>Select topic</button>
+      <button onClick={() => void state.loadQueues()}>Load queues</button>
+      <QueueBrowserResults state={state} />
+    </>
+  );
+}
+
+const renderPreview = () =>
+  render(
+    <QueueFilterPreview
+      instanceId="instance-a"
+      topic="orders"
+      queue={queue}
+      initialOffset={10}
+      onClose={vi.fn()}
+    />,
+  );
+
+describe('QueueFilterPreview', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+    vi.mocked(getQueueOffsets).mockResolvedValue([queue]);
+    vi.mocked(previewQueueFilter).mockResolvedValue(emptyBatch);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('continues after an empty filtered batch and shows the matching message properties', async () => {
+    const user = userEvent.setup();
+    vi.mocked(previewQueueFilter)
+      .mockResolvedValueOnce(emptyBatch)
+      .mockResolvedValueOnce({
+        ...emptyBatch,
+        items: [matched],
+        startOffset: 50,
+        nextOffset: 100,
+        hasMore: false,
+        status: 'FOUND',
+      });
+    renderPreview();
+    await user.click(screen.getByRole('button', { name: 'Preview from offset' }));
+    expect(
+      await screen.findByText('No matches in this batch. Continue to inspect later offsets.'),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Next batch' }));
+    expect(await screen.findByText('message-a')).toBeInTheDocument();
+    expect(previewQueueFilter).toHaveBeenLastCalledWith(
+      expect.objectContaining({ offset: 50 }),
+      expect.any(AbortSignal),
+    );
+    expect(screen.getByRole('button', { name: 'Next batch' })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: 'Expand row' }));
+    expect(screen.getByText('event payload')).toBeInTheDocument();
+    expect(screen.getByText(/"amount": "200"/)).toBeInTheDocument();
+  });
+
+  it('passes SQL92 unchanged and keeps broker rejection visible for correction', async () => {
+    const user = userEvent.setup();
+    vi.mocked(previewQueueFilter).mockRejectedValueOnce(
+      new Error('Property filtering is disabled'),
+    );
+    renderPreview();
+    await user.click(screen.getByRole('combobox', { name: 'Expression type' }));
+    const options = screen.getAllByText('SQL92', { exact: true });
+    await user.click(options[options.length - 1]);
+    fireEvent.change(screen.getByRole('textbox', { name: 'Filter expression' }), {
+      target: { value: "amount > 100 AND region = 'east'" },
+    });
+    await user.click(screen.getByRole('button', { name: 'Preview from offset' }));
+    expect(await screen.findByText('Property filtering is disabled')).toBeInTheDocument();
+    expect(previewQueueFilter).toHaveBeenCalledTimes(1);
+    expect(previewQueueFilter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expressionType: 'SQL92',
+        expression: "amount > 100 AND region = 'east'",
+      }),
+      expect.any(AbortSignal),
+    );
+    expect(screen.getByRole('textbox', { name: 'Filter expression' })).toBeEnabled();
+  });
+
+  it('clears the continuation when the operator edits the expression', async () => {
+    const user = userEvent.setup();
+    renderPreview();
+    await user.click(screen.getByRole('button', { name: 'Preview from offset' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Next batch' })).toBeEnabled());
+    fireEvent.change(screen.getByRole('textbox', { name: 'Filter expression' }), {
+      target: { value: 'paid || shipped' },
+    });
+    expect(screen.getByRole('button', { name: 'Next batch' })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: 'Preview from offset' }));
+    expect(previewQueueFilter).toHaveBeenLastCalledWith(
+      expect.objectContaining({ offset: 10, expression: 'paid || shipped' }),
+      expect.any(AbortSignal),
+    );
+  });
+
+  it('aborts a pending request when the drawer is removed', async () => {
+    let complete!: (page: QueueFilterPage) => void;
+    vi.mocked(previewQueueFilter).mockReturnValue(
+      new Promise((resolve) => {
+        complete = resolve;
+      }),
+    );
+    const { unmount } = renderPreview();
+    fireEvent.click(screen.getByRole('button', { name: 'Preview from offset' }));
+    const signal = vi.mocked(previewQueueFilter).mock.calls[0][1];
+    expect(signal?.aborted).toBe(false);
+    unmount();
+    expect(signal?.aborted).toBe(true);
+    await act(async () => complete(emptyBatch));
+  });
+
+  it('opens from the selected queue and uses its current slider position', async () => {
+    const user = userEvent.setup();
+    render(<BrowserHarness />);
+    await user.click(screen.getByRole('button', { name: 'Select topic' }));
+    await user.click(screen.getByRole('button', { name: 'Load queues' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'Preview filter on broker-a queue 0' }),
+    );
+    expect(screen.getByRole('spinbutton', { name: 'Starting offset' })).toHaveValue('99');
+    await user.click(screen.getByRole('button', { name: 'Preview from offset' }));
+    expect(previewQueueFilter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceId: 'instance-a',
+        topic: 'orders',
+        brokerName: 'broker-a',
+        queueId: 0,
+        offset: 99,
+      }),
+      expect.any(AbortSignal),
+    );
+  });
+});


### PR DESCRIPTION
## 变更目的

在现有队列浏览中增加消费过滤预览，帮助排查“队列里有消息，但消费者的 TAG／SQL92 过滤器没有匹配”的问题。

点击队列行的 `Filter`，从当前 offset 开始使用 Broker 原生过滤器读取一批匹配消息，展开查看消息体和业务属性。空批次仍保留继续位置，用户可以显式读取下一批。

## 实现范围

- 新增只读 `GET /api/messages/queue-filter-preview`，校验实例、队列、非负 offset 和 TAG／SQL92 表达式。
- 通过实例绑定的 Apache pull 客户端读取路由与边界，每次最多执行一次 20 条、3 秒 pull；不自动扫描整条队列，不提交消费位点。
- 返回起点、下一位置、可读范围和位置调整标志，正确处理 `NO_MATCHED_MSG`、`NO_NEW_MSG`、`OFFSET_ILLEGAL` 与 Broker 过滤拒绝。
- 新增队列入口与预览面板：表达式输入、起始位置、显式下一批、消息体／属性展开、截断提示，以及关闭时的请求取消。
- 修改表达式或起点会清除旧继续位置；Broker 拒绝 SQL92 时不降级为无过滤查询。
- 新增中文操作、协议、超时和回滚说明。

已核对 #3314 的订阅一致性／规则冲突诊断，以及 #3360、#3349 的云端过滤模式展示；它们不提供基于实际队列消息的原生过滤预览。本 PR 没有另建订阅模型或客户端 SQL 解释器。

协议依据：[RocketMQ 5.5.0 DefaultMQPullConsumerImpl](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultMQPullConsumerImpl.java) 的 `MessageSelector` 同步 pull 路径。

## 本地验证

基线 `d6dee7d7ccfcf4886f02466ec51452a6928b2cc8`，Java 21、Node 24.18.0，2026-09-08。

```bash
cd server
mvn -B -ntp -Dtest=QueueFilterPreviewTest,RocketMQMessageProviderTest,MessageServiceTest,MessageControllerTest verify
cd ../web
npx vitest run src/components/__tests__/QueueFilterPreview.test.tsx src/components/__tests__/QueueBrowser.test.tsx src/api/message.test.ts src/pages/instance/__tests__/MessagePageAsyncState.test.tsx src/pages/instance/__tests__/MessagePage.test.tsx
npm run build
```

- 后端 80 个测试通过，包含 16 个新增 HTTP／服务／Provider 组合用例；Checkstyle 和打包通过。
- JaCoCo：新增 Provider 预览路径行覆盖率 35/37（94.6%），分支 28/42；Controller 与 Service 委托均覆盖。
- 前端 50 个测试通过；TypeScript 和 Vite 构建通过，修改文件 ESLint 0 错误，仅保留 QueueBrowser 原有两个 Fast Refresh 警告。
- Playwright 使用真实本地页面及受控 GET 响应，验证 SQL92 表达式和 offset 10 被正确发送、空匹配批次可继续到 offset 50、下一批详情显示消息体和属性、到达末尾后禁用继续按钮。没有连接真实集群。
- `git diff --check` 通过；14 个文件，936 行新增、8 行删除，共 944 行。

同一原样上游基线已有 3 个全量后端失败（AuthCorsIntegrationTest 两项、AliyunInstanceProviderTest 一项）和依赖漏洞。本 PR 无新增依赖，相关验证无新增失败；不把增量验证称为项目级全量验收。未执行真实集群 E2E、压力、容量或混沌验证。

SQL92 需要 Broker 属性过滤支持；路由／边界读取有各自 SDK 超时，3 秒是单次 pull 超时，不是整个 HTTP 请求总超时。浏览器取消也不保证已经开始的 Broker RPC 立即终止。

无迁移，直接替换；没有新增配置或数据库字段。回滚本提交即可，无需调整消费组状态。提交含 `[skip ci]`，验证在本地执行。
