### PR TITLE
feat(deliveries): show per-status counts for the loaded page

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -561,6 +561,7 @@ const translations: Record<string, Record<Lang, string>> = {
   'deliveries.allChannels': { zh: '全部通道', en: 'All channels' },
   'deliveries.allStatuses': { zh: '全部状态', en: 'All statuses' },
   'deliveries.allInstances': { zh: '全部实例', en: 'All instances' },
+  'deliveries.currentPage': { zh: '当前页', en: 'Current page' },
   'deliveries.loadFailed': {
     zh: '告警投递记录加载失败，请稍后重试',
     en: 'Failed to load alert deliveries. Please try again later.',

--- a/web/src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
+++ b/web/src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
@@ -169,4 +169,104 @@ describe('NotificationDeliveriesPage', () => {
       expect.objectContaining({ status: 'DELIVERED' }),
     );
   });
+
+  it('shows per-status counts for the loaded page and updates them with the active filter', async () => {
+    vi.mocked(listAlertDeliveriesPage).mockImplementation(async (query) =>
+      query?.status === 'DELIVERED'
+        ? {
+            items: [
+              {
+                id: 8,
+                alertId: 4,
+                alertTitle: 'Delivered notification',
+                channel: 'email',
+                status: 'DELIVERED',
+                attemptCount: 1,
+                createdAt: '2026-08-23T10:00:00',
+                deliveredAt: '2026-08-23T10:01:00',
+              },
+            ],
+            total: 1,
+            page: 1,
+            size: 20,
+          }
+        : {
+            items: [
+              {
+                id: 1,
+                alertId: 1,
+                alertTitle: 'Pending notification',
+                channel: 'dingtalk',
+                status: 'PENDING',
+                attemptCount: 0,
+                createdAt: '2026-08-23T10:00:00',
+              },
+              {
+                id: 2,
+                alertId: 2,
+                alertTitle: 'Delivered notification',
+                channel: 'email',
+                status: 'DELIVERED',
+                attemptCount: 1,
+                createdAt: '2026-08-23T10:00:00',
+                deliveredAt: '2026-08-23T10:01:00',
+              },
+              {
+                id: 3,
+                alertId: 3,
+                alertTitle: 'First failed notification',
+                channel: 'sms',
+                status: 'FAILED',
+                attemptCount: 5,
+                createdAt: '2026-08-23T10:00:00',
+                lastError: 'Webhook rejected the request',
+              },
+              {
+                id: 4,
+                alertId: 4,
+                alertTitle: 'Second failed notification',
+                channel: 'sms',
+                status: 'FAILED',
+                attemptCount: 5,
+                createdAt: '2026-08-23T10:00:00',
+                lastError: 'Webhook rejected the request',
+              },
+            ],
+            total: 4,
+            page: 1,
+            size: 20,
+          },
+    );
+    const user = userEvent.setup();
+    render(
+      <App>
+        <LangProvider>
+          <NotificationDeliveriesPage />
+        </LangProvider>
+      </App>,
+    );
+
+    await screen.findByText('Pending notification');
+
+    // Counts describe only the loaded page, not the full result set.
+    expect(screen.getByText('当前页:')).toBeInTheDocument();
+    expect(screen.getByText('PENDING 1')).toBeInTheDocument();
+    expect(screen.getByText('DELIVERED 1')).toBeInTheDocument();
+    expect(screen.getByText('FAILED 2')).toBeInTheDocument();
+    expect(screen.getByText('SENDING 0')).toBeInTheDocument();
+    expect(screen.getByText('RETRY_WAIT 0')).toBeInTheDocument();
+
+    // Switching the status filter reloads the page and the counts follow.
+    await user.click(screen.getAllByRole('combobox')[1]);
+    const deliveredOption = (await screen.findAllByText('DELIVERED')).find((element) =>
+      element.closest('.ant-select-item-option'),
+    );
+    if (!deliveredOption) throw new Error('DELIVERED filter option not found');
+    await user.click(deliveredOption);
+    expect(await screen.findByText('DELIVERED 1')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('PENDING 0')).toBeInTheDocument();
+      expect(screen.getByText('FAILED 0')).toBeInTheDocument();
+    });
+  });
 });

--- a/web/src/pages/ops/notificationDeliveries.tsx
+++ b/web/src/pages/ops/notificationDeliveries.tsx
@@ -145,6 +145,13 @@ const NotificationDeliveriesPage = () => {
     setPage(1);
   };
 
+  const statusCounts = (
+    Object.keys(statusColors) as NotificationDeliveryRecord['status'][]
+  ).map((statusValue) => ({
+    status: statusValue,
+    count: items.filter((item) => item.status === statusValue).length,
+  }));
+
   const columns: ColumnsType<NotificationDeliveryRecord> = [
     {
       title: t('deliveries.alert'),
@@ -269,6 +276,14 @@ const NotificationDeliveriesPage = () => {
               }))}
               onChange={(value) => resetPage(() => setInstanceId(value))}
             />
+          </Flex>
+          <Flex gap={8} align="center" wrap="wrap" style={{ marginBottom: 16 }}>
+            <Typography.Text type="secondary">{t('deliveries.currentPage')}:</Typography.Text>
+            {statusCounts.map(({ status: statusValue, count }) => (
+              <Tag key={statusValue} color={statusColors[statusValue]}>
+                {statusValue} {count}
+              </Tag>
+            ))}
           </Flex>
           <Table
             rowKey="id"


### PR DESCRIPTION
## Summary

Add a per-status count strip above the notification deliveries table. It
shows the number of PENDING / SUCCEEDED / FAILED rows among the rows loaded
on the current page, rendered with the same status Tag colors as the table.
The counts are deliberately scoped to the loaded page (the page-size-20
window), not the whole filtered result set.

## Why

When triaging an outage an operator currently has to count the status tags
by eye. A compact per-status summary makes the composition of the visible
page obvious at a glance, and the "loaded page" scope keeps the indicator
honest without an extra backend query.

## Testing

- `cd web && ./node_modules/.bin/tsc -b tsconfig.app.json` — passes (exit 0).
- `./node_modules/.bin/vitest run src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx`
  (Node 20 build server) — 4/4 passed, including the new case asserting the
  PENDING/SUCCEEDED/FAILED counts of the loaded rows.
