### PR TITLE
[studio] fix(ai): preserve whitespace-only streaming chunks

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
@@ -270,7 +270,8 @@ public class OpenAiCompatibleLlmClient {
             return true;
         }
         String token = parseDelta(data);
-        if (StringUtils.hasText(token)) {
+        // Whitespace-only deltas carry formatting and must reach the consumer.
+        if (StringUtils.hasLength(token)) {
             tokenConsumer.accept(token);
         }
         return false;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
@@ -208,7 +208,8 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
     }
 
     private void emitEnhanceChunk(LlmSseSession session, String chunk) {
-        if (!StringUtils.hasText(chunk)) {
+        // Preserve whitespace in the streamed prompt preview.
+        if (!StringUtils.hasLength(chunk)) {
             return;
         }
         try {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
@@ -23,6 +23,8 @@ import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -153,6 +155,55 @@ class OpenAiCompatibleLlmClientTest {
         assertThat(tokens).containsExactly("hel", "lo");
         assertThat(requestBody.get().path("model").asText()).isEqualTo("gpt-test");
         assertThat(requestBody.get().path("stream").asBoolean()).isTrue();
+    }
+
+    @Test
+    void streamShouldIgnoreNonContentDeltasAndStopAtDoneTest() {
+        server.createContext("/v1/chat/completions", exchange -> respond(exchange, 200, """
+                data: {"choices":[{"delta":{"role":"assistant"}}]}
+
+                data: {"choices":[{"delta":{"content":""}}]}
+
+                data: {"choices":[{"delta":{"content":null}}]}
+
+                data: {"choices":[{"delta":{"content":"hello"}}]}
+
+                data: {"choices":[{"delta":{},"finish_reason":"stop"}]}
+
+                data: {"choices":[],"usage":{"completion_tokens":1}}
+
+                data: [DONE]
+
+                data: {"choices":[{"delta":{"content":"ignored"}}]}
+
+                """, "text/event-stream"));
+
+        List<String> tokens = new ArrayList<>();
+        client.stream(config("openai", "sk-test"), "hello", null, tokens::add);
+
+        assertThat(tokens).containsExactly("hello");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {" ", "\n", "\r\n", "\t", "    ", "\n\n"})
+    void streamShouldPreserveWhitespaceOnlyDeltasTest(String whitespace) throws Exception {
+        String whitespaceJson = objectMapper.writeValueAsString(whitespace);
+        server.createContext("/v1/chat/completions", exchange -> respond(exchange, 200, """
+                data: {"choices":[{"delta":{"content":"hello"}}]}
+
+                data: {"choices":[{"delta":{"content":%s}}]}
+
+                data: {"choices":[{"delta":{"content":"world"}}]}
+
+                data: [DONE]
+
+                """.formatted(whitespaceJson), "text/event-stream"));
+
+        List<String> tokens = new ArrayList<>();
+        client.stream(config("openai", "sk-test"), "hello", null, tokens::add);
+
+        assertThat(tokens).containsExactly("hello", whitespace, "world");
+        assertThat(String.join("", tokens)).isEqualTo("hello" + whitespace + "world");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGatewayTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGatewayTest.java
@@ -266,6 +266,42 @@ class OpenAiCompatibleLlmGatewayTest {
         }
     }
 
+    @Test
+    void httpEnhanceShouldPreserveWhitespaceOnlyChunksTest() throws Exception {
+        ExecutorService executor = singleChatExecutor();
+        List<RecordingSseEmitter> emitters = new CopyOnWriteArrayList<>();
+        OpenAiCompatibleLlmGateway testedGateway = gateway(executor, emitters);
+        LlmConfigVO config = config("openai", "sk-test");
+        when(configService.getConfig()).thenReturn(config);
+        when(llmClient.supports(config)).thenReturn(true);
+        doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            Consumer<String> consumer = invocation.getArgument(3, Consumer.class);
+            List.of("", "hello", " ", "world", "\n", "\r\n", "\t", "    ", "next").forEach(consumer);
+            return null;
+        }).doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            Consumer<String> consumer = invocation.getArgument(3, Consumer.class);
+            consumer.accept("answer");
+            return null;
+        }).when(llmClient).stream(any(), any(), any(), any());
+        try {
+            testedGateway.chat(ChatDTO.builder().message("raw prompt").enhance(true).build());
+            RecordingSseEmitter emitter = emitters.get(0);
+            assertThat(emitter.completedLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+            assertThat(emitter.eventCount("event:enhance")).isEqualTo(8);
+            assertThat(emitter.eventText())
+                    .contains("{\"delta\":\" \"}", "{\"delta\":\"\\n\"}", "{\"delta\":\"\\r\\n\"}",
+                            "{\"delta\":\"\\t\"}", "{\"delta\":\"    \"}", "{\"text\":\"answer\"}")
+                    .doesNotContain("{\"delta\":\"\"}", "event:error");
+            assertThat(emitter.eventCount("event:done")).isEqualTo(1);
+            verify(llmClient).stream(eq(config), eq("hello world\n\r\n\t    next"), any(), any());
+        } finally {
+            testedGateway.destroy();
+        }
+    }
+
     private OpenAiCompatibleLlmGateway gateway(ExecutorService executor,
                                                 List<RecordingSseEmitter> emitters) {
         return new OpenAiCompatibleLlmGateway(


### PR DESCRIPTION
Fixes #4108

## 修复内容

AI 流式响应中的纯空白 content 是有效正文，但 `StringUtils.hasText` 会将其丢弃，导致空格、换行和缩进缺失。

- 客户端改为仅忽略 null/空字符串，保留纯空白 SSE delta。
- 提示词增强预览使用相同规则，避免增强事件再次过滤空白。
- 增加 6 种空白片段的参数化测试，以及无 content/空 content/`[DONE]` 对照测试和增强预览回归测试。

范围：2 个生产代码文件、2 个测试文件；基于 `rocketmq-studio` 的 `d6dee7d7`。

## 验证

修改前，仅加入回归测试：8 个执行用例中 7 个失败、1 个通过；失败分别对应 6 种空白片段丢失和增强预览事件缺失。

修改后，在 Java 21 下执行：

```bash
cd server
mvn -B -ntp -Dtest=OpenAiCompatibleLlmClientTest,OpenAiCompatibleLlmGatewayTest test
```

39 个测试通过，Checkstyle 0 违规。客户端使用本地 HTTP 模拟服务，网关使用 Mock，不依赖真实模型或 API Key。

前端既有 SSE API 测试：

```bash
cd web
npm test -- src/api/ai.test.ts
```

17 个测试通过。

本地未运行全量后端测试；修复后的真实模型浏览器效果尚待人工复测。
