### PR TITLE
fix(group): allow zero retry settings on update

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/UpdateConsumerGroupSettingsDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/UpdateConsumerGroupSettingsDTO.java
@@ -18,7 +18,7 @@ package org.apache.rocketmq.studio.instance.group;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Data;
 
 @Data
@@ -28,10 +28,10 @@ public class UpdateConsumerGroupSettingsDTO {
     @NotBlank(message = "name is required")
     private String name;
     @NotNull(message = "retryQueueNums is required")
-    @Positive(message = "retryQueueNums must be positive")
+    @PositiveOrZero(message = "retryQueueNums must be zero or positive")
     private Integer retryQueueNums;
     @NotNull(message = "retryMaxTimes is required")
-    @Positive(message = "retryMaxTimes must be positive")
+    @PositiveOrZero(message = "retryMaxTimes must be zero or positive")
     private Integer retryMaxTimes;
     private Boolean consumeEnable;
     private Boolean consumeMessageOrderly;

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/UpdateConsumerGroupSettingsDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/UpdateConsumerGroupSettingsDTOTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UpdateConsumerGroupSettingsDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void shouldAcceptZeroRetrySettingsTest() {
+        // 0 is a valid broker-side value (retryQueueNums=0 disables retry queues,
+        // retryMaxTimes=0 sends failures straight to the DLQ) and CreateConsumerGroupDTO
+        // accepts retryMaxTimes=0 — the update path must not reject what create allows.
+        UpdateConsumerGroupSettingsDTO request = new UpdateConsumerGroupSettingsDTO();
+        request.setInstanceId("instance-a");
+        request.setName("cg-orders");
+        request.setRetryQueueNums(0);
+        request.setRetryMaxTimes(0);
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+
+    @Test
+    void shouldRejectNegativeRetrySettingsTest() {
+        UpdateConsumerGroupSettingsDTO request = new UpdateConsumerGroupSettingsDTO();
+        request.setInstanceId("instance-a");
+        request.setName("cg-orders");
+        request.setRetryQueueNums(-1);
+        request.setRetryMaxTimes(-1);
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("retryQueueNums must be zero or positive",
+                        "retryMaxTimes must be zero or positive");
+    }
+}


### PR DESCRIPTION
### Motivation

`UpdateConsumerGroupSettingsDTO` validates both retry fields with `@Positive`:

```java
@NotNull(message = "retryQueueNums is required")
@Positive(message = "retryQueueNums must be positive")
private Integer retryQueueNums;
@NotNull(message = "retryMaxTimes is required")
@Positive(message = "retryMaxTimes must be positive")
private Integer retryMaxTimes;
```

But `0` is a legitimate broker-side value — `RocketMQAdminClientImpl` forwards these straight into `SubscriptionGroupConfig.setRetryQueueNums/setRetryMaxTimes`, where `retryQueueNums=0` disables retry queues and `retryMaxTimes=0` sends failed messages directly to the DLQ. The sibling `CreateConsumerGroupDTO` already accepts it:

```java
@PositiveOrZero(message = "retryMaxTimes must be zero or positive")
private Integer retryMaxTimes;
```

Concrete failure: a group created via `POST /api/groups/create` with `retryMaxTimes: 0` (accepted) can never have its settings re-saved via the settings endpoint while keeping that value — the request fails bean validation with a 400 before reaching `MetadataService`.

### Modifications

Both fields switch to `@PositiveOrZero` with matching messages, aligning the update path with the create path and the broker semantics. Negative values are still rejected.

### Verification

New standalone `UpdateConsumerGroupSettingsDTOTest` (the controller test file is under review in another PR, so the validation is pinned in its own class, modeled on `AlertRuleRequestDTOTest`):
- `shouldAcceptZeroRetrySettingsTest` — before the fix: fails with `retryQueueNums must be positive` / `retryMaxTimes must be positive`; after: passes.
- `shouldRejectNegativeRetrySettingsTest` — negative values still produce the two violations.
- Regression: `mvn -f server/pom.xml test -Dtest='UpdateConsumerGroupSettingsDTOTest,ConsumerGroupControllerTest,MetadataServiceTest'` → **Tests run: 59, Failures: 0, Errors: 0**.
