### PR TITLE
fix(acl): keep the account whitelist in the update response

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -208,6 +208,7 @@ public class AclService {
                 .secretKey(existing.getSecretKey())
                 .admin(user.getAdmin() == null ? existing.isAdmin() : user.getAdmin())
                 .clusters(user.getClusters() == null ? existing.getClusters() : user.getClusters())
+                .whiteRemoteAddress(existing.getWhiteRemoteAddress())
                 .gmtCreate(existing.getGmtCreate())
                 .build();
         AclUserVO saved = aclRepository.replaceUser(merged)

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -543,6 +543,21 @@ class AclServiceTest {
     }
 
     @Test
+    void updateUserShouldKeepTheExistingWhiteRemoteAddress() {
+        existingUser.setWhiteRemoteAddress("10.0.1.0/24");
+        UpdateAclUserDTO input = new UpdateAclUserDTO();
+        input.setId("1");
+        input.setUsername("renamed");
+
+        when(aclRepository.findUserById(1L)).thenReturn(Optional.of(existingUser));
+        when(aclRepository.replaceUser(any(AclUserVO.class))).thenAnswer(inv -> Optional.of(inv.getArgument(0)));
+
+        AclUserVO result = aclService.updateUser(input, null);
+
+        assertThat(result.getWhiteRemoteAddress()).isEqualTo("10.0.1.0/24");
+    }
+
+    @Test
     void updateUserShouldPreserveAdminWhenNotProvided() {
         AclUserVO adminUser = AclUserVO.builder()
                 .id(1L)


### PR DESCRIPTION
### Motivation

`AclService.updateUser` (local plain-access path) carefully preserves every existing field of the account through a partial update — `accessKey`, `secretKey`, `admin`, `clusters`, `gmtCreate` — but the merge builder omits `whiteRemoteAddress`:

```java
AclUserVO merged = AclUserVO.builder()
        .id(existing.getId())
        .username(...)
        .accessKey(existing.getAccessKey())
        .secretKey(existing.getSecretKey())
        .admin(...)
        .clusters(...)
        .gmtCreate(existing.getGmtCreate())
        .build();
```

`whiteRemoteAddress` is a real, persisted field of local plain-access accounts (`rmq_acl_user.white_remote_address`, written by `createAndUpdatePlainAccessConfig`, read back by `toUserVO`). The stored row survives the update (MyBatis-Plus `updateById` skips null columns), but `replaceUser` returns the merged VO, so `POST /api/acl/users/update` responds with `whiteRemoteAddress: null` after a harmless rename — the API reports the account's IP whitelist as gone even though it is still enforced.

### Modifications

Carry `existing.getWhiteRemoteAddress()` through the merge, like every other preserved field.

### Verification

New test `updateUserShouldKeepTheExistingWhiteRemoteAddress` (model: `updateUserShouldSaveExistingUser`): existing user with `whiteRemoteAddress = "10.0.1.0/24"`, rename via DTO.
- Before the fix: fails — `whiteRemoteAddress` in the response is `null`.
- After the fix: passes.
- ACL suite regression: `mvn -f server/pom.xml test -Dtest='AclServiceTest,MybatisPlusAclRepositoryTest,AclControllerTest'` → **Tests run: 114, Failures: 0, Errors: 0**.
