### PR TITLE
feat: inspect native ConsumeQueue storage indices

### DIFF
--- a/docs/consume-queue-inspection.md
+++ b/docs/consume-queue-inspection.md
@@ -1,0 +1,71 @@
+# ConsumeQueue 索引诊断
+
+## 场景与入口
+
+消息查询页切换到“按队列浏览”，选择 Topic 并加载队列，
+点击目标队列的 `Inspect index`。此功能用于检查存储索引与扩展过滤信息，
+例如消息体尚未拉取、SQL92 初筛行为需要核对、索引扩展数据缺失等场景。
+
+功能仅对真实 Apache 实例开放，云厂商实例和模拟数据模式不提供入口。
+服务端复用实例解析器与凭据配置，不接受客户端指定任意 Broker 地址。
+读取者可调用只读接口，不需要管理员写权限。
+
+## 请求与结果
+
+`GET /api/messages/consume-queue` 参数：
+
+| 参数 | 含义 |
+| --- | --- |
+| instanceId | 已登记的 Apache 实例 |
+| topic、brokerName、queueId | Topic 与目标队列；queueId 非负 |
+| index | 非负有符号 64 位十进制字符串 |
+| count | 逻辑索引跨度，1–32，默认 16 |
+| consumerGroup | 可选消费组，用于读取 Broker 当前订阅与初筛信息 |
+
+服务端先查所选实例的集群登记信息，定位 brokerId=0 的主节点，
+再通过 Topic 统计确认该队列存在并取得范围。没有主节点或队列时明确报错。
+不回退到副本，不自动移动到别的队列，不持久化任何配置。
+
+输入 index 可以等于队列末尾 max，此时返回 `atEnd=true` 与空数组，
+避免 Broker 对不存在的迭代位置返回成功但没有消息体的响应。
+小于 min 或大于 max 返回业务码 416，并提供采样范围。
+Broker 范围不合法、返回体或索引列表缺失时返回 502，不伪装成空队列。
+
+结果中的 minIndex、maxIndex、requestedIndex、physicalOffset 和 tagsCode
+均为十进制字符串，浏览器不把它们转换为 JavaScript Number。
+每个条目包含物理位置、物理大小、tagsCode、可用的扩展 JSON、位图及 Broker 提示。
+
+## 如何解释过滤与条目位置
+
+RocketMQ 的响应条目没有逐条逻辑 queueOffset。表格 Ordinal 仅表示返回顺序，
+不能用 `index + ordinal - 1` 推算逻辑位置。批量队列尤其可能只返回少量条目；
+count 表示逻辑跨度，不承诺返回恰好 count 条记录。
+
+SDK 的 eval 是原生布尔值，默认 false。Broker 对不需要扩展过滤的条目会直接跳过，
+因此本功能仅在请求指定消费组、Broker 返回订阅、且条目带扩展数据时展示布尔结果。
+其余情况 `indexMatch=null`，页面显示 `Not evaluated`。
+消费组离线、订阅不存在、扩展索引缺失都不能由默认 false 推断为“过滤未通过”。
+
+`Passed` 仅表示 ConsumeQueue 阶段通过，仍可能需要 CommitLog 阶段过滤；
+它不表示消费成功、最终表达式匹配或消息已经投递。本接口不读取消息正文。
+Broker filter metadata、扩展 JSON 和位图保留原始内容以便诊断。
+
+## 一致性与限制
+
+Topic 范围与索引读取是两次请求，并非原子快照。保留策略、主从切换或持续写入
+可能在两次采样之间改变范围；成功读取时使用索引响应自带的最新范围。
+失败后可手动重新查询，不自动重试或修改输入。关闭弹窗会取消前端请求并丢弃迟到响应；
+这不保证已发往 Broker 的读取立即停止。修改输入会清除旧诊断结果。
+
+## 验证与回滚
+
+本地验证覆盖精度、边界、初筛三态、缺失元数据、主节点约束、HTTP 契约、
+取消与迟到响应，以及原消息页和队列浏览回归。实际集群存储布局与 Broker 版本
+兼容性仍需在目标环境验证；未执行真实集群 E2E、压力、容量或混沌测试。
+
+无新增依赖、无数据库迁移；直接部署包含功能的版本即可。
+回滚时撤销本次提交或部署前一版本，无远端数据需要恢复。
+
+协议依据：Apache RocketMQ `AdminBrokerProcessor.queryConsumeQueue`、
+`QueryConsumeQueueResponseBody`、`ConsumeQueueData`。
+核验日期：2026-09-08。

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/ConsumeQueueController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/ConsumeQueueController.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.Result;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ConsumeQueueController {
+    private final ConsumeQueueService service;
+
+    @GetMapping("/api/messages/consume-queue")
+    public Result<ConsumeQueueSnapshot> inspect(@RequestParam String instanceId,
+            @RequestParam String topic, @RequestParam String brokerName, @RequestParam int queueId,
+            @RequestParam String index, @RequestParam(defaultValue = "16") int count,
+            @RequestParam(required = false) String consumerGroup) {
+        return Result.ok(service.inspect(instanceId, topic, brokerName, queueId, index, count, consumerGroup));
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/ConsumeQueueService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/ConsumeQueueService.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.protocol.body.ConsumeQueueData;
+import org.apache.rocketmq.remoting.protocol.body.QueryConsumeQueueResponseBody;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.remoting.protocol.admin.TopicOffset;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class ConsumeQueueService {
+    private final RuntimeAdminClientResolver resolver;
+
+    public ConsumeQueueSnapshot inspect(String instanceId, String topic, String brokerName,
+            int queueId, String index, int count, String consumerGroup) {
+        if (!StringUtils.hasText(topic) || !StringUtils.hasText(brokerName) || queueId < 0
+                || count < 1 || count > 32) {
+            throw new BusinessException(400, "Topic, broker, nonnegative queue ID and count 1..32 are required");
+        }
+        long start = parseIndex(index);
+        String group = StringUtils.hasText(consumerGroup) ? consumerGroup.trim() : null;
+        return resolver.execute(instanceId, admin -> {
+            try {
+                var cluster = admin.examineBrokerClusterInfo();
+                BrokerData broker = cluster == null || cluster.getBrokerAddrTable() == null
+                        ? null : cluster.getBrokerAddrTable().get(brokerName);
+                String address = broker == null || broker.getBrokerAddrs() == null
+                        ? null : broker.getBrokerAddrs().get(0L);
+                if (!StringUtils.hasText(address)) {
+                    throw new BusinessException(404, "Registered master not found for broker: " + brokerName);
+                }
+                var stats = admin.examineTopicStats(topic);
+                TopicOffset range = stats == null || stats.getOffsetTable() == null ? null
+                        : stats.getOffsetTable().get(new MessageQueue(topic, brokerName, queueId));
+                if (range == null) {
+                    throw new BusinessException(404, "Queue not found in the selected topic");
+                }
+                long min = range.getMinOffset();
+                long max = range.getMaxOffset();
+                if (min < 0 || max < min) {
+                    throw new BusinessException(502, "Broker returned an invalid queue range");
+                }
+                if (start < min || start > max) {
+                    throw new BusinessException(416, "Index is outside [" + min + ", " + max + "]");
+                }
+                if (start == max) {
+                    return new ConsumeQueueSnapshot(address, Long.toString(min), Long.toString(max),
+                            Long.toString(start), count, true, null, null, null, List.of());
+                }
+                var body = admin.queryConsumeQueue(address, topic, queueId, start, count, group);
+                return snapshot(address, start, count, group, body);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new BusinessException(502, "ConsumeQueue inspection was interrupted");
+            }
+        });
+    }
+
+    private long parseIndex(String index) {
+        if (index == null || !index.matches("[0-9]{1,19}")) {
+            throw new BusinessException(400, "Index must be a nonnegative 64-bit decimal string");
+        }
+        try {
+            return Long.parseLong(index);
+        } catch (NumberFormatException exception) {
+            throw new BusinessException(400, "Index exceeds the signed 64-bit range");
+        }
+    }
+
+    private ConsumeQueueSnapshot snapshot(String address, long start, int count, String group,
+            QueryConsumeQueueResponseBody body) {
+        if (body == null || body.getQueueData() == null || body.getMinQueueIndex() < 0
+                || body.getMaxQueueIndex() < body.getMinQueueIndex()) {
+            throw new BusinessException(502, "Broker did not return a valid ConsumeQueue snapshot");
+        }
+        var subscription = body.getSubscriptionData();
+        List<ConsumeQueueSnapshot.Entry> entries = new ArrayList<>();
+        for (ConsumeQueueData data : body.getQueueData()) {
+            if (data == null || entries.size() >= count) {
+                throw new BusinessException(502, "Broker returned invalid or excessive index entries");
+            }
+            // RocketMQ leaves eval=false when it skips extension-based filtering.
+            Boolean match = group != null && subscription != null && data.getExtendDataJson() != null
+                    ? data.isEval() : null;
+            entries.add(new ConsumeQueueSnapshot.Entry(entries.size() + 1,
+                    Long.toString(data.getPhysicOffset()), data.getPhysicSize(),
+                    Long.toString(data.getTagsCode()), data.getExtendDataJson(), data.getBitMap(),
+                    match, data.getMsg()));
+        }
+        return new ConsumeQueueSnapshot(address, Long.toString(body.getMinQueueIndex()),
+                Long.toString(body.getMaxQueueIndex()), Long.toString(start), count, false,
+                subscription == null ? null : subscription.getExpressionType(),
+                subscription == null ? null : subscription.getSubString(), body.getFilterData(),
+                List.copyOf(entries));
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/ConsumeQueueSnapshot.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/ConsumeQueueSnapshot.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import java.util.List;
+
+public record ConsumeQueueSnapshot(String brokerAddress, String minIndex, String maxIndex,
+        String requestedIndex, int count, boolean atEnd, String expressionType, String expression,
+        String filterData, List<Entry> entries) {
+    public record Entry(int ordinal, String physicalOffset, int physicalSize, String tagsCode,
+            String extension, String bitmap, Boolean indexMatch, String message) {
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/ConsumeQueueServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/ConsumeQueueServiceTest.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.body.ConsumeQueueData;
+import org.apache.rocketmq.remoting.protocol.body.QueryConsumeQueueResponseBody;
+import org.apache.rocketmq.remoting.protocol.heartbeat.SubscriptionData;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.remoting.protocol.admin.TopicOffset;
+import org.apache.rocketmq.remoting.protocol.admin.TopicStatsTable;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminProperties;
+import org.apache.rocketmq.studio.cluster.broker.MqClientPool;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ConsumeQueueServiceTest {
+    private final DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+    private final InstanceRepository repository = mock(InstanceRepository.class);
+    private ConsumeQueueService service;
+    private ClusterInfo cluster;
+    private BrokerData broker;
+    private TopicStatsTable stats;
+    private TopicOffset range;
+    private QueryConsumeQueueResponseBody body;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        var factory = new MqAdminExtFactory() {
+            @Override
+            protected DefaultMQAdminExt newAdmin(RPCHook hook) {
+                return admin;
+            }
+        };
+        var resolver = new RuntimeAdminClientResolver(repository, factory, new MqAdminProperties(),
+                mock(MqClientPool.class));
+        service = new ConsumeQueueService(resolver);
+        when(repository.findByIdentifier("instance-a")).thenReturn(Optional.of(
+                InstanceVO.builder().endpoint("ns-a:9876").vendor(InstanceVendor.APACHE).build()));
+        cluster = new ClusterInfo();
+        cluster.setBrokerAddrTable(new HashMap<>());
+        broker = new BrokerData("cluster-a", "broker-a", new HashMap<>());
+        broker.getBrokerAddrs().put(0L, "master-a:10911");
+        cluster.getBrokerAddrTable().put("broker-a", broker);
+        when(admin.examineBrokerClusterInfo()).thenReturn(cluster);
+        stats = new TopicStatsTable();
+        range = new TopicOffset();
+        range.setMinOffset(0);
+        range.setMaxOffset(100);
+        stats.getOffsetTable().put(new MessageQueue("orders", "broker-a", 2), range);
+        when(admin.examineTopicStats("orders")).thenReturn(stats);
+        body = new QueryConsumeQueueResponseBody();
+        body.setMinQueueIndex(0);
+        body.setMaxQueueIndex(100);
+        body.setQueueData(List.of(entry(false)));
+        when(admin.queryConsumeQueue(eq("master-a:10911"), eq("orders"), eq(2),
+                anyLong(), anyInt(), any())).thenReturn(body);
+    }
+
+    private ConsumeQueueData entry(boolean extension) {
+        var data = new ConsumeQueueData();
+        data.setPhysicOffset(9007199254740993L);
+        data.setPhysicSize(128);
+        data.setTagsCode(-9007199254740993L);
+        if (extension) {
+            data.setExtendDataJson("{\"tagsCode\":12}");
+            data.setBitMap("1010");
+        }
+        return data;
+    }
+
+    private ConsumeQueueSnapshot inspect(String index, String group) {
+        return service.inspect("instance-a", "orders", "broker-a", 2, index, 16, group);
+    }
+
+    @Test
+    void preservesPrecisionAndDoesNotInventLogicalOffsetsOrFilterResults() throws Exception {
+        var snapshot = inspect("42", null);
+        assertThat(snapshot.entries()).hasSize(1);
+        var entry = snapshot.entries().getFirst();
+        assertThat(entry.physicalOffset()).isEqualTo("9007199254740993");
+        assertThat(entry.tagsCode()).isEqualTo("-9007199254740993");
+        assertThat(entry.ordinal()).isEqualTo(1);
+        assertThat(entry.indexMatch()).isNull();
+        verify(admin).setNamesrvAddr("ns-a:9876");
+        verify(admin).queryConsumeQueue("master-a:10911", "orders", 2, 42L, 16, null);
+    }
+
+    @Test
+    void mapsOnlyActuallyEvaluatedExtensionResults() {
+        var subscription = new SubscriptionData("orders", "amount > 10");
+        subscription.setExpressionType("SQL92");
+        body.setSubscriptionData(subscription);
+        body.setFilterData("{\"bloomFilterData\":{}}");
+        var pass = entry(true);
+        pass.setEval(true);
+        var reject = entry(true);
+        var missing = entry(false);
+        missing.setMsg("Cq extend not exist!addr: -1");
+        body.setQueueData(List.of(pass, reject, missing));
+        var snapshot = inspect("42", " group-a ");
+        assertThat(snapshot.expressionType()).isEqualTo("SQL92");
+        assertThat(snapshot.expression()).isEqualTo("amount > 10");
+        assertThat(snapshot.filterData()).contains("bloomFilterData");
+        assertThat(snapshot.entries()).extracting(ConsumeQueueSnapshot.Entry::indexMatch)
+                .containsExactly(true, false, null);
+        assertThat(snapshot.entries().getFirst().bitmap()).isEqualTo("1010");
+        assertThat(snapshot.entries().getFirst().extension()).contains("tagsCode");
+        assertThat(snapshot.entries().getLast().message()).contains("not exist");
+    }
+
+    @Test
+    void unavailableSubscriptionAndOmittedGroupCannotReportMatch() {
+        body.setQueueData(List.of(entry(true)));
+        body.setFilterData("group-a@orders is not online!");
+        assertThat(inspect("42", "group-a").entries().getFirst().indexMatch()).isNull();
+        body.setSubscriptionData(new SubscriptionData("orders", "*"));
+        assertThat(inspect("42", " ").entries().getFirst().indexMatch()).isNull();
+    }
+
+    @Test
+    void handlesExactQueueEndWithoutCallingTheBodylessBrokerResponse() throws Exception {
+        range.setMaxOffset(9007199254740993L);
+        var snapshot = inspect("9007199254740993", null);
+        assertThat(snapshot.atEnd()).isTrue();
+        assertThat(snapshot.entries()).isEmpty();
+        assertThat(snapshot.maxIndex()).isEqualTo("9007199254740993");
+        verify(admin, never()).queryConsumeQueue(any(), any(), anyInt(), anyLong(), anyInt(), any());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"-1", "1.1", " 1", "1e3", "9223372036854775808", "11111111111111111111"})
+    void rejectsInvalidIndexBeforeBrokerAccess(String index) throws Exception {
+        assertThatThrownBy(() -> inspect(index, null)).isInstanceOf(BusinessException.class);
+        verify(admin, never()).examineBrokerClusterInfo();
+    }
+
+    @Test
+    void validatesRequiredTargetAndBoundedSpan() {
+        assertThatThrownBy(() -> service.inspect("instance-a", "", "broker-a", 2, "0", 16, null))
+                .hasMessageContaining("required");
+        assertThatThrownBy(() -> service.inspect("instance-a", "orders", "", 2, "0", 16, null))
+                .hasMessageContaining("required");
+        assertThatThrownBy(() -> service.inspect("instance-a", "orders", "broker-a", -1, "0", 16, null))
+                .hasMessageContaining("required");
+        for (int count : new int[] {0, 33}) {
+            assertThatThrownBy(() -> service.inspect("instance-a", "orders", "broker-a", 2, "0", count, null))
+                    .hasMessageContaining("required");
+        }
+    }
+
+    @Test
+    void rejectsUnavailableMastersIncludingMissingTopology() throws Exception {
+        broker.getBrokerAddrs().clear();
+        assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("Registered master");
+        broker.setBrokerAddrs(null);
+        assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("Registered master");
+        cluster.getBrokerAddrTable().clear();
+        assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("Registered master");
+        cluster.setBrokerAddrTable(null);
+        assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("Registered master");
+        when(admin.examineBrokerClusterInfo()).thenReturn(null);
+        assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("Registered master");
+        verify(admin, never()).examineTopicStats(any());
+    }
+
+    @Test
+    void rejectsQueuesOutsideTopicAndInvalidStats() throws Exception {
+        stats.getOffsetTable().clear();
+        assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("Queue not found");
+        stats.setOffsetTable(null);
+        assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("Queue not found");
+        when(admin.examineTopicStats("orders")).thenReturn(null);
+        assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("Queue not found");
+    }
+
+    @Test
+    void distinguishesRetentionRangeErrorsFromInvalidBrokerRanges() {
+        range.setMinOffset(10);
+        assertThatThrownBy(() -> inspect("9", null)).hasMessageContaining("[10, 100]");
+        assertThatThrownBy(() -> inspect("101", null)).hasMessageContaining("[10, 100]");
+        range.setMaxOffset(9);
+        assertThatThrownBy(() -> inspect("10", null)).hasMessageContaining("invalid queue range");
+        range.setMinOffset(-1);
+        assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("invalid queue range");
+    }
+
+    @Test
+    void rejectsUnavailableAndMalformedSnapshots() throws Exception {
+        body.setQueueData(null);
+        assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("valid ConsumeQueue");
+        body.setQueueData(List.of());
+        body.setMinQueueIndex(-1);
+        assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("valid ConsumeQueue");
+        body.setMinQueueIndex(101);
+        assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("valid ConsumeQueue");
+        when(admin.queryConsumeQueue(any(), any(), anyInt(), anyLong(), anyInt(), isNull())).thenReturn(null);
+        assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("valid ConsumeQueue");
+    }
+
+    @Test
+    void rejectsNullOrExcessiveEntries() {
+        var entries = new ArrayList<ConsumeQueueData>();
+        entries.add(null);
+        body.setQueueData(entries);
+        assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("invalid or excessive");
+        body.setQueueData(java.util.Collections.nCopies(17, entry(false)));
+        assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("invalid or excessive");
+    }
+
+    @Test
+    void preservesInterruptionAndReportsRpcFailures() throws Exception {
+        when(admin.examineBrokerClusterInfo()).thenThrow(new InterruptedException());
+        try {
+            assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("interrupted");
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted();
+        }
+        doThrow(new IllegalStateException("broker offline")).when(admin).examineBrokerClusterInfo();
+        assertThatThrownBy(() -> inspect("0", null)).hasMessageContaining("broker offline");
+    }
+
+    @Test
+    void httpContractReturnsExactStringsAndNullableEvaluation() throws Exception {
+        MockMvc mvc = MockMvcBuilders.standaloneSetup(new ConsumeQueueController(service)).build();
+        mvc.perform(get("/api/messages/consume-queue").param("instanceId", "instance-a")
+                .param("topic", "orders").param("brokerName", "broker-a").param("queueId", "2")
+                .param("index", "42"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.requestedIndex").value("42"))
+                .andExpect(jsonPath("$.data.entries[0].physicalOffset").value("9007199254740993"))
+                .andExpect(jsonPath("$.data.entries[0].physicalSize").value(128))
+                .andExpect(jsonPath("$.data.entries[0].indexMatch").isEmpty());
+        mvc.perform(get("/api/messages/consume-queue").param("instanceId", "instance-a"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/web/src/api/consumeQueue.test.ts
+++ b/web/src/api/consumeQueue.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import client from './client';
+import { inspectConsumeQueue } from './consumeQueue';
+
+const mock = new MockAdapter(client);
+const query = {
+  instanceId: 'instance-a',
+  topic: 'orders',
+  brokerName: 'broker-a',
+  queueId: 2,
+  index: '9007199254740993',
+  count: 16,
+};
+
+describe('ConsumeQueue API contract', () => {
+  beforeEach(() => {
+    mock.reset();
+    vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('uses GET and transmits exact decimal strings with cancellation', async () => {
+    const controller = new AbortController();
+    mock.onGet('/messages/consume-queue').reply((config) => {
+      expect(config.params).toEqual(query);
+      expect(config.signal).toBe(controller.signal);
+      return [200, { code: 200, data: { maxIndex: '9007199254740995', entries: [] } }];
+    });
+    await expect(inspectConsumeQueue(query, controller.signal)).resolves.toEqual({
+      maxIndex: '9007199254740995',
+      entries: [],
+    });
+    expect(mock.history.post).toHaveLength(0);
+  });
+
+  it('does not convert broker errors to an empty snapshot', async () => {
+    mock.onGet('/messages/consume-queue').reply(200, { code: 502, message: 'Missing queue data' });
+    await expect(inspectConsumeQueue(query)).rejects.toThrow('Missing queue data');
+  });
+});

--- a/web/src/api/consumeQueue.ts
+++ b/web/src/api/consumeQueue.ts
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import client from './client';
+
+export interface ConsumeQueueQuery {
+  instanceId: string;
+  topic: string;
+  brokerName: string;
+  queueId: number;
+  index: string;
+  count: number;
+  consumerGroup?: string;
+}
+
+export interface ConsumeQueueEntry {
+  ordinal: number;
+  physicalOffset: string;
+  physicalSize: number;
+  tagsCode: string;
+  extension: string | null;
+  bitmap: string | null;
+  indexMatch: boolean | null;
+  message: string | null;
+}
+
+export interface ConsumeQueueSnapshot {
+  brokerAddress: string;
+  minIndex: string;
+  maxIndex: string;
+  requestedIndex: string;
+  count: number;
+  atEnd: boolean;
+  expressionType: string | null;
+  expression: string | null;
+  filterData: string | null;
+  entries: ConsumeQueueEntry[];
+}
+
+export async function inspectConsumeQueue(params: ConsumeQueueQuery, signal?: AbortSignal) {
+  const response = await client.get<{ data: ConsumeQueueSnapshot }>('/messages/consume-queue', {
+    params,
+    signal,
+  });
+  return response.data.data;
+}

--- a/web/src/components/ConsumeQueueDialog.tsx
+++ b/web/src/components/ConsumeQueueDialog.tsx
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import { useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Descriptions,
+  Form,
+  Input,
+  InputNumber,
+  Modal,
+  Space,
+  Table,
+  Tag,
+  Typography,
+} from 'antd';
+import {
+  inspectConsumeQueue,
+  type ConsumeQueueSnapshot,
+  type ConsumeQueueEntry,
+} from '../api/consumeQueue';
+
+export interface ConsumeQueueTarget {
+  topic: string;
+  brokerName: string;
+  queueId: number;
+}
+
+export function ConsumeQueueDialog({
+  instanceId,
+  target,
+  onClose,
+}: {
+  instanceId: string;
+  target: ConsumeQueueTarget;
+  onClose: () => void;
+}) {
+  const [index, setIndex] = useState('0');
+  const [count, setCount] = useState(16);
+  const [group, setGroup] = useState('');
+  const [snapshot, setSnapshot] = useState<ConsumeQueueSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const request = useRef<AbortController | null>(null);
+  const active = useRef(true);
+  const busyRef = useRef(false);
+  useEffect(() => {
+    active.current = true;
+    return () => {
+      active.current = false;
+      request.current?.abort();
+    };
+  }, []);
+  const clear = () => {
+    setSnapshot(null);
+    setError(null);
+  };
+  const read = async () => {
+    if (busyRef.current) return;
+    if (!/^[0-9]{1,19}$/.test(index) || BigInt(index) > 9223372036854775807n) {
+      setError('Index must be a nonnegative signed 64-bit decimal string');
+      return;
+    }
+    busyRef.current = true;
+    setBusy(true);
+    clear();
+    const controller = new AbortController();
+    request.current = controller;
+    try {
+      const result = await inspectConsumeQueue(
+        {
+          instanceId,
+          ...target,
+          index,
+          count,
+          consumerGroup: group.trim() || undefined,
+        },
+        controller.signal,
+      );
+      if (active.current) setSnapshot(result);
+    } catch (failure) {
+      if (active.current && !controller.signal.aborted) {
+        setError(failure instanceof Error ? failure.message : 'ConsumeQueue inspection failed');
+      }
+    } finally {
+      busyRef.current = false;
+      if (active.current) setBusy(false);
+    }
+  };
+  return (
+    <Modal
+      open
+      title="ConsumeQueue index inspection"
+      width={1020}
+      onCancel={onClose}
+      footer={
+        <Space>
+          <Button onClick={onClose}>Close</Button>
+          <Button type="primary" loading={busy} onClick={() => void read()}>
+            Read indices
+          </Button>
+        </Space>
+      }
+    >
+      <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+        <Alert
+          type="info"
+          showIcon
+          message="Read-only storage diagnostics"
+          description="Entries expose physical positions, not message bodies. Ordinals are not logical queue offsets. An index-stage pass does not guarantee a final message match."
+        />
+        <Typography.Text>
+          {target.topic} / {target.brokerName} / Queue {target.queueId}
+        </Typography.Text>
+        <Form layout="inline" disabled={busy}>
+          <Form.Item label="Start index">
+            <Input
+              aria-label="Start index"
+              value={index}
+              onChange={(event) => {
+                setIndex(event.target.value);
+                clear();
+              }}
+            />
+          </Form.Item>
+          <Form.Item label="Logical span">
+            <InputNumber
+              aria-label="Logical span"
+              min={1}
+              max={32}
+              precision={0}
+              value={count}
+              onChange={(value) => {
+                setCount(value ?? 16);
+                clear();
+              }}
+            />
+          </Form.Item>
+          <Form.Item label="Consumer group (optional)">
+            <Input
+              aria-label="Consumer group"
+              value={group}
+              onChange={(event) => {
+                setGroup(event.target.value);
+                clear();
+              }}
+            />
+          </Form.Item>
+        </Form>
+        {error && <Alert type="error" showIcon message={error} />}
+        {snapshot && (
+          <>
+            <Descriptions size="small" bordered column={2}>
+              <Descriptions.Item label="Broker">{snapshot.brokerAddress}</Descriptions.Item>
+              <Descriptions.Item label="Sampled range">
+                [{snapshot.minIndex}, {snapshot.maxIndex})
+              </Descriptions.Item>
+              <Descriptions.Item label="Requested index">
+                {snapshot.requestedIndex}
+              </Descriptions.Item>
+              <Descriptions.Item label="Subscription">
+                {snapshot.expressionType ?? 'Unavailable'}: {snapshot.expression ?? 'Unavailable'}
+              </Descriptions.Item>
+            </Descriptions>
+            {snapshot.atEnd && <Alert type="info" message="Index is at the sampled queue end" />}
+            {snapshot.filterData && (
+              <details>
+                <summary>Broker filter metadata</summary>
+                <pre style={{ whiteSpace: 'pre-wrap' }}>{snapshot.filterData}</pre>
+              </details>
+            )}
+            <Table<ConsumeQueueEntry>
+              rowKey="ordinal"
+              size="small"
+              pagination={false}
+              dataSource={snapshot.entries}
+              scroll={{ x: 850 }}
+              expandable={{
+                expandedRowRender: (row) => (
+                  <Space direction="vertical">
+                    <Typography.Text>Extension: {row.extension ?? 'Unavailable'}</Typography.Text>
+                    <Typography.Text>Bitmap: {row.bitmap ?? 'Unavailable'}</Typography.Text>
+                    <Typography.Text>Broker message: {row.message ?? 'None'}</Typography.Text>
+                  </Space>
+                ),
+              }}
+              columns={[
+                { title: 'Ordinal', dataIndex: 'ordinal' },
+                {
+                  title: 'Physical offset',
+                  dataIndex: 'physicalOffset',
+                  render: (value) => <Typography.Text copyable>{value}</Typography.Text>,
+                },
+                { title: 'Physical bytes', dataIndex: 'physicalSize' },
+                { title: 'Tags code', dataIndex: 'tagsCode' },
+                {
+                  title: 'Index stage',
+                  dataIndex: 'indexMatch',
+                  render: (value) => (
+                    <Tag color={value === null ? 'default' : value ? 'blue' : 'orange'}>
+                      {value === null ? 'Not evaluated' : value ? 'Passed' : 'Rejected'}
+                    </Tag>
+                  ),
+                },
+              ]}
+            />
+          </>
+        )}
+      </Space>
+    </Modal>
+  );
+}

--- a/web/src/components/QueueBrowser.tsx
+++ b/web/src/components/QueueBrowser.tsx
@@ -197,7 +197,13 @@ export const QueueBrowserControls = ({
   </Flex>
 );
 
-export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => (
+export const QueueBrowserResults = ({
+  state,
+  onInspectIndex,
+}: {
+  state: QueueBrowserState;
+  onInspectIndex?: (queue: QueueOffset) => void;
+}) => (
   <Card>
     {state.loading ? (
       <Flex justify="center" style={{ padding: 32 }}>
@@ -280,14 +286,21 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
                 render: (_: unknown, record: QueueOffset) => {
                   const key = `${record.brokerName}-${record.queueId}`;
                   return (
-                    <Button
-                      size="small"
-                      type="primary"
-                      loading={state.pulling.has(key)}
-                      onClick={() => void state.handlePull(record)}
-                    >
-                      查看
-                    </Button>
+                    <Space direction="vertical">
+                      <Button
+                        size="small"
+                        type="primary"
+                        loading={state.pulling.has(key)}
+                        onClick={() => void state.handlePull(record)}
+                      >
+                        查看
+                      </Button>
+                      {onInspectIndex && (
+                        <Button size="small" onClick={() => onInspectIndex(record)}>
+                          Inspect index
+                        </Button>
+                      )}
+                    </Space>
                   );
                 },
               },

--- a/web/src/components/__tests__/ConsumeQueueDialog.test.tsx
+++ b/web/src/components/__tests__/ConsumeQueueDialog.test.tsx
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ConfigProvider } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConsumeQueueDialog } from '../ConsumeQueueDialog';
+import { inspectConsumeQueue, type ConsumeQueueSnapshot } from '../../api/consumeQueue';
+
+vi.mock('../../api/consumeQueue', () => ({ inspectConsumeQueue: vi.fn() }));
+const sample: ConsumeQueueSnapshot = {
+  brokerAddress: 'master-a:10911',
+  minIndex: '0',
+  maxIndex: '9007199254740999',
+  requestedIndex: '9007199254740993',
+  count: 16,
+  atEnd: false,
+  expressionType: 'SQL92',
+  expression: 'amount > 10',
+  filterData: 'subscription metadata',
+  entries: [
+    {
+      ordinal: 1,
+      physicalOffset: '9007199254740993',
+      physicalSize: 128,
+      tagsCode: '-9007199254740993',
+      extension: null,
+      bitmap: null,
+      indexMatch: null,
+      message: 'Extension missing',
+    },
+    {
+      ordinal: 2,
+      physicalOffset: '9007199254740995',
+      physicalSize: 64,
+      tagsCode: '10',
+      extension: '{}',
+      bitmap: '1010',
+      indexMatch: true,
+      message: null,
+    },
+    {
+      ordinal: 3,
+      physicalOffset: '9007199254740997',
+      physicalSize: 64,
+      tagsCode: '11',
+      extension: '{}',
+      bitmap: '0010',
+      indexMatch: false,
+      message: null,
+    },
+  ],
+};
+const open = (onClose = vi.fn()) =>
+  render(
+    <ConfigProvider theme={{ token: { motion: false } }}>
+      <ConsumeQueueDialog
+        instanceId="instance-a"
+        target={{ topic: 'orders', brokerName: 'broker-a', queueId: 2 }}
+        onClose={onClose}
+      />
+    </ConfigProvider>,
+  );
+
+describe('ConsumeQueue inspection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: false,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+    vi.mocked(inspectConsumeQueue).mockResolvedValue(sample);
+  });
+
+  it('preserves large decimal input and three distinct filter states', async () => {
+    open();
+    fireEvent.change(screen.getByLabelText('Start index'), {
+      target: { value: '9007199254740993' },
+    });
+    fireEvent.change(screen.getByLabelText('Consumer group'), { target: { value: ' group-a ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Read indices' }));
+    expect(await screen.findByText('Not evaluated')).toBeInTheDocument();
+    expect(screen.getByText('Passed')).toBeInTheDocument();
+    expect(screen.getByText('Rejected')).toBeInTheDocument();
+    expect(screen.getByText('-9007199254740993')).toBeInTheDocument();
+    expect(inspectConsumeQueue).toHaveBeenCalledWith(
+      {
+        instanceId: 'instance-a',
+        topic: 'orders',
+        brokerName: 'broker-a',
+        queueId: 2,
+        index: '9007199254740993',
+        count: 16,
+        consumerGroup: 'group-a',
+      },
+      expect.any(AbortSignal),
+    );
+    fireEvent.click(screen.getAllByRole('button', { name: 'Expand row' })[0]);
+    expect(screen.getByText('Broker message: Extension missing')).toBeInTheDocument();
+    expect(screen.getByText('Extension: Unavailable')).toBeInTheDocument();
+  });
+
+  it.each(['-1', '1e3', '9223372036854775808', ''])('rejects invalid index %s', async (index) => {
+    open();
+    fireEvent.change(screen.getByLabelText('Start index'), { target: { value: index } });
+    fireEvent.click(screen.getByRole('button', { name: 'Read indices' }));
+    expect(
+      await screen.findByText('Index must be a nonnegative signed 64-bit decimal string'),
+    ).toBeInTheDocument();
+    expect(inspectConsumeQueue).not.toHaveBeenCalled();
+  });
+
+  it('clears stale results whenever the request changes', async () => {
+    open();
+    fireEvent.click(screen.getByRole('button', { name: 'Read indices' }));
+    await screen.findByText('Not evaluated');
+    fireEvent.change(screen.getByLabelText('Consumer group'), { target: { value: 'new-group' } });
+    expect(screen.queryByText('Not evaluated')).not.toBeInTheDocument();
+  });
+
+  it('reports sampled end and unavailable subscriptions without a match claim', async () => {
+    vi.mocked(inspectConsumeQueue).mockResolvedValue({
+      ...sample,
+      atEnd: true,
+      expression: null,
+      expressionType: null,
+      filterData: null,
+      entries: [],
+    });
+    open();
+    fireEvent.click(screen.getByRole('button', { name: 'Read indices' }));
+    expect(await screen.findByText('Index is at the sampled queue end')).toBeInTheDocument();
+    expect(screen.getByText('Unavailable: Unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('Passed')).not.toBeInTheDocument();
+  });
+
+  it('reports failure and permits a fresh manual request', async () => {
+    vi.mocked(inspectConsumeQueue).mockRejectedValueOnce(new Error('Broker offline'));
+    open();
+    fireEvent.click(screen.getByRole('button', { name: 'Read indices' }));
+    expect(await screen.findByText('Broker offline')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Read indices' }));
+    await screen.findByText('Not evaluated');
+    expect(screen.queryByText('Broker offline')).not.toBeInTheDocument();
+  });
+
+  it('locks concurrent reads and aborts on unmount even if the request ignores cancellation', async () => {
+    let resolve!: (value: ConsumeQueueSnapshot) => void;
+    vi.mocked(inspectConsumeQueue).mockReturnValue(
+      new Promise((done) => {
+        resolve = done;
+      }),
+    );
+    const view = open();
+    const read = screen.getByRole('button', { name: 'Read indices' });
+    fireEvent.click(read);
+    fireEvent.click(read);
+    expect(inspectConsumeQueue).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText('Start index')).toBeDisabled();
+    const signal = vi.mocked(inspectConsumeQueue).mock.calls[0][1];
+    view.unmount();
+    expect(signal?.aborted).toBe(true);
+    await act(async () => resolve(sample));
+    expect(screen.queryByText('Not evaluated')).not.toBeInTheDocument();
+  });
+
+  it('closes through the explicit footer control', async () => {
+    const close = vi.fn();
+    open(close);
+    const buttons = screen.getAllByRole('button', { name: 'Close' });
+    fireEvent.click(buttons[buttons.length - 1]);
+    await waitFor(() => expect(close).toHaveBeenCalledTimes(1));
+  });
+});

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -69,6 +69,9 @@ import {
 } from '../../services/messageService';
 import { listTopics } from '../../services/topicService';
 import { useInstanceFilter } from '../../hooks/useInstanceFilter';
+import { supportsApacheRuntime } from '../../api/instance';
+import { isMockMode } from '../../services/dataMode';
+import { ConsumeQueueDialog, type ConsumeQueueTarget } from '../../components/ConsumeQueueDialog';
 import { downloadBlob } from '../../utils/download';
 import {
   readMessageTraceTopic,
@@ -316,13 +319,15 @@ const TraceDiagnosticsPanel = ({ diagnostics }: { diagnostics: MessageTraceDiagn
    MessagePage
    ═══════════════════════════════════════════ */
 type InstanceFilterProps = {
+  canInspectIndex: boolean;
   selectedInstanceId: string | undefined;
   selectInstance: (instanceId: string) => void;
   instanceOptions: { value: string; label: string }[];
 };
 
 const MessagePage = () => {
-  const { selectedInstanceId, selectInstance, instanceOptions } = useInstanceFilter();
+  const { selectedInstanceId, selectedInstance, selectInstance, instanceOptions } =
+    useInstanceFilter();
   // Keying the content by the selected instance makes React remount it whenever the instance
   // changes — whether from this page's own <Select> or from the shared filter/route elsewhere —
   // so query results, the detail modal and in-flight request ownership all reset cleanly.
@@ -332,6 +337,9 @@ const MessagePage = () => {
       selectedInstanceId={selectedInstanceId}
       selectInstance={selectInstance}
       instanceOptions={instanceOptions}
+      canInspectIndex={
+        !!selectedInstance && supportsApacheRuntime(selectedInstance) && !isMockMode()
+      }
     />
   );
 };
@@ -340,6 +348,7 @@ const MessagePage = () => {
    MessagePageContent
    ═══════════════════════════════════════════ */
 const MessagePageContent = ({
+  canInspectIndex,
   selectedInstanceId,
   selectInstance,
   instanceOptions,
@@ -381,6 +390,7 @@ const MessagePageContent = ({
   }, [loadTopicOptions]);
   const [queryMode, setQueryMode] = useState<QueryMode>('topic');
   const queueBrowser = useQueueBrowser(selectedInstanceId);
+  const [indexTarget, setIndexTarget] = useState<ConsumeQueueTarget | null>(null);
   const [selectedTopic, setSelectedTopic] = useState<string | undefined>();
   const [dateRange, setDateRange] = useState<[Dayjs, Dayjs]>(getDefaultRange);
   const [keyInput, setKeyInput] = useState('');
@@ -1148,7 +1158,30 @@ const MessagePageContent = ({
         </Space>
       </Card>
 
-      {queryMode === 'queue' && <QueueBrowserResults state={queueBrowser} />}
+      {queryMode === 'queue' && (
+        <QueueBrowserResults
+          state={queueBrowser}
+          onInspectIndex={
+            canInspectIndex
+              ? (queue) => {
+                  if (queueBrowser.topic)
+                    setIndexTarget({
+                      topic: queueBrowser.topic,
+                      brokerName: queue.brokerName,
+                      queueId: queue.queueId,
+                    });
+                }
+              : undefined
+          }
+        />
+      )}
+      {indexTarget && selectedInstanceId && canInspectIndex && (
+        <ConsumeQueueDialog
+          instanceId={selectedInstanceId}
+          target={indexTarget}
+          onClose={() => setIndexTarget(null)}
+        />
+      )}
 
       {topicError && (
         <Alert


### PR DESCRIPTION
消息队列浏览目前只能按 offset 拉取消息正文，无法检查 ConsumeQueue 的物理位置、扩展索引缺失或 SQL92 初筛信息。本 PR 在队列行增加只读索引诊断入口，使用 RocketMQ 原生 queryConsumeQueue，并完整处理协议的边界和结果语义。

## 改动说明

- 复用所选 Apache 实例的凭据，主节点必须来自实例登记信息，并核对 Topic 队列和采样范围；不接受任意 Broker 地址。
- 所有 64 位位置和 tagsCode 使用字符串，保留超过 2^53 的值。count 限制为 1–32，等于队列末尾时返回明确的 atEnd，缺失响应不伪装为空结果。
- 索引条目只有序号，不推算 SDK 未返回的逻辑 queueOffset。仅在确实执行扩展过滤时展示布尔初筛结果，其余显示 Not evaluated；Passed 不代表最终消息匹配。
- 页面提供原始扩展 JSON、位图和 Broker 提示，修改参数清除旧结果，关闭与切换实例丢弃迟到响应。云实例、模拟模式不开放入口。

## 原提交验证记录

验证：本地后端 69 项、前端 49 项测试通过；新增服务 56/56 行、66/66 分支覆盖；Checkstyle、ESLint、TypeScript/Vite 构建及后端打包通过。浏览器使用本地拦截验证队列入口、超大偏移、初筛三态中的未执行/通过，以及扩展缺失提示，没有真实 Broker 调用。HTTP 契约使用真实服务和实例解析器，模拟底层 SDK。

协议依据：[AdminBrokerProcessor.queryConsumeQueue](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java#L2783)。Broker 默认 eval=false 并不等于执行过滤后失败；返回的 ConsumeQueueData 不含逻辑索引。该功能不同于消息拉取过滤预览，也不修改消费位点。

## 兼容性与回滚

无新增依赖、无数据迁移；撤销本提交即可回滚。Topic 范围与索引读取不是原子快照，真实 Broker 版本兼容性、集群 E2E、压力、容量和混沌验证未执行。上游已有 3 项全量测试失败及既有依赖审计缺口（含已由 #4000 处理的 Browserslist high），未宣称全量质量门槛通过。本提交遵循已授权的增量验证交付方式。提交含 [skip ci]，未触发远端工作流。核验日期：2026-09-08。
