### PR TITLE
feat(ai): copy the latest assistant answer

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -940,6 +940,9 @@ const translations: Record<string, Record<Lang, string>> = {
   // ─── AI Page ───
   'ai.title': { zh: 'AI 交互', en: 'AI Chat' },
   'ai.commonCommands': { zh: '常用指令', en: 'Common Commands' },
+  'ai.copyLatestAnswer': { zh: '复制最新回答', en: 'Copy Latest Answer' },
+  'ai.copyAnswerSuccess': { zh: '回答已复制', en: 'Answer copied' },
+  'ai.copyAnswerFailed': { zh: '复制失败', en: 'Copy failed' },
   'ai.mockProviderDisabled': {
     zh: 'Mock 模式已禁用 AI Provider 调用',
     en: 'Mock mode disables AI provider calls',

--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -536,4 +536,41 @@ describe('AiPage tool runner', () => {
     expect(await screen.findByText('工具参数必须是有效的 JSON 对象')).toBeInTheDocument();
     expect(executeTool).not.toHaveBeenCalled();
   });
+
+  it('copies the latest assistant answer to the clipboard', async () => {
+    vi.mocked(chatStream).mockImplementation(async (_request, onChunk) => {
+      onChunk('集群状态正常');
+    });
+    // userEvent.setup() replaces navigator.clipboard with its own stub, so install
+    // the mocked writeText afterwards (and restore the stub when the test ends).
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    try {
+      renderPage({ prompt: '检查集群状态' });
+
+      const copyButton = await screen.findByRole('button', { name: '复制最新回答' });
+      await waitFor(() => expect(copyButton).not.toBeDisabled());
+      await user.click(copyButton);
+
+      await waitFor(() => expect(writeText).toHaveBeenCalledWith('集群状态正常'));
+      expect(await screen.findByText('回答已复制')).toBeInTheDocument();
+    } finally {
+      if (originalClipboard) {
+        Object.defineProperty(navigator, 'clipboard', originalClipboard);
+      } else {
+        Reflect.deleteProperty(navigator, 'clipboard');
+      }
+    }
+  });
+
+  it('disables the copy button when there is no assistant answer', async () => {
+    renderPage();
+
+    expect(await screen.findByRole('button', { name: '复制最新回答' })).toBeDisabled();
+  });
 });

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -45,6 +45,7 @@ import {
   ArrowUp,
   CaretDown,
   ClockCounterClockwise,
+  Copy,
   SlidersHorizontal,
   Sparkle,
   Stop,
@@ -110,6 +111,27 @@ interface Message {
   pending?: boolean;
   actions?: { label: string; type?: 'primary' | 'default' }[];
 }
+
+/* ─── Clipboard helpers ─── */
+
+const writeClipboardText = async (text: string): Promise<void> => {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const copied = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    if (!copied) {
+      throw new Error('Clipboard copy is not supported');
+    }
+  }
+};
 
 /* ─── Mock Data ─── */
 
@@ -459,6 +481,26 @@ const AiPage = () => {
   );
   const messages = useMemo(() => activeConversation?.messages ?? [], [activeConversation]);
   const legacyMessageTimestamp = activeConversation?.updatedAt || undefined;
+  const latestAssistantMessage = useMemo(() => {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const item = messages[index];
+      if (item.role === 'ai' && Boolean(item.summary || item.text)) {
+        return item;
+      }
+    }
+    return null;
+  }, [messages]);
+  const latestAnswerText = latestAssistantMessage?.summary || latestAssistantMessage?.text || '';
+
+  const handleCopyLatestAnswer = async () => {
+    if (!latestAnswerText) return;
+    try {
+      await writeClipboardText(latestAnswerText);
+      message.success(t('ai.copyAnswerSuccess'));
+    } catch {
+      message.error(t('ai.copyAnswerFailed'));
+    }
+  };
   const updateMessages = useAiChatHistoryStore((state) => state.setMessages);
   const startConversation = useAiChatHistoryStore((state) => state.startConversation);
   const selectConversation = useAiChatHistoryStore((state) => state.selectConversation);
@@ -1112,6 +1154,18 @@ const AiPage = () => {
                     >
                       <Sparkle size={17} />
                       <span>Prompt 增强</span>
+                    </button>
+                    <button
+                      className="tool-btn"
+                      disabled={!latestAnswerText}
+                      title={t('ai.copyLatestAnswer')}
+                      onClick={() => void handleCopyLatestAnswer()}
+                      style={
+                        latestAnswerText ? undefined : { opacity: 0.5, cursor: 'not-allowed' }
+                      }
+                    >
+                      <Copy size={17} />
+                      <span>{t('ai.copyLatestAnswer')}</span>
                     </button>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

Add a "复制最新回答" (Copy Latest Answer) button to the AI page bottom toolbar. It copies the text of the latest assistant message in the current conversation via `navigator.clipboard.writeText`, with a textarea + `document.execCommand('copy')` fallback, and shows success/error toasts. The button is disabled when the current conversation has no assistant message with content.

Field notes (per the actual page structure, which differs slightly from the issue description): assistant messages use `role: 'ai'` (not `'assistant'`), and the streamed answer text lives in the `summary` field (`text` is only set on user messages). The copy handler therefore reads `summary || text` of the last `ai`-role message.

## Why

Copying a long generated answer currently requires manual selection in the chat area. A one-click copy action is a small, common quality-of-life improvement for the assistant workflow.

## Testing

- Local type-check: `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` → exit 0.
- Server Node 20: `./node_modules/.bin/vitest run src/pages/ai/__tests__/AiPage.test.tsx` → all tests green.
- New tests (existing tests did not cover clipboard behavior):
  - copies the latest assistant answer to the clipboard (mocked `navigator.clipboard.writeText`, asserts the streamed answer text and the success toast);
  - disables the copy button when there is no assistant answer.
