### PR TITLE
feat(group): adjust one offline queue consumer offset precisely

### DIFF
--- a/docs/single-queue-consumer-offset.md
+++ b/docs/single-queue-consumer-offset.md
@@ -1,0 +1,60 @@
+# 单队列消费位点调整
+
+消费组详情的队列进度表新增 `Set offset`，用于将一个队列的 Broker 持久化消费位点调整到明确位置。
+例如只回放 `orders / broker-a / Queue 1` 的一段消息，而不改变同 Topic 其他队列的位置。
+
+## 操作前提
+
+本功能面向传统集群消费的离线维护。先停止该消费组全部消费者，并保持停止直到操作完成。
+它不会停止应用进程，也不会处理 POP 的不可见消息或广播客户端的本地位点。
+页面对云实例、Mock 模式以及已识别的 POP／广播组禁用入口。
+启用登录校验时，预览和提交接口均需要管理员权限。
+
+## 使用流程
+
+1. 选择 Apache 实例，打开消费组详情的队列进度页。
+2. 在目标队列行点击 `Set offset`，核对实例、消费组、Topic、Broker 和 Queue ID。
+3. 输入目标整数位点，点击 `Preview change`。
+4. 查看当前位点、保留范围、回放／跳过的位置数量与预计积压。
+5. 确认后点击 `Confirm queue offset`。成功后刷新当前消费组进度，再按维护计划恢复应用。
+
+目标范围为 `[minOffset, maxOffset]`，`maxOffset` 是下一条消息的位置，可用来跳过当前积压。
+数量表示队列位置差，不保证等同于业务过滤后实际处理的消息条数。
+输入、预览和提交中的位点均使用十进制字符串，避免超过 JavaScript 安全整数范围时丢失精度。
+修改目标位点会清除预览；无变化的预览不能确认提交。
+
+## 服务端检查
+
+接口从所选实例的 Topic 路由解析指定 Broker 的主节点，不接受客户端指定网络地址，也不回退到从节点。
+查询目标主节点的消费组连接，在线、权限失败或无法确认状态时拒绝调整。
+只有原生 `CONSUMER_NOT_ONLINE` 或空连接集合被视为该节点的离线观测。
+预览读取队列保留范围及已有消费位点，缺失值不当成零。
+提交会重新读取连接、范围和消费位点，并要求当前位点与预览一致；否则返回 409，要求重新预览。
+
+这些检查不是分布式锁或原子比较交换。客户端可能在检查后重新连接，因此操作期间必须由运维保持消费组停止。
+目标主节点的连接观测不代表所有其他 Broker 的全局状态。
+各 RPC 使用现有超时，网络错误后结果可能不确定；页面不会自动重试。
+
+## 接口和实现依据
+
+```http
+POST /api/groups/queue-offset/preview
+POST /api/groups/queue-offset
+Content-Type: application/json
+
+{"instanceId":"instance-a","group":"cg-orders","topic":"orders","brokerName":"broker-a","queueId":1,"offset":"20","expectedCurrentOffset":"40"}
+```
+
+预览不要求 `expectedCurrentOffset`；提交必须携带预览返回的 `currentOffset`。
+成功结果返回本次检查的旧位点、目标和影响；不声称已对消费者应用做端到端验证。
+写入使用 SDK 的 `updateConsumeOffset`，只发送指定队列的 `UPDATE_CONSUMER_OFFSET`。
+不使用 `resetOffsetByQueueId`，因为该 SDK 方法还会调用按时间重置协议，旧 Broker 路径可能忽略 Queue ID 并影响其他队列。
+相关原文见 [DefaultMQAdminExtImpl](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java)。
+
+审计操作名为 `SET_QUEUE_CONSUMER_OFFSET`，保存实例、消费组、队列、原位置、目标和结果。
+审计存储失败不会把已接受的 Broker 写入改报失败。
+没有新增依赖、配置或数据库字段。无迁移，直接部署；回滚代码移除入口和接口。
+数据回滚需在消费者仍停止时，根据审计中的原位置重新调整，且原位置必须仍在保留范围内。
+
+本地验证覆盖 HTTP、真实实例解析及管理客户端包装、模拟 SDK、权限、审计、范围漂移与前端确认流程。
+真实集群 E2E、性能、压力、容量与混沌测试尚未执行。浏览器检查只使用本地受控响应。最后核对日期：2026-09-08。

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/QueueOffsetCommand.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/QueueOffsetCommand.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record QueueOffsetCommand(@NotBlank String instanceId, @NotBlank String group,
+                                 @NotBlank String topic, @NotBlank String brokerName,
+                                 @NotNull @Min(0) Integer queueId,
+                                 @NotBlank @Pattern(regexp = "0|[1-9][0-9]{0,18}") String offset,
+                                 String expectedCurrentOffset) {
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/QueueOffsetController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/QueueOffsetController.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import org.apache.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/groups/queue-offset")
+@RequiredArgsConstructor
+public class QueueOffsetController {
+    private final QueueOffsetService service;
+
+    @PostMapping("/preview")
+    public Result<QueueOffsetPreview> preview(@Valid @RequestBody QueueOffsetCommand request) {
+        return Result.ok(service.preview(request));
+    }
+
+    @PostMapping
+    public Result<QueueOffsetPreview> apply(@Valid @RequestBody QueueOffsetCommand request) {
+        return Result.ok(service.apply(request));
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/QueueOffsetPreview.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/QueueOffsetPreview.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+/** Decimal strings preserve physical queue positions across JSON and browser boundaries. */
+public record QueueOffsetPreview(String brokerAddress, String currentOffset, String targetOffset,
+                                 String minOffset, String maxOffset, String offsetDelta, String projectedLag) {
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/QueueOffsetService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/QueueOffsetService.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QueueOffsetService {
+    private static final long READ_TIMEOUT_MS = 5000;
+    private final RuntimeAdminClientResolver resolver;
+    private final OperationAuditService audit;
+
+    public QueueOffsetPreview preview(QueueOffsetCommand request) {
+        long offset = parseOffset(request.offset());
+        return resolver.execute(request.instanceId(), admin -> inspect(admin, request, offset));
+    }
+
+    public QueueOffsetPreview apply(QueueOffsetCommand request) {
+        long offset = parseOffset(request.offset());
+        long expected = parseOffset(request.expectedCurrentOffset());
+        return resolver.execute(request.instanceId(), admin -> {
+            var preview = inspect(admin, request, offset);
+            if (Long.parseLong(preview.currentOffset()) != expected) {
+                throw new BusinessException(409, "Consumer offset changed; inspect the queue again");
+            }
+            var queue = queue(request);
+            try {
+                // Do not use resetOffsetByQueueId: its second RPC can reset every topic queue
+                // when the broker uses the legacy client-side timestamp reset protocol.
+                admin.updateConsumeOffset(preview.brokerAddress(), request.group().trim(), queue, offset);
+            } catch (Exception failure) {
+                if (failure instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+                record(request, preview, "FAILED", failure.getMessage());
+                throw failure;
+            }
+            record(request, preview, "SUCCESS", null);
+            return preview;
+        });
+    }
+
+    private QueueOffsetPreview inspect(MQAdminExt admin, QueueOffsetCommand request, long target) throws Exception {
+        var queue = queue(request);
+        var route = admin.examineTopicRouteInfo(queue.getTopic());
+        String address = route.getBrokerDatas().stream()
+                .filter(broker -> queue.getBrokerName().equals(broker.getBrokerName()))
+                .map(broker -> broker.getBrokerAddrs().get(0L)).filter(value -> value != null && !value.isBlank())
+                .findFirst().orElseThrow(() -> new BusinessException(409, "Queue has no registered master"));
+        requireOffline(admin, request.group().trim(), address);
+        var stats = admin.examineTopicStats(queue.getTopic());
+        var range = stats.getOffsetTable().get(queue);
+        if (range == null) {
+            throw new BusinessException(404, "Queue is not present in the topic");
+        }
+        long min = range.getMinOffset();
+        long max = range.getMaxOffset();
+        if (min < 0 || max < min || target < min || target > max) {
+            throw new BusinessException(409, "Target offset is outside the readable queue range");
+        }
+        var consumption = admin.examineConsumeStats(address, request.group().trim(), queue.getTopic(), READ_TIMEOUT_MS);
+        var current = consumption.getOffsetTable().get(queue);
+        if (current == null || current.getConsumerOffset() < 0) {
+            throw new BusinessException(409, "Queue has no committed consumer offset");
+        }
+        long currentOffset = current.getConsumerOffset();
+        return new QueueOffsetPreview(address, Long.toString(currentOffset), Long.toString(target),
+                Long.toString(min), Long.toString(max), Long.toString(target - currentOffset), Long.toString(max - target));
+    }
+
+    private void requireOffline(MQAdminExt admin, String group, String address) throws Exception {
+        try {
+            var connections = admin.examineConsumerConnectionInfo(group, address);
+            if (connections == null || !connections.getConnectionSet().isEmpty()) {
+                throw new BusinessException(409, "Stop all consumers before changing a queue offset");
+            }
+        } catch (MQClientException failure) {
+            if (failure.getResponseCode() != ResponseCode.CONSUMER_NOT_ONLINE) {
+                throw failure;
+            }
+        } catch (MQBrokerException failure) {
+            if (failure.getResponseCode() != ResponseCode.CONSUMER_NOT_ONLINE) {
+                throw failure;
+            }
+        }
+    }
+
+    private long parseOffset(String value) {
+        try {
+            long offset = Long.parseLong(value);
+            if (offset < 0) {
+                throw new NumberFormatException();
+            }
+            return offset;
+        } catch (NumberFormatException failure) {
+            throw new BusinessException(400, "A non-negative 64-bit offset is required");
+        }
+    }
+
+    private MessageQueue queue(QueueOffsetCommand request) {
+        return new MessageQueue(request.topic().trim(), request.brokerName().trim(), request.queueId());
+    }
+
+    private void record(QueueOffsetCommand request, QueueOffsetPreview preview, String result, String error) {
+        audit.record("SET_QUEUE_CONSUMER_OFFSET", "CONSUMER_GROUP", request.group().trim(), request.instanceId(),
+                "topic=" + request.topic().trim() + ", broker=" + request.brokerName().trim()
+                        + ", queueId=" + request.queueId() + ", previous=" + preview.currentOffset()
+                        + ", target=" + preview.targetOffset(), result, error);
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
@@ -42,6 +42,20 @@ import static org.mockito.Mockito.when;
 
 class AuthInterceptorTest {
 
+    @ParameterizedTest
+    @ValueSource(strings = {"/api/groups/queue-offset", "/api/groups/queue-offset/preview"})
+    void singleQueueOffsetChangesRequireAdmin(String path) throws Exception {
+        TestSession reader = login(false);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        assertThat(reader.interceptor().preHandle(authenticatedRequest("POST", path, reader.token()),
+                response, new Object())).isFalse();
+        assertThat(response.getStatus()).isEqualTo(403);
+
+        TestSession admin = login(true);
+        assertThat(admin.interceptor().preHandle(authenticatedRequest("POST", path, admin.token()),
+                new MockHttpServletResponse(), new Object())).isTrue();
+    }
+
     @Test
     void shouldResolveAuthenticatedUserOnlyOncePerRequest() throws Exception {
         AuthProperties properties = new AuthProperties();

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/QueueOffsetTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/QueueOffsetTest.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.remoting.protocol.admin.ConsumeStats;
+import org.apache.rocketmq.remoting.protocol.admin.OffsetWrapper;
+import org.apache.rocketmq.remoting.protocol.admin.TopicOffset;
+import org.apache.rocketmq.remoting.protocol.admin.TopicStatsTable;
+import org.apache.rocketmq.remoting.protocol.body.ConsumerConnection;
+import org.apache.rocketmq.remoting.protocol.body.Connection;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminProperties;
+import org.apache.rocketmq.studio.cluster.broker.MqClientPool;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.GlobalExceptionHandler;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.studio.persistence.entity.RmqOperationAudit;
+import org.apache.rocketmq.studio.persistence.mapper.RmqOperationAuditMapper;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+class QueueOffsetTest {
+    private static final MessageQueue QUEUE = new MessageQueue("orders", "broker-a", 1);
+    private final DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+    private final InstanceRepository instances = mock(InstanceRepository.class);
+    private final RmqOperationAuditMapper audits = mock(RmqOperationAuditMapper.class);
+    private final MqAdminExtFactory factory = new MqAdminExtFactory() {
+        @Override
+        protected DefaultMQAdminExt newAdmin(RPCHook hook) {
+            return admin;
+        }
+    };
+    private final TopicStatsTable topic = new TopicStatsTable();
+    private final ConsumeStats consumption = new ConsumeStats();
+    private final TopicOffset range = new TopicOffset();
+    private final OffsetWrapper current = new OffsetWrapper();
+    private QueueOffsetService service;
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        when(instances.findByIdentifier("instance-a")).thenReturn(Optional.of(InstanceVO.builder()
+                .name("instance-a").vendor(InstanceVendor.APACHE).endpoint("selected:9876").build()));
+        var resolver = new RuntimeAdminClientResolver(instances, factory, new MqAdminProperties(), new MqClientPool());
+        service = new QueueOffsetService(resolver, new OperationAuditService(audits));
+        var route = new TopicRouteData();
+        route.setBrokerDatas(List.of(new BrokerData("cluster-a", "broker-a",
+                new HashMap<>(Map.of(0L, "master:10911", 1L, "replica:10911")))));
+        when(admin.examineTopicRouteInfo("orders")).thenReturn(route);
+        when(admin.examineConsumerConnectionInfo("cg-orders", "master:10911"))
+                .thenReturn(new ConsumerConnection());
+        range.setMinOffset(10);
+        range.setMaxOffset(100);
+        topic.getOffsetTable().put(QUEUE, range);
+        when(admin.examineTopicStats("orders")).thenReturn(topic);
+        current.setConsumerOffset(40);
+        consumption.getOffsetTable().put(QUEUE, current);
+        when(admin.examineConsumeStats("master:10911", "cg-orders", "orders", 5000)).thenReturn(consumption);
+        mvc = MockMvcBuilders.standaloneSetup(new QueueOffsetController(service))
+                .setControllerAdvice(new GlobalExceptionHandler()).build();
+    }
+
+    @AfterEach
+    void close() {
+        Thread.interrupted();
+        factory.shutdown();
+    }
+
+    @Test
+    void httpPreviewShowsReplayAndDoesNotWriteOffsets() throws Exception {
+        mvc.perform(post("/api/groups/queue-offset/preview").contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsBytes(request("20", null))))
+                .andExpect(jsonPath("$.data.currentOffset").value("40"))
+                .andExpect(jsonPath("$.data.targetOffset").value("20"))
+                .andExpect(jsonPath("$.data.offsetDelta").value("-20"))
+                .andExpect(jsonPath("$.data.projectedLag").value("80"));
+        verify(admin, never()).updateConsumeOffset(anyString(), anyString(), any(), anyLong());
+        verifyNoInteractions(audits);
+    }
+
+    @Test
+    void httpApplyOnlyUpdatesChosenQueueWithoutTimestampResetFallback() throws Exception {
+        mvc.perform(post("/api/groups/queue-offset").contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsBytes(request("60", "40"))))
+                .andExpect(jsonPath("$.data.offsetDelta").value("20"));
+        verify(admin).setNamesrvAddr("selected:9876");
+        verify(admin).updateConsumeOffset("master:10911", "cg-orders", QUEUE, 60);
+        verify(admin, never()).resetOffsetByQueueId(anyString(), anyString(), anyString(), anyInt(), anyLong());
+        verify(admin, never()).resetOffsetNew(anyString(), anyString(), anyLong());
+        verify(audits).insert(any(RmqOperationAudit.class));
+    }
+
+    @Test
+    void applyRejectsPositionChangesAfterPreview() throws Exception {
+        service.preview(request("60", null));
+        current.setConsumerOffset(41);
+        assertThatThrownBy(() -> service.apply(request("60", "40"))).hasMessageContaining("changed");
+        verify(admin, never()).updateConsumeOffset(anyString(), anyString(), any(), anyLong());
+    }
+
+    @Test
+    void applyRechecksConnectionsAndRejectsRestartedConsumers() throws Exception {
+        service.preview(request("60", null));
+        var online = new ConsumerConnection();
+        online.getConnectionSet().add(new Connection());
+        when(admin.examineConsumerConnectionInfo("cg-orders", "master:10911")).thenReturn(online);
+        assertThatThrownBy(() -> service.apply(request("60", "40"))).hasMessageContaining("Stop all consumers");
+        verify(admin, never()).updateConsumeOffset(anyString(), anyString(), any(), anyLong());
+    }
+
+    @Test
+    void brokerOfflineResponseAndEmptyConnectionSetAreRecognized() throws Exception {
+        when(admin.examineConsumerConnectionInfo("cg-orders", "master:10911"))
+                .thenThrow(new MQClientException(ResponseCode.CONSUMER_NOT_ONLINE, "offline"))
+                .thenThrow(new MQBrokerException(ResponseCode.CONSUMER_NOT_ONLINE, "offline"))
+                .thenReturn(new ConsumerConnection());
+        assertThat(service.preview(request("60", null)).targetOffset()).isEqualTo("60");
+        assertThat(service.preview(request("60", null)).targetOffset()).isEqualTo("60");
+        assertThat(service.preview(request("60", null)).targetOffset()).isEqualTo("60");
+    }
+
+    @Test
+    void permissionFailureAndNullConnectionResponseDoNotMeanOffline() throws Exception {
+        when(admin.examineConsumerConnectionInfo("cg-orders", "master:10911"))
+                .thenThrow(new MQBrokerException(ResponseCode.NO_PERMISSION, "denied"))
+                .thenThrow(new MQClientException(ResponseCode.SYSTEM_ERROR, "unavailable"))
+                .thenReturn(null);
+        assertThatThrownBy(() -> service.preview(request("60", null))).hasMessageContaining("denied");
+        assertThatThrownBy(() -> service.preview(request("60", null))).hasMessageContaining("unavailable");
+        assertThatThrownBy(() -> service.preview(request("60", null))).hasMessageContaining("Stop all consumers");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"9", "101"})
+    void offsetsOutsideCurrentRetentionRangeCannotBeApplied(String offset) {
+        assertThatThrownBy(() -> service.apply(request(offset, "40"))).hasMessageContaining("readable queue range");
+    }
+
+    @Test
+    void endOffsetAndLongPrecisionArePreserved() {
+        range.setMaxOffset(9007199254740993L);
+        current.setConsumerOffset(9007199254740990L);
+        var result = service.preview(request("9007199254740993", null));
+        assertThat(result.targetOffset()).isEqualTo("9007199254740993");
+        assertThat(result.currentOffset()).isEqualTo("9007199254740990");
+        assertThat(result.offsetDelta()).isEqualTo("3");
+        assertThat(result.projectedLag()).isEqualTo("0");
+    }
+
+    @Test
+    void retentionChangeAfterPreviewIsRechecked() {
+        service.preview(request("20", null));
+        range.setMinOffset(21);
+        assertThatThrownBy(() -> service.apply(request("20", "40"))).hasMessageContaining("readable queue range");
+    }
+
+    @Test
+    void missingQueueOrCommitIsNotAnImplicitZero() {
+        topic.getOffsetTable().clear();
+        assertThatThrownBy(() -> service.preview(request("20", null))).hasMessageContaining("not present");
+        topic.getOffsetTable().put(QUEUE, range);
+        consumption.getOffsetTable().clear();
+        assertThatThrownBy(() -> service.preview(request("20", null))).hasMessageContaining("no committed");
+        current.setConsumerOffset(-1);
+        consumption.getOffsetTable().put(QUEUE, current);
+        assertThatThrownBy(() -> service.preview(request("20", null))).hasMessageContaining("no committed");
+    }
+
+    @Test
+    void missingMasterCannotFallBackToReplica() throws Exception {
+        admin.examineTopicRouteInfo("orders").getBrokerDatas().getFirst().getBrokerAddrs().remove(0L);
+        assertThatThrownBy(() -> service.apply(request("20", "40"))).hasMessageContaining("no registered master");
+        verify(admin, never()).updateConsumeOffset(anyString(), anyString(), any(), anyLong());
+    }
+
+    @Test
+    void invalidOffsetAndMissingExpectedPositionAreRejectedBeforeSdkWork() throws Exception {
+        for (String invalid : new String[] {"-1", "9223372036854775808", "bad"}) {
+            assertThatThrownBy(() -> service.preview(request(invalid, null))).hasMessageContaining("64-bit offset");
+        }
+        assertThatThrownBy(() -> service.apply(request("20", null))).hasMessageContaining("64-bit offset");
+        verify(admin, never()).examineTopicRouteInfo(anyString());
+    }
+
+    @Test
+    void failedWriteIsAuditedAndKeepsItsCause() throws Exception {
+        doThrow(new MQBrokerException(ResponseCode.SYSTEM_ERROR, "write rejected")).when(admin)
+                .updateConsumeOffset("master:10911", "cg-orders", QUEUE, 20);
+        assertThatThrownBy(() -> service.apply(request("20", "40"))).hasMessageContaining("write rejected");
+        var capture = org.mockito.ArgumentCaptor.forClass(RmqOperationAudit.class);
+        verify(audits).insert(capture.capture());
+        assertThat(capture.getValue().getResult()).isEqualTo("FAILED");
+        assertThat(capture.getValue().getDetail()).contains("previous=40", "target=20", "queueId=1");
+    }
+
+    @Test
+    void interruptedWriteRestoresInterruptFlag() throws Exception {
+        doThrow(new InterruptedException("cancelled")).when(admin)
+                .updateConsumeOffset("master:10911", "cg-orders", QUEUE, 20);
+        assertThatThrownBy(() -> service.apply(request("20", "40"))).hasMessageContaining("cancelled");
+        assertThat(Thread.currentThread().isInterrupted()).isTrue();
+    }
+
+    @Test
+    void auditFailureDoesNotRetryAnAcceptedUpdate() throws Exception {
+        when(audits.insert(any(RmqOperationAudit.class))).thenThrow(new IllegalStateException("audit unavailable"));
+        assertThat(service.apply(request("20", "40")).targetOffset()).isEqualTo("20");
+        verify(admin).updateConsumeOffset("master:10911", "cg-orders", QUEUE, 20);
+    }
+
+    @Test
+    void httpContractRejectsMissingQueueAndNegativeQueueId() throws Exception {
+        for (String body : List.of("{}", "{\"instanceId\":\"instance-a\",\"group\":\"cg-orders\","
+                + "\"topic\":\"orders\",\"brokerName\":\"broker-a\",\"queueId\":-1,\"offset\":\"20\"}")) {
+            mvc.perform(post("/api/groups/queue-offset/preview").contentType(MediaType.APPLICATION_JSON).content(body))
+                    .andExpect(jsonPath("$.code").value(400));
+        }
+    }
+
+    private QueueOffsetCommand request(String offset, String expected) {
+        return new QueueOffsetCommand("instance-a", "cg-orders", "orders", "broker-a", 1, offset, expected);
+    }
+}

--- a/web/src/api/queueOffset.test.ts
+++ b/web/src/api/queueOffset.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, describe, expect, it } from 'vitest';
+import client from './client';
+import { applyQueueOffset, previewQueueOffset } from './queueOffset';
+
+const mock = new MockAdapter(client);
+const target = {
+  instanceId: 'instance-a',
+  group: 'cg-orders',
+  topic: 'orders',
+  brokerName: 'broker-a',
+  queueId: 1,
+};
+afterEach(() => mock.reset());
+
+describe('single queue offset contract', () => {
+  it('previews only the selected queue with an exact decimal offset', async () => {
+    mock.onPost('/groups/queue-offset/preview').reply((request) => {
+      expect(JSON.parse(request.data)).toEqual({ ...target, offset: '9007199254740993' });
+      return [200, { code: 200, data: { targetOffset: '9007199254740993' } }];
+    });
+    expect((await previewQueueOffset(target, '9007199254740993')).targetOffset).toBe(
+      '9007199254740993',
+    );
+    expect(mock.history.post).toHaveLength(1);
+  });
+
+  it('includes the previously observed position when applying the update', async () => {
+    mock.onPost('/groups/queue-offset').reply((request) => {
+      expect(JSON.parse(request.data)).toEqual({
+        ...target,
+        offset: '20',
+        expectedCurrentOffset: '40',
+      });
+      return [200, { code: 200, data: { currentOffset: '40', targetOffset: '20' } }];
+    });
+    expect((await applyQueueOffset(target, '20', '40')).targetOffset).toBe('20');
+    expect(mock.history.post).toHaveLength(1);
+  });
+});

--- a/web/src/api/queueOffset.ts
+++ b/web/src/api/queueOffset.ts
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import client from './client';
+
+export interface QueueOffsetTarget {
+  instanceId: string;
+  group: string;
+  topic: string;
+  brokerName: string;
+  queueId: number;
+}
+
+export interface QueueOffsetPreview {
+  brokerAddress: string;
+  currentOffset: string;
+  targetOffset: string;
+  minOffset: string;
+  maxOffset: string;
+  offsetDelta: string;
+  projectedLag: string;
+}
+
+export async function previewQueueOffset(target: QueueOffsetTarget, offset: string) {
+  const response = await client.post<{ data: QueueOffsetPreview }>('/groups/queue-offset/preview', {
+    ...target,
+    offset,
+  });
+  return response.data.data;
+}
+
+export async function applyQueueOffset(
+  target: QueueOffsetTarget,
+  offset: string,
+  expectedCurrentOffset: string,
+) {
+  const response = await client.post<{ data: QueueOffsetPreview }>('/groups/queue-offset', {
+    ...target,
+    offset,
+    expectedCurrentOffset,
+  });
+  return response.data.data;
+}

--- a/web/src/components/QueueOffsetDialog.tsx
+++ b/web/src/components/QueueOffsetDialog.tsx
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Alert, Button, Descriptions, Input, Modal, Space, Typography } from 'antd';
+import {
+  applyQueueOffset,
+  previewQueueOffset,
+  type QueueOffsetPreview,
+  type QueueOffsetTarget,
+} from '../api/queueOffset';
+
+interface Props {
+  target: QueueOffsetTarget;
+  onClose: () => void;
+  onApplied: () => void;
+}
+
+export default function QueueOffsetDialog({ target, onClose, onApplied }: Props) {
+  const [offset, setOffset] = useState('');
+  const [preview, setPreview] = useState<QueueOffsetPreview | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [applied, setApplied] = useState(false);
+  const [busy, setBusy] = useState<'preview' | 'apply' | null>(null);
+  const busyRef = useRef(false);
+  const activeRef = useRef(true);
+  useEffect(() => {
+    activeRef.current = true;
+    return () => {
+      activeRef.current = false;
+    };
+  }, []);
+
+  const run = async (mode: 'preview' | 'apply') => {
+    if (busyRef.current || !/^(0|[1-9][0-9]{0,18})$/.test(offset)) return;
+    if (mode === 'apply' && (!preview || applied)) return;
+    busyRef.current = true;
+    setBusy(mode);
+    setError(null);
+    try {
+      if (mode === 'preview') {
+        setPreview(null);
+        setApplied(false);
+        const result = await previewQueueOffset(target, offset);
+        if (activeRef.current) setPreview(result);
+      } else if (preview) {
+        await applyQueueOffset(target, preview.targetOffset, preview.currentOffset);
+        if (activeRef.current) {
+          setApplied(true);
+          onApplied();
+        }
+      }
+    } catch (failure) {
+      if (activeRef.current) {
+        setError(failure instanceof Error ? failure.message : 'Queue offset operation failed');
+        setPreview(null);
+      }
+    } finally {
+      busyRef.current = false;
+      if (activeRef.current) setBusy(null);
+    }
+  };
+
+  return (
+    <Modal
+      open
+      title="Set one queue's consumer offset"
+      width={720}
+      onCancel={onClose}
+      closable={busy !== 'apply'}
+      keyboard={busy !== 'apply'}
+      maskClosable={busy !== 'apply'}
+      styles={{ body: { maxHeight: '65vh', overflowY: 'auto' } }}
+      footer={
+        <Space>
+          <Button onClick={onClose} disabled={busy === 'apply'}>
+            Close
+          </Button>
+          <Button
+            onClick={() => void run('preview')}
+            loading={busy === 'preview'}
+            disabled={busy === 'apply' || !/^(0|[1-9][0-9]{0,18})$/.test(offset)}
+          >
+            Preview change
+          </Button>
+          <Button
+            danger
+            type="primary"
+            loading={busy === 'apply'}
+            disabled={!preview || applied || busy === 'preview' || preview.offsetDelta === '0'}
+            onClick={() => void run('apply')}
+          >
+            Confirm queue offset
+          </Button>
+        </Space>
+      }
+    >
+      <Space direction="vertical" style={{ width: '100%' }} size="middle">
+        <Alert
+          type="warning"
+          showIcon
+          message="Stop all consumers and keep them stopped until this operation completes"
+          description="This changes one persisted broker offset for traditional clustered consumption. It does not clear POP in-flight messages or update broadcasting clients' local offsets."
+        />
+        <Descriptions bordered column={1} size="small">
+          <Descriptions.Item label="Instance">{target.instanceId}</Descriptions.Item>
+          <Descriptions.Item label="Consumer group">{target.group}</Descriptions.Item>
+          <Descriptions.Item label="Topic / Broker / Queue">
+            {target.topic} / {target.brokerName} / {target.queueId}
+          </Descriptions.Item>
+        </Descriptions>
+        <label>
+          <Typography.Text>Target offset</Typography.Text>
+          <Input
+            aria-label="Target offset"
+            value={offset}
+            inputMode="numeric"
+            disabled={busy !== null}
+            onChange={(event) => {
+              setOffset(event.target.value);
+              setPreview(null);
+              setApplied(false);
+              setError(null);
+            }}
+          />
+        </label>
+        {preview && (
+          <Descriptions bordered column={2} size="small">
+            <Descriptions.Item label="Master address">{preview.brokerAddress}</Descriptions.Item>
+            <Descriptions.Item label="Current offset">{preview.currentOffset}</Descriptions.Item>
+            <Descriptions.Item label="Minimum offset">{preview.minOffset}</Descriptions.Item>
+            <Descriptions.Item label="End offset">{preview.maxOffset}</Descriptions.Item>
+            <Descriptions.Item label="Target offset">{preview.targetOffset}</Descriptions.Item>
+            <Descriptions.Item label="Projected lag">{preview.projectedLag}</Descriptions.Item>
+            <Descriptions.Item label="Impact" span={2}>
+              {preview.offsetDelta === '0'
+                ? 'No change'
+                : preview.offsetDelta.startsWith('-')
+                  ? `Replay ${preview.offsetDelta.slice(1)} queue positions`
+                  : `Skip ${preview.offsetDelta} queue positions`}
+            </Descriptions.Item>
+          </Descriptions>
+        )}
+        {error && <Alert type="error" showIcon message={error} />}
+        {applied && (
+          <Alert type="success" showIcon message="Broker accepted the queue offset update" />
+        )}
+      </Space>
+    </Modal>
+  );
+}

--- a/web/src/components/__tests__/QueueOffsetDialog.test.tsx
+++ b/web/src/components/__tests__/QueueOffsetDialog.test.tsx
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, fireEvent, render as renderComponent, screen, waitFor } from '@testing-library/react';
+import { ConfigProvider } from 'antd';
+import type { ReactElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import QueueOffsetDialog from '../QueueOffsetDialog';
+import {
+  applyQueueOffset,
+  previewQueueOffset,
+  type QueueOffsetPreview,
+} from '../../api/queueOffset';
+
+vi.mock('../../api/queueOffset', () => ({
+  applyQueueOffset: vi.fn(),
+  previewQueueOffset: vi.fn(),
+}));
+const target = {
+  instanceId: 'instance-a',
+  group: 'cg-orders',
+  topic: 'orders',
+  brokerName: 'broker-a',
+  queueId: 1,
+};
+const result: QueueOffsetPreview = {
+  brokerAddress: 'master:10911',
+  currentOffset: '40',
+  targetOffset: '20',
+  minOffset: '10',
+  maxOffset: '100',
+  offsetDelta: '-20',
+  projectedLag: '80',
+};
+const render = (element: ReactElement) =>
+  renderComponent(element, {
+    wrapper: ({ children }) => (
+      <ConfigProvider theme={{ token: { motion: false } }}>{children}</ConfigProvider>
+    ),
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(previewQueueOffset).mockResolvedValue(result);
+  vi.mocked(applyQueueOffset).mockResolvedValue(result);
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockReturnValue({
+      matches: false,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  });
+});
+
+async function preview() {
+  fireEvent.change(screen.getByRole('textbox', { name: 'Target offset' }), {
+    target: { value: '20' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Preview change' }));
+  await waitFor(() => expect(screen.getByText('Replay 20 queue positions')).toBeVisible());
+}
+
+describe('QueueOffsetDialog', () => {
+  it('previews one queue and applies the exact target with the observed current offset', async () => {
+    const applied = vi.fn();
+    render(<QueueOffsetDialog target={target} onClose={vi.fn()} onApplied={applied} />);
+    expect(screen.getByRole('button', { name: 'Confirm queue offset' })).toBeDisabled();
+    await preview();
+    expect(previewQueueOffset).toHaveBeenCalledWith(target, '20');
+    expect(applyQueueOffset).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm queue offset' }));
+    await waitFor(() =>
+      expect(screen.getByText('Broker accepted the queue offset update')).toBeVisible(),
+    );
+    expect(applyQueueOffset).toHaveBeenCalledWith(target, '20', '40');
+    expect(applied).toHaveBeenCalledOnce();
+    expect(screen.getByRole('button', { name: 'Confirm queue offset' })).toBeDisabled();
+  });
+
+  it('invalidates preview when the requested offset changes and rejects non-integer text', async () => {
+    render(<QueueOffsetDialog target={target} onClose={vi.fn()} onApplied={vi.fn()} />);
+    await preview();
+    fireEvent.change(screen.getByRole('textbox', { name: 'Target offset' }), {
+      target: { value: '30' },
+    });
+    expect(screen.queryByText('Replay 20 queue positions')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm queue offset' })).toBeDisabled();
+    fireEvent.change(screen.getByRole('textbox', { name: 'Target offset' }), {
+      target: { value: '2.5' },
+    });
+    expect(screen.getByRole('button', { name: 'Preview change' })).toBeDisabled();
+  });
+
+  it('shows a changed-offset conflict and requires a new preview', async () => {
+    vi.mocked(applyQueueOffset).mockRejectedValue(
+      new Error('Consumer offset changed; inspect the queue again'),
+    );
+    render(<QueueOffsetDialog target={target} onClose={vi.fn()} onApplied={vi.fn()} />);
+    await preview();
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm queue offset' }));
+    await waitFor(() => expect(screen.getByText(/Consumer offset changed/)).toBeVisible());
+    expect(screen.getByRole('button', { name: 'Confirm queue offset' })).toBeDisabled();
+  });
+
+  it('prevents duplicate submissions and locks close while the write is pending', async () => {
+    let finish!: (value: QueueOffsetPreview) => void;
+    vi.mocked(applyQueueOffset).mockReturnValue(
+      new Promise((resolve) => {
+        finish = resolve;
+      }),
+    );
+    render(<QueueOffsetDialog target={target} onClose={vi.fn()} onApplied={vi.fn()} />);
+    await preview();
+    const button = screen.getByRole('button', { name: 'Confirm queue offset' });
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(applyQueueOffset).toHaveBeenCalledOnce();
+    expect(screen.getByRole('button', { name: 'Close' })).toBeDisabled();
+    await act(async () => finish(result));
+  });
+
+  it('preserves 64-bit offsets without converting input to JavaScript numbers', async () => {
+    vi.mocked(previewQueueOffset).mockResolvedValue({
+      ...result,
+      currentOffset: '9007199254740990',
+      targetOffset: '9007199254740993',
+      maxOffset: '9007199254740993',
+      offsetDelta: '3',
+      projectedLag: '0',
+    });
+    render(<QueueOffsetDialog target={target} onClose={vi.fn()} onApplied={vi.fn()} />);
+    fireEvent.change(screen.getByRole('textbox', { name: 'Target offset' }), {
+      target: { value: '9007199254740993' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Preview change' }));
+    await waitFor(() => expect(screen.getByText('Skip 3 queue positions')).toBeVisible());
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm queue offset' }));
+    await waitFor(() =>
+      expect(applyQueueOffset).toHaveBeenCalledWith(target, '9007199254740993', '9007199254740990'),
+    );
+  });
+
+  it('does not allow a no-op confirmation', async () => {
+    vi.mocked(previewQueueOffset).mockResolvedValue({ ...result, offsetDelta: '0' });
+    render(<QueueOffsetDialog target={target} onClose={vi.fn()} onApplied={vi.fn()} />);
+    fireEvent.change(screen.getByRole('textbox', { name: 'Target offset' }), {
+      target: { value: '40' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Preview change' }));
+    await waitFor(() => expect(screen.getByText('No change')).toBeVisible());
+    expect(screen.getByRole('button', { name: 'Confirm queue offset' })).toBeDisabled();
+  });
+
+  it('discards a response after unmount without refreshing the old instance', async () => {
+    let finish!: (value: QueueOffsetPreview) => void;
+    vi.mocked(applyQueueOffset).mockReturnValue(
+      new Promise((resolve) => {
+        finish = resolve;
+      }),
+    );
+    const applied = vi.fn();
+    const { unmount } = render(
+      <QueueOffsetDialog target={target} onClose={vi.fn()} onApplied={applied} />,
+    );
+    await preview();
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm queue offset' }));
+    unmount();
+    await act(async () => finish(result));
+    expect(applied).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -60,6 +60,9 @@ import {
   SlidersHorizontal,
 } from '@phosphor-icons/react';
 import { ImportOutlined, ExportOutlined, DeleteOutlined, SyncOutlined } from '@ant-design/icons';
+import QueueOffsetDialog from '../../components/QueueOffsetDialog';
+import type { QueueOffsetTarget } from '../../api/queueOffset';
+import { isMockMode } from '../../services/dataMode';
 import type { ColumnsType } from 'antd/es/table';
 import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
@@ -271,6 +274,7 @@ const ConsumerPageContent = ({
   const [modeFilter, setModeFilter] = useState<string>('ALL');
   const [modalOpen, setModalOpen] = useState(false);
   const [selectedGroup, setSelectedGroup] = useState<ConsumerGroup | null>(null);
+  const [queueOffsetTarget, setQueueOffsetTarget] = useState<QueueOffsetTarget | null>(null);
   const [settingsGroup, setSettingsGroup] = useState<ConsumerGroup | null>(null);
   const [settingsLoading, setSettingsLoading] = useState(false);
   const [settingsSubmitting, setSettingsSubmitting] = useState(false);
@@ -1220,6 +1224,36 @@ const ConsumerPageContent = ({
      Modal: Queue Progress Tab
      ═══════════════════════════════════════════ */
   const queueColumns: ColumnsType<QueueProgress> = [
+    {
+      title: 'Offset action',
+      key: 'offsetAction',
+      width: 140,
+      render: (_, queue) => (
+        <Button
+          size="small"
+          disabled={
+            isCloudInstance ||
+            isMockMode() ||
+            !selectedInstanceId ||
+            selectedGroup?.subscriptionMode?.toUpperCase() === 'POP' ||
+            selectedGroup?.consumeType?.toUpperCase() === 'BROADCASTING'
+          }
+          onClick={() =>
+            selectedInstanceId &&
+            selectedGroup &&
+            setQueueOffsetTarget({
+              instanceId: selectedInstanceId,
+              group: selectedGroup.name,
+              topic: queue.topic,
+              brokerName: queue.broker,
+              queueId: queue.queueId,
+            })
+          }
+        >
+          Set offset
+        </Button>
+      ),
+    },
     {
       title: 'Topic 主题',
       dataIndex: 'topic',
@@ -2374,6 +2408,15 @@ const ConsumerPageContent = ({
           )}
         </Form>
       </Modal>
+
+      {queueOffsetTarget && (
+        <QueueOffsetDialog
+          key={JSON.stringify(queueOffsetTarget)}
+          target={queueOffsetTarget}
+          onClose={() => setQueueOffsetTarget(null)}
+          onApplied={() => void loadProgress(queueOffsetTarget.group, true)}
+        />
+      )}
 
       {/* ═══════════════════════════════════════════
          Import Group Modal


### PR DESCRIPTION
## 变更目的

消费组详情的队列进度表增加 `Set offset`，在离线维护期间调整一个队列的精确消费位置。例如只将 `orders / broker-a / Queue 1` 从 40 回放到 20，保留其他队列的位点。

现有 #2816 预览按 Topic 时间重置，#3310 修复全 Topic 重置的 force／离线行为，#3993／#3994 提供全 Topic 跳过积压预设；这些不提供指定队列的精确整数位点调整。已检索标题正文并补充在线 `single queue offset` 去重。

## 实现范围

- 新增管理员 `POST /api/groups/queue-offset/preview` 和 `POST /api/groups/queue-offset`。
- 通过所选 Apache 实例的 Topic 路由找到目标主节点，检查消费组连接、队列保留范围和已提交位置，不接受任意 Broker 地址。
- 预览展示回放／跳过位置差与预计积压；提交重新检查连接、范围和 `expectedCurrentOffset`，发现漂移返回 409。
- 位点以十进制字符串跨 JSON／浏览器传递，保留 64 位整数精度；不存在的队列或消费位置不回填零。
- 只调用 SDK `updateConsumeOffset`，记录单队列成功／失败审计，保留中断状态，审计失败不触发误报重试。
- 增加队列行入口、目标确认、预览失效、提交锁定、成功后进度刷新及迟到结果隔离；云／Mock 和已识别的 POP／广播组禁用入口。
- 新增中文使用、限制、协议和数据回滚说明，无新依赖、配置或数据库字段。

依据官方 [DefaultMQAdminExtImpl](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java)，`resetOffsetByQueueId` 先更新位点，再调用按时间重置协议；旧 Broker 路径可能忽略 Queue ID。因此这里使用仅发送 `UPDATE_CONSUMER_OFFSET` 的 `updateConsumeOffset`，不进入该回退路径。

## 本地验证

基线 `d6dee7d7ccfcf4886f02466ec51452a6928b2cc8`，Java 21、Node 24.18.0，2026-09-08。

```bash
cd server
mvn -B -ntp -Dtest=QueueOffsetTest,RuntimeAdminClientResolverTest,ConsumerGroupControllerTest,OperationAuditServiceTest,AuthInterceptorTest verify
cd ../web
npx vitest run src/api/queueOffset.test.ts src/components/__tests__/QueueOffsetDialog.test.tsx src/pages/instance/__tests__/ConsumerPage.test.tsx
npm run build
```

- 后端 92 个测试通过，包括 17 个新位点场景和 2 个新权限场景；真实实例解析与管理客户端包装只模拟底层 SDK。
- 新增服务 JaCoCo 行覆盖率 63/63（100%），分支 29/32；Checkstyle 与打包通过。
- 前端 40 个测试通过，TypeScript、Vite、修改文件 ESLint 通过。
- Playwright 在本地真实消费组详情页验证队列入口、从 40 到 20 的回放预览、提交中的 `expectedCurrentOffset="40"` 及成功后禁用确认。两个精确本地 POST 明确返回受控结果，其他非 GET 中止，没有真实 Broker 写入。
- `git diff --check` 通过；12 个文件，共 1,086 行新增。

原样上游基线已有 3 个全量后端失败（AuthCorsIntegrationTest 两项、AliyunInstanceProviderTest 一项）与依赖漏洞。本 PR 无新增依赖，相关验证无新增失败，不将增量验证表述为项目级全量验收。真实集群 E2E、性能、压力、容量及混沌测试未执行。

调用方必须停止并保持全部消费者停止直到操作完成。目标节点连接查询是一次观测，不是分布式锁或原子比较交换；它不修改广播本地位点，也不清理 POP 不可见消息。网络超时后的结果可能不确定，页面不自动重试。

无迁移，直接部署；代码回滚移除接口与入口。数据回滚需在离线维护期间按照审计中的原位置重新调整，且原位置仍在 Broker 保留范围内。提交含 `[skip ci]`，验证在本地执行。
