### PR TITLE
fix(acl): read plain-access rules by exact principal match

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -208,6 +208,7 @@ public class AclService {
                 .secretKey(existing.getSecretKey())
                 .admin(user.getAdmin() == null ? existing.isAdmin() : user.getAdmin())
                 .clusters(user.getClusters() == null ? existing.getClusters() : user.getClusters())
+                .whiteRemoteAddress(existing.getWhiteRemoteAddress())
                 .gmtCreate(existing.getGmtCreate())
                 .build();
         AclUserVO saved = aclRepository.replaceUser(merged)

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
@@ -342,7 +342,13 @@ public class MybatisPlusAclRepository implements AclRepository {
     }
 
     private PlainAccessConfigVO toPlainAccessConfig(AclUserVO user) {
-        List<AclRuleVO> userRules = ruleMapper.selectList(ruleQuery(user.getAccessKey(), null, null, null, null))
+        // Exact principal match, mirroring the delete in upsertPlainAccessRules: the
+        // substring LIKE in ruleQuery would also absorb rules of other accounts whose
+        // accessKey contains this one (e.g. "svc-a" also matching "svc-a-v2").
+        List<AclRuleVO> userRules = ruleMapper.selectList(new QueryWrapper<RmqAclRule>()
+                        .eq("principal", user.getAccessKey())
+                        .orderByDesc("gmt_create")
+                        .orderByDesc("id"))
                 .stream()
                 .map(MybatisPlusAclRepository::toRuleVO)
                 .collect(Collectors.toList());

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -543,6 +543,21 @@ class AclServiceTest {
     }
 
     @Test
+    void updateUserShouldKeepTheExistingWhiteRemoteAddress() {
+        existingUser.setWhiteRemoteAddress("10.0.1.0/24");
+        UpdateAclUserDTO input = new UpdateAclUserDTO();
+        input.setId("1");
+        input.setUsername("renamed");
+
+        when(aclRepository.findUserById(1L)).thenReturn(Optional.of(existingUser));
+        when(aclRepository.replaceUser(any(AclUserVO.class))).thenAnswer(inv -> Optional.of(inv.getArgument(0)));
+
+        AclUserVO result = aclService.updateUser(input, null);
+
+        assertThat(result.getWhiteRemoteAddress()).isEqualTo("10.0.1.0/24");
+    }
+
+    @Test
     void updateUserShouldPreserveAdminWhenNotProvided() {
         AclUserVO adminUser = AclUserVO.builder()
                 .id(1L)

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
@@ -551,6 +551,28 @@ class MybatisPlusAclRepositoryTest {
         assertThat(captor.getValue().getClusters()).isEqualTo("cluster-a,cluster-b");
     }
 
+    @Test
+    void examineShouldNotAbsorbRulesOfAccountsWhoseAccessKeysOverlap() {
+        RmqAclUser user = userEntity(1L, "svc-a", CredentialUtils.encodeBase64("secret-a-value"));
+        when(userMapper.selectList(any(QueryWrapper.class))).thenReturn(List.of(user));
+        RmqAclRule ownRule = plainRuleEntity("svc-a", "orders", "Topic", "PUB");
+        RmqAclRule otherAccountRule = plainRuleEntity("svc-a-v2", "payments", "Topic", "SUB");
+        // Simulate SQL semantics: a substring LIKE on the principal matches both
+        // accounts, an exact equality only the requested one.
+        when(ruleMapper.selectList(any(QueryWrapper.class))).thenAnswer(invocation -> {
+            QueryWrapper<RmqAclRule> query = invocation.getArgument(0);
+            return query.getSqlSegment().contains("LIKE")
+                    ? List.of(ownRule, otherAccountRule)
+                    : List.of(ownRule);
+        });
+
+        AclClusterConfigVO config = repository.examineBrokerClusterAclConfig("cluster-a");
+
+        assertThat(config.getAccounts()).hasSize(1);
+        PlainAccessConfigVO account = config.getAccounts().get(0);
+        assertThat(account.getTopicPerms()).containsExactly("orders=PUB");
+    }
+
     private static RmqAclUser userEntity(Long id, String accessKey, String encodedSecret) {
         RmqAclUser entity = new RmqAclUser();
         entity.setId(id);
@@ -560,5 +582,20 @@ class MybatisPlusAclRepositoryTest {
         entity.setAdmin(false);
         entity.setGmtCreate(LocalDateTime.of(2026, 1, 1, 0, 0));
         return entity;
+    }
+
+    private static RmqAclRule plainRuleEntity(String principal, String resource,
+            String resourceType, String actions) {
+        RmqAclRule rule = new RmqAclRule();
+        rule.setPrincipal(principal);
+        rule.setResource(resource);
+        rule.setResourceType(resourceType);
+        rule.setResourcePattern("LITERAL");
+        rule.setActions(actions);
+        rule.setDecision("ALLOW");
+        rule.setScope("*");
+        rule.setAclVersion("2.0");
+        rule.setGmtCreate(LocalDateTime.of(2026, 1, 1, 0, 0));
+        return rule;
     }
 }


### PR DESCRIPTION
### Motivation

`MybatisPlusAclRepository.toPlainAccessConfig` rebuilds each account's plain-access config (`topicPerms` / `groupPerms` / default perms) by reusing `ruleQuery(...)`, whose `principal` condition is a substring `LIKE` — that helper exists for the rule **search** endpoint (`findRulePage`). Access keys are free-form strings (`@NotBlank` only), so when one account's key contains another's (`svc-a` vs `svc-a-v2`), each account's view absorbs the other's rules.

The write path (`upsertPlainAccessRules`) already deletes rules with an **exact** `eq("principal", accessKey)` match, so the read/write asymmetry is a straight copy-paste reuse of the search helper:

```java
// read (LIKE '%accessKey%')
ruleMapper.selectList(ruleQuery(user.getAccessKey(), null, null, null, null))
// write (exact)
ruleMapper.delete(new QueryWrapper<RmqAclRule>()
        .eq("principal", config.getAccessKey())
        .eq("acl_version", "2.0"));
```

Concretely: `GET /api/acl/cluster-config` → `AclService.examineBrokerClusterAclConfig` → `toPlainAccessConfig` returns `svc-a`'s account with `svc-a-v2`'s rules included; the edit modal (`web/src/pages/instance/acl.tsx` `openEditPlainModal`) seeds from that view and `handlePlainSubmit` saves the polluted set back — persisting the wrong rules under the wrong account.

### Modifications

- `toPlainAccessConfig` now queries rules with an exact `eq("principal", accessKey)` match (plus the same deterministic ordering), mirroring the delete in `upsertPlainAccessRules`.

### Verification

- New test `examineShouldNotAbsorbRulesOfAccountsWhoseAccessKeysOverlap` in `MybatisPlusAclRepositoryTest`: the `ruleMapper.selectList` stub simulates SQL semantics (a substring `LIKE` on the principal returns both accounts' rows, an exact equality only the requested one).
  - Before the fix: fails — the account reports `["orders=PUB", "payments=SUB"]` (the other account's rule is absorbed).
  - After the fix: passes — `["orders=PUB"]` only.
- Full test class: `mvn -f server/pom.xml test -Dtest=MybatisPlusAclRepositoryTest` → **Tests run: 23, Failures: 0, Errors: 0**.
