### PR TITLE
fix(alert): trim stored metric keys when normalizing percentage thresholds

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplate.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplate.java
@@ -62,7 +62,8 @@ final class AlertNotificationTemplate {
         if (alert.getCurrentValue() == null) {
             return "";
         }
-        if (rule != null && "%".equals(rule.getThresholdUnit()) && RATIO_METRICS.contains(rule.getMetric())) {
+        if (rule != null && "%".equals(rule.getThresholdUnit())
+                && RATIO_METRICS.contains(rule.getMetric() == null ? "" : rule.getMetric().trim())) {
             return String.valueOf(alert.getCurrentValue() * 100);
         }
         return String.valueOf(alert.getCurrentValue());

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleSemanticFingerprint.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleSemanticFingerprint.java
@@ -62,7 +62,7 @@ final class AlertRuleSemanticFingerprint {
     }
 
     static double normalizedThreshold(AlertRuleVO rule) {
-        if ("%".equals(rule.getThresholdUnit()) && RATIO_METRICS.contains(rule.getMetric())) {
+        if ("%".equals(rule.getThresholdUnit()) && RATIO_METRICS.contains(normalize(rule.getMetric()))) {
             return rule.getThreshold() / 100D;
         }
         return rule.getThreshold();

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplateTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplateTest.java
@@ -33,6 +33,19 @@ class AlertNotificationTemplateTest {
     }
 
     @Test
+    void rendersPercentageValuesForPaddedStoredMetricsTest() {
+        AlertRuleVO rule = AlertRuleVO.builder().name("Disk threshold").metric(" broker.disk.usage_ratio ")
+                .threshold(85).thresholdUnit("%").build();
+        SystemAlertVO alert = SystemAlertVO.builder().level(AlertLevel.warning).title("Disk threshold")
+                .description("FIRING").transition("FIRING").instanceId("local").currentValue(0.865)
+                .time(LocalDateTime.of(2026, 8, 23, 12, 0)).labels(Map.of()).build();
+
+        String rendered = AlertNotificationTemplate.render("${value}${thresholdUnit}", alert, rule);
+
+        assertThat(rendered).isEqualTo("86.5%");
+    }
+
+    @Test
     void usesTheExistingNotificationFormatWhenNoTemplateWasConfiguredTest() {
         SystemAlertVO alert = SystemAlertVO.builder().level(AlertLevel.info).title("Test")
                 .description("connection works").build();

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleEvaluatorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleEvaluatorTest.java
@@ -51,6 +51,20 @@ class AlertRuleEvaluatorTest {
     }
 
     @Test
+    void appliesPercentageThresholdsToPaddedStoredMetricsTest() {
+        // The evaluator matches padded stored metrics via rule.getMetric().trim()
+        // (legacy rows); the % normalization must see the same trimmed value or a
+        // " broker.disk.usage_ratio > 85%" rule compares 0.9 >= 85 and never fires.
+        AlertRuleVO rule = AlertRuleVO.builder().domain(AlertDomain.CLUSTER).metric(" broker.disk.usage_ratio ")
+                .operator(">=").threshold(85).thresholdUnit("%").enabled(true).build();
+
+        AlertEvaluationResult result = evaluator.evaluate(rule, sample(MetricAvailability.AVAILABLE, 0.9));
+
+        assertThat(result.matches()).isTrue();
+        assertThat(result.conditionMet()).isTrue();
+    }
+
+    @Test
     void unavailableMetricDoesNotBehaveAsZeroTest() {
         AlertRuleVO rule = AlertRuleVO.builder().domain(AlertDomain.CLUSTER).metric("broker.disk.usage_ratio")
                 .operator("<").threshold(0.1).enabled(true).build();


### PR DESCRIPTION
### Motivation

`AlertRuleEvaluator` matches a rule against a sample using the trimmed metric key (`rule.getMetric().trim()`), but two ratio-aware code paths still consult `RATIO_METRICS` with the raw stored key:

- `AlertRuleSemanticFingerprint.normalizedThreshold` checks `RATIO_METRICS.contains(rule.getMetric())`
- `AlertNotificationTemplate.formattedValue` checks `RATIO_METRICS.contains(rule.getMetric())`

For a rule stored with a padded metric like `" broker.disk.usage_ratio "` and a `%` threshold of 85:

- the threshold is **not** divided by 100, so the evaluator compares the raw ratio `0.9 >= 85` and the rule never fires (or fires on every healthy disk with `<=`)
- the notification renders the raw ratio next to the unit, e.g. `0.865%/85` instead of `86.5%/85`

`AlertRuleSemanticFingerprint.of()` already trims every field for identity and the request DTO normalizes the metric key on write, so this only affects rules persisted through other paths.

### Modifications

- `AlertRuleSemanticFingerprint.normalizedThreshold`: look up `RATIO_METRICS` with the existing `normalize()` helper instead of the raw metric
- `AlertNotificationTemplate.formattedValue`: compare against the trimmed metric

### Verification

Fail-before (both tests added in this PR, run against the unpatched code):

```
[ERROR] Tests run: 6, Failures: 1 -- AlertRuleEvaluatorTest
Expecting value to be true but was false
[ERROR] Tests run: 4, Failures: 1 -- AlertNotificationTemplateTest
expected: "86.5%" but was: "0.865%"
```

Pass-after:

```
Tests run: 6, Failures: 0, Errors: 0 -- AlertRuleEvaluatorTest
Tests run: 4, Failures: 0, Errors: 0 -- AlertNotificationTemplateTest
Tests run: 3, Failures: 0, Errors: 0 -- AlertRuleSemanticFingerprintTest
Tests run: 13, Failures: 0, Errors: 0
```
