### PR TITLE
fix(ai): allow null counts in tool output schemas

### DIFF
--- a/server/src/main/resources/tool-catalog/rmq-tools.yaml
+++ b/server/src/main/resources/tool-catalog/rmq-tools.yaml
@@ -126,7 +126,7 @@ tools:
             brokers:
               type: integer
             proxies:
-              type: integer
+              type: [integer, 'null']
             topics:
               type: integer
             groups:
@@ -164,9 +164,9 @@ tools:
             totalBrokers:
               type: integer
             totalProxies:
-              type: integer
+              type: [integer, 'null']
             totalNameServers:
-              type: integer
+              type: [integer, 'null']
             totalTopics:
               type: integer
             totalConsumerGroups:
@@ -332,7 +332,7 @@ tools:
               onlineInstances:
                 type: integer
               totalLag:
-                type: integer
+                type: [integer, 'null']
               subscribedTopics:
                 type: array
                 items:

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
@@ -41,6 +41,7 @@ import org.apache.rocketmq.studio.ops.dashboard.ClusterOverviewVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardService;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardStatsVO;
+import org.apache.rocketmq.studio.provider.apache.ConsumerLagResolver;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,6 +55,8 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -340,6 +343,48 @@ class ToolGatewayServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void executesDashboardSummaryWhenTopologyCountsAreUnavailable() {
+        // Mirrors the V5/degraded provider paths (RocketMQDashboardProvider) and
+        // DashboardControllerTest.getDashboardShouldPreserveUnavailableTopologyCounts:
+        // proxy/name-server counts are deliberately null when the topology is unavailable.
+        when(dashboardService.getDashboard()).thenReturn(DashboardDataVO.builder()
+                .stats(DashboardStatsVO.builder()
+                        .totalClusters(1)
+                        .healthyClusters(1)
+                        .totalBrokers(2)
+                        .totalProxies(null)
+                        .totalNameServers(null)
+                        .totalTopics(3)
+                        .totalConsumerGroups(4)
+                        .build())
+                .clusters(List.of(ClusterOverviewVO.builder()
+                        .id("cluster-v5")
+                        .name("test")
+                        .type(ClusterType.V5_PROXY_CLUSTER)
+                        .status(ClusterStatus.healthy)
+                        .brokers(2)
+                        .proxies(null)
+                        .topics(3)
+                        .groups(4)
+                        .tpsIn(7)
+                        .tpsOut(8)
+                        .version("5.2.0")
+                        .build()))
+                .build());
+
+        Object output = gateway.execute(
+                "rmq.dashboard.summary", Map.of("cluster", "cluster-v5"));
+
+        Map<String, Object> result = (Map<String, Object>) output;
+        Map<String, Object> cluster = (Map<String, Object>) result.get("cluster");
+        assertThat(cluster).containsEntry("proxies", null);
+        Map<String, Object> stats = (Map<String, Object>) result.get("stats");
+        assertThat(stats).containsEntry("totalProxies", null);
+        assertThat(stats).containsEntry("totalNameServers", null);
+    }
+
+    @Test
     void rejectsDashboardSummaryWithoutRequiredClusterBeforeHandlerRuns() {
         assertThatThrownBy(() -> gateway.execute("rmq.dashboard.summary", Map.of()))
                 .isInstanceOf(BusinessException.class)
@@ -456,6 +501,24 @@ class ToolGatewayServiceTest {
                 "page", 2,
                 "size", 20));
         assertThat(output.toString()).doesNotContain("delaySeconds");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void executesConsumerGroupListWhenLagIsUnknown() {
+        when(clusterService.getCluster("cluster-v5")).thenReturn(cluster(ClusterType.V5_PROXY_CLUSTER));
+        ConsumerGroupVO group = consumerGroup();
+        group.setTotalLag(ConsumerLagResolver.UNKNOWN);
+        when(metadataService.listConsumerGroupsPage(any(), any(), any(), anyInt(), anyInt()))
+                .thenReturn(PageResult.of(List.of(group), 1, 1, 20));
+
+        Object output = gateway.execute("rmq.group.list", Map.of(
+                "cluster", "cluster-v5", "search", "order", "page", 1, "pageSize", 20));
+
+        Map<String, Object> page = (Map<String, Object>) output;
+        List<Map<String, Object>> items = (List<Map<String, Object>>) page.get("items");
+        assertThat(items).hasSize(1);
+        assertThat(items.get(0)).containsEntry("totalLag", null);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

`rmq.dashboard.summary` and `rmq.group.list` fail output validation (HTTP 500 `IllegalStateException: Tool output validation failed`) whenever the data behind a declared `type: integer` count is unavailable — which the producers deliberately encode as `null`:

- `rmq.dashboard.summary`: `RocketMQDashboardProvider` reports proxy/name-server topology counts as `null` for V5 clusters (`.proxies(clusterType == ClusterType.V4_DIRECT ? 0 : null)`), for aggregate mode (`.totalProxies(null)`), and in the degraded no-namesrv path (both `totalProxies(null)` / `totalNameServers(null)`). `DashboardControllerTest.getDashboardShouldPreserveUnavailableTopologyCounts` pins these nulls as the intended HTTP semantics — only the tool schema rejects them.
- `rmq.group.list`: #3988 deliberately changed the handler projection to `totalLag == ConsumerLagResolver.UNKNOWN ? null : totalLag` (unknown lag for 5.0 gRPC consumers), but the output schema was not updated — so any cluster containing one such group makes the whole listing fail with a 500, exactly when the user most needs it.

`objectMapper.valueToTree` keeps the keys (`{"totalLag": null}`) and the schema validator rejects `null` against `type: integer`.

### Modifications

In `tool-catalog/rmq-tools.yaml`, the four affected fields become `type: ['integer', 'null']` (keys stay in `required`, so they must still be present):
- `rmq.dashboard.summary` → `cluster.proxies`, `stats.totalProxies`, `stats.totalNameServers`
- `rmq.group.list` → `items[].totalLag`

### Verification

Two new `ToolGatewayServiceTest` cases mirroring the producer semantics:
- `executesDashboardSummaryWhenTopologyCountsAreUnavailable` (dashboard with `proxies/totalProxies/totalNameServers = null`)
- `executesConsumerGroupListWhenLagIsUnknown` (group with `totalLag = ConsumerLagResolver.UNKNOWN`)

Before the fix both fail with the production error, e.g.:
```
IllegalStateException: Tool output validation failed for rmq.dashboard.summary:
[/cluster/proxies: null found, integer expected,
 /stats/totalNameServers: null found, integer expected,
 /stats/totalProxies: null found, integer expected]
IllegalStateException: Tool output validation failed for rmq.group.list:
[/items/0/totalLag: null found, integer expected]
```

After the fix: `mvn -f server/pom.xml test -Dtest='ToolGatewayServiceTest,ToolCatalogTest'` → **Tests run: 40, Failures: 0, Errors: 0** (catalog meta-schema validation included).
