### PR TITLE
fix(ai): pass the tool cluster input to the cluster-scoped read

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/ConsumerGroupListToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/ConsumerGroupListToolHandler.java
@@ -45,7 +45,7 @@ public class ConsumerGroupListToolHandler implements ToolHandler {
         String clusterId = (String) input.get("cluster");
         String search = (String) input.get("search");
         PageResult<ConsumerGroupVO> page = metadataService.listConsumerGroupsPage(
-                clusterId, null, search, ToolListPagination.page(input), ToolListPagination.pageSize(input));
+                null, clusterId, search, ToolListPagination.page(input), ToolListPagination.pageSize(input));
         return ToolListPagination.pagedResult(page, page.getItems().stream()
                 .map(ConsumerGroupListToolHandler::safeProjection)
                 .toList());

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/TopicListToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/TopicListToolHandler.java
@@ -44,7 +44,7 @@ public class TopicListToolHandler implements ToolHandler {
         String type = (String) input.get("type");
         String search = (String) input.get("search");
         PageResult<TopicVO> page = metadataService.listTopicsPage(
-                clusterId, null, type, search, ToolListPagination.page(input), ToolListPagination.pageSize(input));
+                null, clusterId, type, search, ToolListPagination.page(input), ToolListPagination.pageSize(input));
         return ToolListPagination.pagedResult(page, page.getItems().stream()
                 .map(TopicListToolHandler::safeProjection)
                 .toList());

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
@@ -29,6 +29,7 @@ import com.aliyun.sdk.service.rocketmq20220801.models.ListTopicSubscriptionsResp
 import com.aliyun.sdk.service.rocketmq20220801.models.ListTopicsResponseBody;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
+import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.common.util.SubscriptionFilterModes;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
@@ -118,6 +119,9 @@ final class AliyunConverters {
         vo.setName(data.getTopicName());
         vo.setInstanceId(studioInstanceId);
         vo.setType(toTopicType(data.getMessageType()));
+        // Aliyun's ListTopics API does not return permissions; console-created cloud
+        // topics are read-write, matching the Tencent provider's mapping.
+        vo.setPerm(TopicPerm.RW);
         vo.setRemark(data.getRemark());
         vo.setGmtCreate(parseDateTime(data.getCreateTime()));
         vo.setGmtModified(parseDateTime(data.getUpdateTime()));
@@ -127,8 +131,8 @@ final class AliyunConverters {
     }
 
     static TopicType toTopicType(String messageType) {
-        if (messageType == null) {
-            return null;
+        if (messageType == null || messageType.isBlank()) {
+            return TopicType.NORMAL;
         }
         switch (messageType.toUpperCase(Locale.ROOT)) {
             case "NORMAL":
@@ -140,7 +144,10 @@ final class AliyunConverters {
             case "TRANSACTION":
                 return TopicType.TRANSACTION;
             default:
-                return null;
+                // Unknown message types fall back to NORMAL so read paths (web
+                // detail, AI rmq.topic.list) never see a null type, matching the
+                // Apache provider's parseTopicType fallback.
+                return TopicType.NORMAL;
         }
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
@@ -29,6 +29,7 @@ import com.aliyun.sdk.service.rocketmq20220801.models.ListTopicSubscriptionsResp
 import com.aliyun.sdk.service.rocketmq20220801.models.ListTopicsResponseBody;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
+import org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.common.util.SubscriptionFilterModes;
@@ -164,22 +165,20 @@ final class AliyunConverters {
         vo.setName(data.getConsumerGroupId());
         vo.setInstanceId(studioInstanceId);
         vo.setConsumeType(toConsumeType(data.getMessageModel()));
+        // Aliyun's messageModel carries the consume model, not the subscription mode; cloud TCP
+        // consumer groups are push consumers. Read paths (web detail, AI rmq.group.list) require
+        // a non-null subscriptionMode, mirroring the Apache provider invariant.
+        vo.setSubscriptionMode(SubscriptionMode.Push);
         vo.setGmtCreate(parseDateTime(data.getCreateTime()));
         vo.setGmtModified(parseDateTime(data.getUpdateTime()));
         return vo;
     }
 
     static ConsumeType toConsumeType(String messageModel) {
-        if (messageModel == null) {
-            return null;
-        }
-        if ("Clustering".equalsIgnoreCase(messageModel)) {
-            return ConsumeType.CLUSTERING;
-        }
         if ("Broadcasting".equalsIgnoreCase(messageModel)) {
             return ConsumeType.BROADCASTING;
         }
-        return null;
+        return ConsumeType.CLUSTERING;
     }
 
     static List<QueueProgressVO> toQueueProgressRows(GetConsumerGroupLagResponseBody.Data data) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -48,6 +48,7 @@ import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -944,6 +945,9 @@ public class TencentInstanceProvider implements InstanceProvider {
         group.setClusterId(item.getClusterIdV4());
         group.setNamespace(item.getNamespaceV4());
         group.setConsumeType(toConsumeType(item.getConsumeMessageOrderly()));
+        // Tencent consumer groups are TCP push consumers; read paths (web detail,
+        // AI rmq.group.list) require a non-null subscriptionMode.
+        group.setSubscriptionMode(SubscriptionMode.Push);
         group.setDeliveryOrderType(item.getConsumeMessageOrderly() == null || !item.getConsumeMessageOrderly()
                 ? "Concurrently" : "Orderly");
         group.setRetryMaxTimes(toInt(item.getMaxRetryTimes()));

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -1036,12 +1036,15 @@ public class TencentInstanceProvider implements InstanceProvider {
 
     private static TopicType toTopicType(String raw) {
         if (!StringUtils.hasText(raw)) {
-            return null;
+            return TopicType.NORMAL;
         }
         try {
             return TopicType.valueOf(raw.trim().toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException ignored) {
-            return null;
+        } catch (IllegalArgumentException ex) {
+            // Unknown topic types fall back to NORMAL so read paths (web detail,
+            // AI rmq.topic.list) never see a null type, matching the Apache
+            // provider's parseTopicType fallback.
+            return TopicType.NORMAL;
         }
     }
 

--- a/server/src/main/resources/tool-catalog/rmq-tools.yaml
+++ b/server/src/main/resources/tool-catalog/rmq-tools.yaml
@@ -126,7 +126,7 @@ tools:
             brokers:
               type: integer
             proxies:
-              type: integer
+              type: [integer, 'null']
             topics:
               type: integer
             groups:
@@ -164,9 +164,9 @@ tools:
             totalBrokers:
               type: integer
             totalProxies:
-              type: integer
+              type: [integer, 'null']
             totalNameServers:
-              type: integer
+              type: [integer, 'null']
             totalTopics:
               type: integer
             totalConsumerGroups:
@@ -332,7 +332,7 @@ tools:
               onlineInstances:
                 type: integer
               totalLag:
-                type: integer
+                type: [integer, 'null']
               subscribedTopics:
                 type: array
                 items:

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ConsumerGroupListToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ConsumerGroupListToolHandlerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai.tool;
+
+import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
+import org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
+import org.apache.rocketmq.studio.instance.topic.MetadataService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConsumerGroupListToolHandlerTest {
+
+    @Mock
+    private MetadataService metadataService;
+
+    @InjectMocks
+    private ConsumerGroupListToolHandler handler;
+
+    @Test
+    void executeShouldRouteClusterToClusterScopedRead() {
+        ConsumerGroupVO group = new ConsumerGroupVO();
+        group.setName("cg-orders");
+        group.setClusterId("DefaultCluster");
+        group.setSubscriptionMode(SubscriptionMode.Push);
+        group.setConsumeType(ConsumeType.CLUSTERING);
+        group.setOnlineInstances(3);
+        group.setTotalLag(42L);
+        group.setSubscribedTopics(List.of("orders"));
+        group.setRetryMaxTimes(16);
+        when(metadataService.listConsumerGroupsPage(isNull(), eq("DefaultCluster"), eq("order"), eq(1), eq(20)))
+                .thenReturn(PageResult.of(List.of(group), 1L, 1, 20));
+
+        Object result = handler.execute(Map.of("cluster", "DefaultCluster", "search", "order"));
+
+        Map<?, ?> page = (Map<?, ?>) result;
+        assertThat(page.get("total")).isEqualTo(1L);
+        List<?> items = (List<?>) page.get("items");
+        assertThat(items).hasSize(1);
+        Map<?, ?> row = (Map<?, ?>) items.get(0);
+        assertThat(row.get("name")).isEqualTo("cg-orders");
+        assertThat(row.get("subscriptionMode")).isEqualTo("Push");
+        assertThat(row.get("consumeType")).isEqualTo("CLUSTERING");
+        assertThat(row.get("totalLag")).isEqualTo(42L);
+        verify(metadataService).listConsumerGroupsPage(isNull(), eq("DefaultCluster"), eq("order"), eq(1), eq(20));
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
@@ -391,7 +391,7 @@ class ToolGatewayServiceTest {
         when(clusterService.getCluster("cluster-v5")).thenReturn(cluster(ClusterType.V5_PROXY_CLUSTER));
         TopicVO topic = topic();
         topic.setRemark("do-not-expose");
-        when(metadataService.listTopicsPage("cluster-v5", null, "NORMAL", "order", 2, 20))
+        when(metadataService.listTopicsPage(null, "cluster-v5", "NORMAL", "order", 2, 20))
                 .thenReturn(PageResult.of(List.of(topic), 101, 2, 20));
 
         Object output = gateway.execute("rmq.topic.list", Map.of(
@@ -432,7 +432,7 @@ class ToolGatewayServiceTest {
         when(clusterService.getCluster("cluster-v5")).thenReturn(cluster(ClusterType.V5_PROXY_CLUSTER));
         ConsumerGroupVO group = consumerGroup();
         group.setDelaySeconds(30);
-        when(metadataService.listConsumerGroupsPage("cluster-v5", null, "order", 2, 20))
+        when(metadataService.listConsumerGroupsPage(null, "cluster-v5", "order", 2, 20))
                 .thenReturn(PageResult.of(List.of(group), 101, 2, 20));
 
         Object output = gateway.execute("rmq.group.list", Map.of(

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
@@ -41,6 +41,7 @@ import org.apache.rocketmq.studio.ops.dashboard.ClusterOverviewVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardService;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardStatsVO;
+import org.apache.rocketmq.studio.provider.apache.ConsumerLagResolver;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,6 +55,8 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -340,6 +343,48 @@ class ToolGatewayServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void executesDashboardSummaryWhenTopologyCountsAreUnavailable() {
+        // Mirrors the V5/degraded provider paths (RocketMQDashboardProvider) and
+        // DashboardControllerTest.getDashboardShouldPreserveUnavailableTopologyCounts:
+        // proxy/name-server counts are deliberately null when the topology is unavailable.
+        when(dashboardService.getDashboard()).thenReturn(DashboardDataVO.builder()
+                .stats(DashboardStatsVO.builder()
+                        .totalClusters(1)
+                        .healthyClusters(1)
+                        .totalBrokers(2)
+                        .totalProxies(null)
+                        .totalNameServers(null)
+                        .totalTopics(3)
+                        .totalConsumerGroups(4)
+                        .build())
+                .clusters(List.of(ClusterOverviewVO.builder()
+                        .id("cluster-v5")
+                        .name("test")
+                        .type(ClusterType.V5_PROXY_CLUSTER)
+                        .status(ClusterStatus.healthy)
+                        .brokers(2)
+                        .proxies(null)
+                        .topics(3)
+                        .groups(4)
+                        .tpsIn(7)
+                        .tpsOut(8)
+                        .version("5.2.0")
+                        .build()))
+                .build());
+
+        Object output = gateway.execute(
+                "rmq.dashboard.summary", Map.of("cluster", "cluster-v5"));
+
+        Map<String, Object> result = (Map<String, Object>) output;
+        Map<String, Object> cluster = (Map<String, Object>) result.get("cluster");
+        assertThat(cluster).containsEntry("proxies", null);
+        Map<String, Object> stats = (Map<String, Object>) result.get("stats");
+        assertThat(stats).containsEntry("totalProxies", null);
+        assertThat(stats).containsEntry("totalNameServers", null);
+    }
+
+    @Test
     void rejectsDashboardSummaryWithoutRequiredClusterBeforeHandlerRuns() {
         assertThatThrownBy(() -> gateway.execute("rmq.dashboard.summary", Map.of()))
                 .isInstanceOf(BusinessException.class)
@@ -456,6 +501,24 @@ class ToolGatewayServiceTest {
                 "page", 2,
                 "size", 20));
         assertThat(output.toString()).doesNotContain("delaySeconds");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void executesConsumerGroupListWhenLagIsUnknown() {
+        when(clusterService.getCluster("cluster-v5")).thenReturn(cluster(ClusterType.V5_PROXY_CLUSTER));
+        ConsumerGroupVO group = consumerGroup();
+        group.setTotalLag(ConsumerLagResolver.UNKNOWN);
+        when(metadataService.listConsumerGroupsPage(any(), any(), any(), anyInt(), anyInt()))
+                .thenReturn(PageResult.of(List.of(group), 1, 1, 20));
+
+        Object output = gateway.execute("rmq.group.list", Map.of(
+                "cluster", "cluster-v5", "search", "order", "page", 1, "pageSize", 20));
+
+        Map<String, Object> page = (Map<String, Object>) output;
+        List<Map<String, Object>> items = (List<Map<String, Object>>) page.get("items");
+        assertThat(items).hasSize(1);
+        assertThat(items.get(0)).containsEntry("totalLag", null);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/TopicListToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/TopicListToolHandlerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai.tool;
+
+import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
+import org.apache.rocketmq.studio.common.domain.enums.TopicType;
+import org.apache.rocketmq.studio.instance.topic.MetadataService;
+import org.apache.rocketmq.studio.instance.topic.TopicVO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TopicListToolHandlerTest {
+
+    @Mock
+    private MetadataService metadataService;
+
+    @InjectMocks
+    private TopicListToolHandler handler;
+
+    @Test
+    void executeShouldRouteClusterToClusterScopedRead() {
+        TopicVO topic = new TopicVO();
+        topic.setName("orders");
+        topic.setClusterId("DefaultCluster");
+        topic.setType(TopicType.NORMAL);
+        topic.setPerm(TopicPerm.RW);
+        topic.setWriteQueues(8);
+        topic.setReadQueues(8);
+        topic.setMessageCount(100L);
+        topic.setTps(1.5D);
+        topic.setConsumerGroupCount(2);
+        when(metadataService.listTopicsPage(isNull(), eq("DefaultCluster"), eq("NORMAL"), eq("order"), eq(1), eq(20)))
+                .thenReturn(PageResult.of(List.of(topic), 1L, 1, 20));
+
+        Object result = handler.execute(Map.of(
+                "cluster", "DefaultCluster", "type", "NORMAL", "search", "order"));
+
+        Map<?, ?> page = (Map<?, ?>) result;
+        assertThat(page.get("total")).isEqualTo(1L);
+        assertThat(page.get("page")).isEqualTo(1);
+        assertThat(page.get("size")).isEqualTo(20);
+        List<?> items = (List<?>) page.get("items");
+        assertThat(items).hasSize(1);
+        Map<?, ?> row = (Map<?, ?>) items.get(0);
+        assertThat(row.get("name")).isEqualTo("orders");
+        assertThat(row.get("type")).isEqualTo("NORMAL");
+        assertThat(row.get("perm")).isEqualTo("RW");
+        verify(metadataService).listTopicsPage(isNull(), eq("DefaultCluster"), eq("NORMAL"), eq("order"), eq(1), eq(20));
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -313,17 +313,41 @@ class AliyunInstanceProviderTest {
 
         List<QueueProgressVO> rows = provider.getGroupProgress(STUDIO_INSTANCE_ID, "GID_test");
 
-        assertThat(rows).hasSize(2);
+        // with a topic breakdown the aggregate total row is dropped, otherwise callers
+        // that sum the rows would report the same lag twice
+        assertThat(rows).hasSize(1);
         QueueProgressVO topicRow = rows.stream()
                 .filter(row -> "topic:topic-a".equals(row.getBroker()))
                 .findFirst()
                 .orElseThrow();
         assertThat(topicRow.getDiffTotal()).isEqualTo(42L);
-        QueueProgressVO totalRow = rows.stream()
-                .filter(row -> "total".equals(row.getBroker()))
-                .findFirst()
-                .orElseThrow();
-        assertThat(totalRow.getDiffTotal()).isEqualTo(100L);
+        assertThat(rows).noneMatch(row -> "total".equals(row.getBroker()));
+    }
+
+    @Test
+    void getGroupProgressShouldFallBackToTotalRowWithoutTopicBreakdownTest() {
+        stubInstance();
+        stubCallThrough();
+        GetConsumerGroupLagResponse response = GetConsumerGroupLagResponse.create().toBuilder()
+                .statusCode(200)
+                .body(GetConsumerGroupLagResponseBody.builder()
+                        .data(GetConsumerGroupLagResponseBody.Data.builder()
+                                .consumerGroupId("GID_test")
+                                .totalLag(GetConsumerGroupLagResponseBody.TotalLag.builder()
+                                        .readyCount(100L)
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+        when(asyncClient.getConsumerGroupLag(any()))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        List<QueueProgressVO> rows = provider.getGroupProgress(STUDIO_INSTANCE_ID, "GID_test");
+
+        assertThat(rows).singleElement().satisfies(row -> {
+            assertThat(row.getBroker()).isEqualTo("total");
+            assertThat(row.getDiffTotal()).isEqualTo(100L);
+        });
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -38,6 +38,7 @@ import com.aliyun.sdk.service.rocketmq20220801.models.ResetConsumeOffsetResponse
 import com.aliyun.sdk.service.rocketmq20220801.models.ResetConsumeOffsetResponseBody;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
@@ -129,16 +130,35 @@ class AliyunInstanceProviderTest {
         assertThat(all).hasSize(3);
         assertThat(all.get(0).getName()).isEqualTo("topic-normal");
         assertThat(all.get(0).getType()).isEqualTo(TopicType.NORMAL);
+        assertThat(all.get(0).getPerm()).isEqualTo(TopicPerm.RW);
         assertThat(all.get(0).getInstanceId()).isEqualTo(STUDIO_INSTANCE_PK);
         assertThat(all.get(0).getWriteQueues()).isZero();
         assertThat(all.get(0).getReadQueues()).isZero();
         assertThat(all.get(0).getRemark()).isEqualTo("remark-topic-normal");
-        assertThat(all.get(2).getType()).isNull();
+        assertThat(all.get(2).getType()).isEqualTo(TopicType.NORMAL);
 
         List<TopicVO> fifos = provider.listTopics(STUDIO_INSTANCE_ID, "FIFO", null);
 
         assertThat(fifos).hasSize(1);
         assertThat(fifos.get(0).getType()).isEqualTo(TopicType.FIFO);
+    }
+
+    @Test
+    void listTopicsShouldGuaranteeTypeAndPermForAiToolProjectionTest() {
+        stubInstance();
+        stubCallThrough();
+        when(asyncClient.listTopics(any(ListTopicsRequest.class))).thenReturn(CompletableFuture.completedFuture(
+                topicsResponse(
+                        topicRow("topic-untyped", null),
+                        topicRow("topic-unknown", "NEW_TYPE"))));
+
+        List<TopicVO> topics = provider.listTopics(STUDIO_INSTANCE_ID, null, null);
+
+        assertThat(topics).hasSize(2);
+        assertThat(topics).allSatisfy(topic -> {
+            assertThat(topic.getType()).isEqualTo(TopicType.NORMAL);
+            assertThat(topic.getPerm()).isEqualTo(TopicPerm.RW);
+        });
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -37,6 +37,7 @@ import com.aliyun.sdk.service.rocketmq20220801.models.ResetConsumeOffsetRequest;
 import com.aliyun.sdk.service.rocketmq20220801.models.ResetConsumeOffsetResponse;
 import com.aliyun.sdk.service.rocketmq20220801.models.ResetConsumeOffsetResponseBody;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
+import org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
@@ -242,6 +243,37 @@ class AliyunInstanceProviderTest {
         assertThat(groups.get(0).getName()).isEqualTo("GID_test");
         assertThat(groups.get(0).getInstanceId()).isEqualTo(STUDIO_INSTANCE_PK);
         assertThat(groups.get(0).getConsumeType()).isEqualTo(ConsumeType.CLUSTERING);
+        assertThat(groups.get(0).getSubscriptionMode()).isEqualTo(SubscriptionMode.Push);
+    }
+
+    @Test
+    void listConsumerGroupsShouldFallBackWhenMessageModelMissingTest() {
+        stubInstance();
+        stubCallThrough();
+        ListConsumerGroupsResponse response = ListConsumerGroupsResponse.create().toBuilder()
+                .statusCode(200)
+                .body(ListConsumerGroupsResponseBody.builder()
+                        .data(ListConsumerGroupsResponseBody.Data.builder()
+                                .list(java.util.Arrays.asList(ListConsumerGroupsResponseBody.List.builder()
+                                        .consumerGroupId("GID_plain")
+                                        .status("RUNNING")
+                                        .build()))
+                                .pageNumber(1L)
+                                .pageSize(100L)
+                                .totalCount(1L)
+                                .build())
+                        .build())
+                .build();
+        when(asyncClient.listConsumerGroups(any()))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        List<ConsumerGroupVO> groups = provider.listConsumerGroups(STUDIO_INSTANCE_ID, null);
+
+        assertThat(groups).singleElement().satisfies(group -> {
+            // read paths (web detail, AI rmq.group.list) require both enums to be non-null
+            assertThat(group.getConsumeType()).isEqualTo(ConsumeType.CLUSTERING);
+            assertThat(group.getSubscriptionMode()).isEqualTo(SubscriptionMode.Push);
+        });
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -44,6 +44,7 @@ import com.tencentcloudapi.trocket.v20230308.models.SubscriptionData;
 import com.tencentcloudapi.trocket.v20230308.models.TopicItem;
 import com.tencentcloudapi.trocket.v20230308.TrocketClient;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
+import org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
@@ -556,6 +557,7 @@ class TencentInstanceProviderTest {
         assertThat(groups.get(0).getRetryMaxTimes()).isEqualTo(16);
         assertThat(groups.get(0).getGmtCreate()).isNotNull();
         assertThat(groups.get(0).getConsumeType()).isEqualTo(ConsumeType.CLUSTERING);
+        assertThat(groups.get(0).getSubscriptionMode()).isEqualTo(SubscriptionMode.Push);
         assertThat(groups.get(0).getInstances()).isNotNull().isEmpty();
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -46,6 +46,7 @@ import com.tencentcloudapi.trocket.v20230308.TrocketClient;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
@@ -208,6 +209,25 @@ class TencentInstanceProviderTest {
                 .containsExactly("TopicName", "TopicType");
         assertThat(captor.getValue().getFilters()[0].getValues()).containsExactly("fifo");
         assertThat(captor.getValue().getFilters()[1].getValues()).containsExactly("FIFO");
+    }
+
+    @Test
+    void listTopicsShouldFallBackToNormalTypeWhenTopicTypeMissingTest() throws Exception {
+        when(client.DescribeTopicList(any())).thenAnswer(invocation -> {
+            DescribeTopicListResponse response = new DescribeTopicListResponse();
+            response.setData(new TopicItem[]{
+                    topicItem("orders-untyped", null, 4L),
+                    topicItem("orders-unknown", "NEW_TYPE", 4L)});
+            return response;
+        });
+        DescribeTopicResponse detail = new DescribeTopicResponse();
+        when(client.DescribeTopic(any())).thenReturn(detail);
+
+        List<TopicVO> topics = provider.listTopics(STUDIO_INSTANCE_ID, null, null);
+
+        assertThat(topics).hasSize(2);
+        assertThat(topics).allSatisfy(topic -> assertThat(topic.getType()).isEqualTo(TopicType.NORMAL));
+        assertThat(topics).allSatisfy(topic -> assertThat(topic.getPerm()).isEqualTo(TopicPerm.RW));
     }
 
     @Test


### PR DESCRIPTION
### Motivation

`rmq.topic.list` and `rmq.group.list` always fail with `404 Instance not found: DefaultCluster` in the default deployment (namesrv-only, no registered instances).

`MetadataService.listTopicsPage(instanceId, clusterId, ...)` routes a **blank instance id + non-blank cluster id** to the legacy cluster-scoped read (the branch commented `// legacy cluster-scoped read kept for AI tool handlers`). But both handlers pass the tool's `cluster` input into the **first** (instanceId) slot and `null` into the second:

```java
// TopicListToolHandler / ConsumerGroupListToolHandler
metadataService.listTopicsPage(clusterId, null, type, search, page, pageSize);
```

A cluster name such as `DefaultCluster` therefore reaches `providerRegistry.byInstanceId(...)`, which throws `404 "Instance not found: DefaultCluster"` for any value that is not a registered instance id.

This is a regression from #3052: the handlers previously called the 3-arg `listTopics(clusterId, type, search)` overload, which delegates to `listTopics(null, clusterId, ...)` — the old first parameter *was* the cluster id, and #3052 mapped it onto the new signature's renamed first parameter (`instanceId`) unchanged:

```diff
-        return metadataService.listTopics(clusterId, type, search).stream()
+        PageResult<TopicVO> page = metadataService.listTopicsPage(
+                clusterId, null, type, search, ToolListPagination.page(input), ToolListPagination.pageSize(input));
```

The same request proves the contradiction internally: `ToolGatewayService.enforceCapabilities` resolves the same `cluster` input through `clusterService.getCluster(...)` (cluster-name space) and succeeds, then the handler 404s on the same value in the instance-id space.

### Modifications

- `TopicListToolHandler` / `ConsumerGroupListToolHandler`: pass `null` as the instance id and the tool's `cluster` input as the cluster id, restoring the pre-#3052 routing and making the cluster-scoped branch reachable again.
- `ToolGatewayServiceTest`: updated the two stubs that pinned the previous slotting.

### Verification

- New `TopicListToolHandlerTest` / `ConsumerGroupListToolHandlerTest` (modeled on `MessageQueryToolHandlerTest`) stub `metadataService.listTopicsPage(isNull(), eq("DefaultCluster"), ...)` and verify the delegation.
  - Before the fix: both fail with `PotentialStubbingProblem` — the handlers invoke `("DefaultCluster", null, ...)`.
  - After the fix: both pass.
- `mvn -f server/pom.xml test -Dtest='TopicListToolHandlerTest,ConsumerGroupListToolHandlerTest,ToolGatewayServiceTest'` → **Tests run: 34, Failures: 0, Errors: 0**.
