### PR TITLE
fix(alert): trim stored metrics when scoping findActive

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertStateRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertStateRepository.java
@@ -103,7 +103,7 @@ public class MybatisPlusAlertStateRepository implements AlertStateRepository {
                 .filter(rule -> rule.getId() != null)
                 .filter(AlertRuleVO::isEnabled)
                 .filter(rule -> ruleDomain(rule) == scope.domain())
-                .filter(rule -> metricKeys.contains(rule.getMetric()))
+                .filter(rule -> metricKeys.contains(StringUtils.trimWhitespace(rule.getMetric())))
                 .filter(rule -> !StringUtils.hasText(rule.getInstanceId())
                         || scope.instanceId().equals(rule.getInstanceId()))
                 .collect(Collectors.toMap(AlertRuleVO::getId, rule -> rule, (left, right) -> left));

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertStateRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertStateRepositoryTest.java
@@ -97,6 +97,36 @@ class MybatisPlusAlertStateRepositoryTest {
     }
 
     @Test
+    void findsActiveStatesForRulesWithPaddedStoredMetricsTest() {
+        // NativeAlertProcessor keeps rules whose stored metric has surrounding whitespace
+        // (legacy rows) by matching trimWhitespace(rule.getMetric()) against the scope keys;
+        // findActive must apply the same normalization or reconcile sees no active states
+        // and the stale FIRING/ACKED state is never resolved.
+        RmqAlertStateMapper mapper = mock(RmqAlertStateMapper.class);
+        RmqAlertState state = new RmqAlertState();
+        state.setRuleId(4L);
+        state.setFingerprint("fingerprint");
+        state.setStatus(AlertStateStatus.FIRING.name());
+        state.setConsecutiveHits(3);
+        state.setCurrentValue(30D);
+        when(mapper.selectList(any())).thenReturn(List.of(state));
+        RmqSystemAlertMapper alertMapper = mock(RmqSystemAlertMapper.class);
+        when(alertMapper.selectList(any())).thenReturn(List.of(
+                alert(4L, "fingerprint", "local", "{\"consumerGroup\":\"orders\"}")));
+        MybatisPlusAlertStateRepository repository = new MybatisPlusAlertStateRepository(mapper, alertMapper);
+        AlertRuleVO rule = AlertRuleVO.builder().id(4L).domain(AlertDomain.BUSINESS).enabled(true)
+                .instanceId("local").metric(" consumer.lag.total ").build();
+
+        List<ActiveAlertState> active = repository.findActive(new MetricCollectionScope(AlertDomain.BUSINESS,
+                "local", Set.of("consumer.lag.total")), List.of(rule));
+
+        assertThat(active).singleElement().satisfies(item -> {
+            assertThat(item.key()).isEqualTo(new AlertStateKey(4L, "fingerprint"));
+            assertThat(item.state().status()).isEqualTo(AlertStateStatus.FIRING);
+        });
+    }
+
+    @Test
     void findsActiveStatesWithOneLatestAlertMetadataQueryTest() {
         RmqAlertStateMapper mapper = mock(RmqAlertStateMapper.class);
         RmqAlertState first = activeState(4L, "fingerprint-a", AlertStateStatus.FIRING);


### PR DESCRIPTION
### Motivation

`NativeAlertProcessor.reconcileMissingActiveStates` keeps rules whose stored metric has surrounding whitespace by normalizing before matching the scope keys:

```java
.filter(rule -> scope.metricKeys().contains(StringUtils.trimWhitespace(rule.getMetric())))
```

…but the `MybatisPlusAlertStateRepository.findActive` it then calls filters with the **raw** value:

```java
.filter(rule -> metricKeys.contains(rule.getMetric()))
```

For a rule whose stored metric is padded (legacy rows — current write paths trim, but the rule entities are documented to support values "copied from older deployments", and `AlertRuleSemanticFingerprintTest` pins ` metric(" consumer.lag.total ")` as a supported input), the processor keeps the rule while `findActive` drops it → `scopedRules` is empty → `findActive` returns `List.of()` → `reconcileMissingActiveStates` sees no active states → the stale FIRING/ACKED state is never resolved and no recovery notification is sent. This silently reintroduces the exact failure mode the reconcile logic guards against, via a caller/callee normalization mismatch.

### Modifications

`findActive` applies `StringUtils.trimWhitespace(...)` to the metric before the `metricKeys` membership check, matching its only caller.

### Verification

New test `findsActiveStatesForRulesWithPaddedStoredMetricsTest` (model: `findsActiveStatesWithLabelsFromTheLatestAlertEventTest`): rule with `.metric(" consumer.lag.total ")`, scope keys `Set.of("consumer.lag.total")`.
- Before the fix: fails — `Expected size: 1 but was: 0` (active states empty).
- After the fix: passes — the FIRING state is returned with its key.
- Regression: `mvn -f server/pom.xml test -Dtest='MybatisPlusAlertStateRepositoryTest,NativeAlertProcessorTest'` → **Tests run: 23, Failures: 0, Errors: 0**.
