### PR TITLE
feat(broker): filter the broker topology by name and address

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2127,6 +2127,7 @@ const translations: Record<string, Record<Lang, string>> = {
   'brokerCluster.httpAddr': { zh: 'HTTP 地址', en: 'HTTP Address' },
   'brokerCluster.grpcAddr': { zh: 'gRPC 地址', en: 'gRPC Address' },
   'brokerCluster.connections': { zh: '连接数', en: 'Connections' },
+  'brokerCluster.searchPlaceholder': { zh: '搜索 Broker 名称或地址', en: 'Search broker name or address' },
 
   'groupMgmt.lagUnavailable': { zh: '不可用', en: 'Unavailable' },
 

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -16,7 +16,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Table, Button, Tag, Tabs, Card, Space, Switch, Progress, Spin, App, Select } from 'antd';
+import { Table, Button, Tag, Tabs, Card, Space, Switch, Progress, Spin, App, Select, Input } from 'antd';
 import {
   ArrowClockwise,
   Cloud,
@@ -190,6 +190,7 @@ const BrokerClusterPage = () => {
   const [proxyData, setProxyData] = useState<ProxyRecord[]>([]);
   const [instances, setInstances] = useState<Instance[]>([]);
   const [selectedInstanceId, setSelectedInstanceId] = useState<string | undefined>(undefined);
+  const [brokerSearch, setBrokerSearch] = useState('');
   const mountedRef = useRef(true);
   const loadRequestId = useRef(0);
   const { t } = useLang();
@@ -200,6 +201,14 @@ const BrokerClusterPage = () => {
     setNameServerData([]);
     setProxyData([]);
   }, []);
+
+  const normalizedBrokerSearch = brokerSearch.trim().toLowerCase();
+  const filteredBrokers = brokerData.filter((broker) => {
+    if (!normalizedBrokerSearch) return true;
+    return [broker.brokerName, broker.address].some((value) =>
+      value.toLowerCase().includes(normalizedBrokerSearch),
+    );
+  });
 
   const loadData = useCallback(async () => {
     if (!selectedInstanceId && !isMockMode()) {
@@ -316,13 +325,13 @@ const BrokerClusterPage = () => {
     }
     downloadCsv(
       `rocketmq-broker-topology-${today}.csv`,
-      buildCsv(BROKER_EXPORT_COLUMNS, brokerData),
+      buildCsv(BROKER_EXPORT_COLUMNS, filteredBrokers),
     );
   }
   const exportDisabled =
     (activeTab === 'nameserver' && nameServerData.length === 0) ||
     (activeTab === 'proxy' && proxyData.length === 0) ||
-    (activeTab === 'broker' && brokerData.length === 0);
+    (activeTab === 'broker' && filteredBrokers.length === 0);
 
   const brokerColumns = [
     {
@@ -582,15 +591,25 @@ const BrokerClusterPage = () => {
                   </span>
                 ),
                 children: (
-                  <Table
-                    columns={brokerColumns}
-                    dataSource={brokerData}
-                    pagination={{
-                      pageSize: 10,
-                      showTotal: (total) => `${t('common.total')} ${total} Broker`,
-                    }}
-                    size="middle"
-                  />
+                  <div>
+                    <Input.Search
+                      placeholder={t('brokerCluster.searchPlaceholder')}
+                      allowClear
+                      value={brokerSearch}
+                      onChange={(e) => setBrokerSearch(e.target.value)}
+                      onSearch={setBrokerSearch}
+                      style={{ width: 320, marginBottom: 16 }}
+                    />
+                    <Table
+                      columns={brokerColumns}
+                      dataSource={filteredBrokers}
+                      pagination={{
+                        pageSize: 10,
+                        showTotal: (total) => `${t('common.total')} ${total} Broker`,
+                      }}
+                      size="middle"
+                    />
+                  </div>
                 ),
               },
               {

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -402,4 +402,40 @@ describe('BrokerCluster Page', () => {
     expect(screen.getByText('N/A')).toBeInTheDocument();
     expect(screen.queryByText('运行中')).not.toBeInTheDocument();
   });
+
+  it('filters the broker table by broker name', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<BrokerCluster />);
+    await screen.findByText('broker-api-a');
+
+    await user.type(screen.getByPlaceholderText('搜索 Broker 名称或地址'), 'api-b');
+
+    expect(screen.getByText('broker-api-b')).toBeInTheDocument();
+    expect(screen.queryByText('broker-api-a')).not.toBeInTheDocument();
+  });
+
+  it('filters the broker table by broker address', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<BrokerCluster />);
+    await screen.findByText('broker-api-a');
+
+    await user.type(screen.getByPlaceholderText('搜索 Broker 名称或地址'), '10.0.1.10');
+
+    expect(screen.getByText('broker-api-a')).toBeInTheDocument();
+    expect(screen.queryByText('broker-api-b')).not.toBeInTheDocument();
+  });
+
+  it('exports only the filtered broker rows', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<BrokerCluster />);
+    await screen.findByText('broker-api-a');
+
+    await user.type(screen.getByPlaceholderText('搜索 Broker 名称或地址'), 'api-b');
+    await user.click(screen.getByRole('button', { name: '导出' }));
+
+    expect(downloadCsv).toHaveBeenCalledTimes(1);
+    const brokerCsv = vi.mocked(downloadCsv).mock.calls[0][1];
+    expect(brokerCsv).toContain('"broker-api-b"');
+    expect(brokerCsv).not.toContain('"broker-api-a"');
+  });
 });


### PR DESCRIPTION
## Summary

Add a search box above the broker topology table that filters the currently loaded brokers by name or address (trim + lowercase substring match, following the certs page `normalizedSearch` pattern). The filter is client-side only — it never refetches from the API. Export exports the filtered rows (what you see is what you export), and the export button is disabled when the filter yields zero broker rows.

## Why

With many brokers in a topology it is hard to locate one instance. Filtering the loaded rows by name/address keeps the change purely front-end and consistent with the existing search UX on the certificates and clients pages.

## Testing

- Local type-check: `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` → exit 0.
- Server Node 20: `./node_modules/.bin/vitest run src/pages/studio/__tests__/BrokerCluster.test.tsx` → all tests green.
- New tests (existing tests did not cover filtering):
  - filters the broker table by broker name;
  - filters the broker table by broker address;
  - exports only the filtered broker rows.
