### PR TITLE
fix(metrics): report unknown queue lag instead of clamping the sentinel

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqBusinessMetricsCollector.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqBusinessMetricsCollector.java
@@ -129,6 +129,15 @@ public class ApacheRocketMqBusinessMetricsCollector implements BusinessMetricsCo
         Map<String, String> labels = Map.of("consumerGroup", group.getName());
         try {
             List<QueueProgressVO> progress = provider.getGroupProgress(instance.getName(), group.getName());
+            if (progress.stream().anyMatch(row -> row.getDiffTotal() == ConsumerLagResolver.UNKNOWN)) {
+                // diffTotal carries the -1 unknown sentinel (RocketMQ 5.0 gRPC consumers); clamping
+                // it would feed max-queue/backlog alerts a fabricated zero-lag AVAILABLE sample,
+                // the same way consumer.lag.total did before it was fixed.
+                return List.of(unavailable(CONSUMER_LAG_MAX_QUEUE, instance, labels, collectedAt,
+                        "CONSUMER_LAG_UNKNOWN"),
+                        unavailable(TOPIC_BACKLOG_TOTAL, instance, labels, collectedAt,
+                                "CONSUMER_LAG_UNKNOWN"));
+            }
             long maxLag = progress.stream().mapToLong(QueueProgressVO::getDiffTotal)
                     .map(value -> Math.max(0, value)).max().orElse(0);
             List<MetricSample> samples = new ArrayList<>();

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqBusinessMetricsCollectorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqBusinessMetricsCollectorTest.java
@@ -150,6 +150,30 @@ class ApacheRocketMqBusinessMetricsCollectorTest {
                 });
     }
 
+    @Test
+    void reportsUnavailableQueueLagWhenProgressCarriesSentinelTest() {
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        InstanceProvider provider = mock(InstanceProvider.class);
+        ConsumerGroupVO orders = group("orders", "cluster-a", ConsumerLagResolver.UNKNOWN);
+        when(registry.byInstanceId("local")).thenReturn(Optional.of(provider));
+        when(provider.listConsumerGroups("local", null)).thenReturn(List.of(orders));
+        // resolveDiff passes the -1 unknown sentinel through into QueueProgressVO.diffTotal
+        // (RocketMQ 5.0 gRPC consumers), so progress can legitimately carry it.
+        when(provider.getGroupProgress("local", "orders")).thenReturn(List.of(QueueProgressVO.builder()
+                .topic("orders-topic").diffTotal(ConsumerLagResolver.UNKNOWN).build()));
+
+        List<MetricSample> samples = new ApacheRocketMqBusinessMetricsCollector(registry).collect(apacheInstance());
+
+        assertThat(samples).filteredOn(sample -> sample.metricKey().equals(
+                ApacheRocketMqBusinessMetricsCollector.CONSUMER_LAG_MAX_QUEUE)
+                || sample.metricKey().equals(ApacheRocketMqBusinessMetricsCollector.TOPIC_BACKLOG_TOTAL))
+                .hasSize(2).allSatisfy(sample -> {
+                    assertThat(sample.availability()).isEqualTo(MetricAvailability.UNAVAILABLE);
+                    assertThat(sample.value()).isNull();
+                    assertThat(sample.unavailableReason()).isEqualTo("CONSUMER_LAG_UNKNOWN");
+                });
+    }
+
     private static ConsumerGroupVO group(String name, String clusterId, long lag) {
         ConsumerGroupVO group = new ConsumerGroupVO();
         group.setName(name);


### PR DESCRIPTION
### Motivation

`ApacheRocketMqBusinessMetricsCollector.queueLagSamples` clamps every `QueueProgressVO.diffTotal` with `Math.max(0, ...)`. But `RocketMQMetadataProvider.resolveDiff` deliberately passes the broker's `-1` unknown sentinel through into `diffTotal` (its javadoc: *"Resolves the lag for a single queue without clamping the broker's `-1` 'unknown' sentinel to zero… so the unknown state stays visible"* — typical for RocketMQ 5.0 gRPC consumers). The clamp therefore turns "lag unknown" into a fabricated **zero-lag AVAILABLE sample** for `consumer.lag.max_queue` and `topic.backlog.total`:

- a "max queue lag > N" or "topic backlog > N" rule never fires while the state is unknown;
- an already-FIRING alert receives healthy `0`s and falsely resolves;
- window aggregations (AVG/MAX) are diluted with fake `0`s;
- and because a sample *is* emitted, `reconcileMissingActiveStates` never sees a gap to reconcile — the unknown state is fully masked.

This is the same defect #3988 fixed for `consumer.lag.total` (its comment: *"do not clamp it into a fabricated zero-lag AVAILABLE sample that would feed consumer.lag.total alerts a fake 0"*). The sibling `queueLagSamples` path was not covered by that fix.

### Modifications

`queueLagSamples` first checks whether any progress row carries `ConsumerLagResolver.UNKNOWN`; if so it returns UNAVAILABLE samples with reason `CONSUMER_LAG_UNKNOWN` for both affected metrics (mirroring the fixed `totalLag` path). The `Math.max(0, ...)` clamp is kept for the normal path, guarding only genuinely impossible negatives.

### Verification

New test `reportsUnavailableQueueLagWhenProgressCarriesSentinelTest` (modeled on `reportsUnavailableTotalLagWhenSentinelUnknownTest`) stubs `getGroupProgress` with `diffTotal = ConsumerLagResolver.UNKNOWN`:
- Before the fix: fails — samples come back `AVAILABLE` with a fabricated `0`.
- After the fix: passes — both metrics are `UNAVAILABLE`, value `null`, reason `CONSUMER_LAG_UNKNOWN`.
- Full metrics module regression: `mvn -f server/pom.xml test -Dtest='org.apache.rocketmq.studio.cluster.metrics.**'` → **Tests run: 142, Failures: 0, Errors: 0**.
