### PR TITLE
feat: configure reviewed POP and PULL consumer request modes

### DIFF
--- a/docs/consumer-request-mode.md
+++ b/docs/consumer-request-mode.md
@@ -1,0 +1,80 @@
+# 配置消费请求模式
+
+## 适用范围
+
+真实 Apache 实例的消费组详情中，消费进度表提供 `Configure POP/PULL` 入口。
+它配置一个普通 Topic 与消费组组合在所有 Topic 主 Broker 上的请求模式，
+用于采用服务端队列分配的兼容消费者。云实例和 Mock 模式不显示入口。
+
+`PULL`、`POP` 是 RocketMQ 原生请求模式，不等同于把任意客户端的 Push/Pull API 自动转换。
+本功能不会升级客户端、修改订阅配置、重置消费位点或排空未确认的 POP 消息。
+切换前需要规划客户端兼容性、在途消息、重试队列与恢复窗口。
+
+## 操作步骤
+
+1. 停止消费组的全部消费者，并保持停止状态。
+2. 从所需 Topic 的进度行打开窗口，选择请求模式和 POP 共享参数。
+3. 点击 `Preview broker modes`，核对所有 Broker 的有效模式、共享值和配置来源。
+4. 勾选确认项后提交。提交前后端重新读取路由、连接状态和配置，发现变化即要求重新预览。
+5. 核对逐 Broker 回执及实际配置，再按既定方案恢复兼容消费者。
+
+预览和提交都要求消费组已在每个 Topic 主 Broker 上配置且处于离线状态。
+只有空连接集合或明确的 `CONSUMER_NOT_ONLINE` 响应码可证明当次检查离线；
+权限错误、超时及未知响应不能放行。没有登记主节点时不自动向副本写入。
+
+## 默认值与显式覆盖
+
+后端读取 Broker 的 `messageRequestModeMap`，只返回目标 Topic 与消费组的条目。
+不存在条目时显示 `Broker default`；使用 `defaultMessageRequestMode`，
+只有默认模式为 POP 时才使用 `defaultPopShareQueueNum`，PULL 的有效共享值为 `0`。
+存在条目时显示 `Explicit override`，保留存储的模式和参数。
+缺失配置、拒绝读取或格式错误不能当作“没有覆盖”。
+
+界面同时展示 `serverLoadBalancerEnable`，便于判断队列共享规则的适用条件。
+当请求模式已经与默认值相同，提交仍会写入显式覆盖；相同的既有显式覆盖则不重复写入。
+后续 Broker 默认值变化不会自动影响已写入的覆盖。
+
+| POP 共享值 | RocketMQ 5.5.0 分配语义 |
+| --- | --- |
+| `-1`、`0` | 每个客户端可访问全部队列 |
+| 正整数 N | 符合分配条件时，额外共享客户端排序列表中后续 N 个客户端的队列 |
+| N 大于或等于客户端数量减一 | 回退为全部队列 |
+
+共享值不是队列数量硬上限，也不是并发线程数。
+输入支持 `-1` 至 `2147483647` 的整数；选择 PULL 时固定提交 `0`。
+重试 Topic、死信 Topic 不支持此入口。
+
+## 结果、故障与恢复
+
+写入按 Broker 名称排序执行，使用原生 `setMessageRequestMode`，每次写入后重新读取配置。
+`CONFIRMED` 表示写入收到确认且回读与请求的显式覆盖相同；`UNCHANGED` 表示无需写入。
+`UNKNOWN` 表示写入或回读无法确认，后续 Broker 标为 `NOT_ATTEMPTED` 并停止执行。
+先前成功结果会保留，不自动重试或回滚。审计记录原值、原配置来源和请求值，
+审计存储失败不会覆盖 Broker 操作结果。
+
+多 Broker 操作没有原子性。检查之后客户端仍可能重新连接，其他管理员也可能改配置。
+浏览器断网、关闭或切换实例不能撤回已经发出的请求；丢失响应后应逐 Broker 重新读取，
+不能假定全部失败。再次操作必须重新预览。
+
+回滚业务配置时，保持消费者停止，并按保存的预览恢复各 Broker 原模式与共享值。
+原生接口没有删除覆盖的操作；把值恢复为原默认值仍会留下显式覆盖，
+不能恢复为继续继承未来默认值。需要恢复继承关系时，按 Broker 配置维护流程处理，
+不要删除消费组作为替代。上线前应把此限制纳入迁移方案。
+
+## 实现与验证
+
+MQAdminExt 提供写入封装，但没有读取请求模式的封装。
+读取复用现有 DefaultMQAdminExt 的公开 SDK 访问器、认证传输和 VIP 通道设置，
+发送官方 `GET_ALL_MESSAGE_REQUEST_MODE` 命令；没有反射或额外创建未认证客户端。
+POST 沿用管理员权限拦截，GET 仅用于预览读取。
+
+本地测试覆盖默认回退、显式覆盖、协议读取、VIP 地址、全 Topic 范围、预览冲突、
+权限、中断、部分成功、审计异常与前端确认流程。
+浏览器验证以本地接口拦截完成，没有修改真实 Broker。
+真实 POP 客户端切换、压力、容量及网络分区验证未执行。
+
+无新增依赖，无数据库迁移；撤销代码提交可移除入口和接口，已写入的配置需按上述恢复步骤处理。
+最后核验日期：2026-09-08。协议依据为 RocketMQ 5.5.0 的
+[QueryAssignmentProcessor](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/QueryAssignmentProcessor.java)、
+[MessageRequestModeManager](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/loadbalance/MessageRequestModeManager.java)
+及 [AdminBrokerProcessor](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java#L2037)。

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerRequestMode.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerRequestMode.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import java.util.List;
+
+public final class ConsumerRequestMode {
+    private ConsumerRequestMode() { }
+
+    public record Broker(String brokerName, String address, String mode, int popShareQueueNum,
+            boolean explicit, String serverLoadBalancerEnable) { }
+
+    public record Preview(String topic, String group, List<Broker> brokers) { }
+
+    public record Request(String instanceId, String topic, String group, String mode,
+            int popShareQueueNum, List<Broker> expected) { }
+
+    public record Outcome(Broker before, String status, Broker observed) { }
+
+    public record Receipt(List<Outcome> brokers) { }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerRequestModeController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerRequestModeController.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.Result;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/consumer-request-mode")
+public class ConsumerRequestModeController {
+    private final ConsumerRequestModeService service;
+
+    @GetMapping
+    public Result<ConsumerRequestMode.Preview> preview(@RequestParam String instanceId,
+            @RequestParam String topic, @RequestParam String group) {
+        return Result.ok(service.preview(instanceId, topic, group));
+    }
+
+    @PostMapping
+    public Result<ConsumerRequestMode.Receipt> apply(@RequestBody ConsumerRequestMode.Request request) {
+        return Result.ok(service.apply(request));
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerRequestModeService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerRequestModeService.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.TreeSet;
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.message.MessageRequestMode;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.instance.group.ConsumerRequestMode.Broker;
+import org.apache.rocketmq.studio.instance.group.ConsumerRequestMode.Outcome;
+import org.apache.rocketmq.studio.instance.group.ConsumerRequestMode.Preview;
+import org.apache.rocketmq.studio.instance.group.ConsumerRequestMode.Receipt;
+import org.apache.rocketmq.studio.instance.group.ConsumerRequestMode.Request;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class ConsumerRequestModeService {
+    private final RuntimeAdminClientResolver resolver;
+    private final MessageRequestModeReader reader;
+    private final OperationAuditService audit;
+
+    public Preview preview(String instanceId, String topic, String group) {
+        validate(topic, group);
+        return resolver.execute(instanceId, admin -> {
+            try {
+                return inspect(admin, topic, group);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new BusinessException(502, "Request mode inspection was interrupted");
+            }
+        });
+    }
+
+    public Receipt apply(Request request) {
+        validate(request.topic(), request.group());
+        requireMode(request.mode(), 400);
+        if (request.popShareQueueNum() < -1 || "PULL".equals(request.mode()) && request.popShareQueueNum() != 0
+                || request.expected() == null || request.expected().isEmpty()) {
+            throw new BusinessException(400, "A reviewed preview and valid POP sharing value are required");
+        }
+        return resolver.execute(request.instanceId(), admin -> {
+            Preview fresh;
+            try {
+                fresh = inspect(admin, request.topic(), request.group());
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new BusinessException(502, "Request mode preflight was interrupted");
+            }
+            if (!fresh.brokers().equals(request.expected())) {
+                throw new BusinessException(409, "Broker configuration or topology changed; preview again");
+            }
+            var outcomes = new ArrayList<Outcome>();
+            boolean stopped = false;
+            for (Broker before : fresh.brokers()) {
+                if (stopped) {
+                    outcomes.add(new Outcome(before, "NOT_ATTEMPTED", null));
+                    continue;
+                }
+                if (matches(before, request)) {
+                    outcomes.add(new Outcome(before, "UNCHANGED", before));
+                    continue;
+                }
+                Broker observed = null;
+                String status = "UNKNOWN";
+                try {
+                    admin.setMessageRequestMode(before.address(), request.topic(), request.group(),
+                            MessageRequestMode.valueOf(request.mode()), request.popShareQueueNum(), 5000);
+                    observed = read(admin, before.brokerName(), before.address(), request.topic(), request.group());
+                    if (matches(observed, request)) {
+                        status = "CONFIRMED";
+                    }
+                } catch (Exception exception) {
+                    // A failed response does not prove that the broker rejected the update.
+                    if (exception instanceof InterruptedException) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+                stopped = "UNKNOWN".equals(status);
+                outcomes.add(new Outcome(before, status, observed));
+                audit.record("SET_MESSAGE_REQUEST_MODE", "GROUP", request.group(), request.instanceId(),
+                        "topic=" + request.topic() + ", broker=" + before.brokerName() + ", before="
+                                + before.mode() + "/" + before.popShareQueueNum() + ", explicit=" + before.explicit()
+                                + ", requested=" + request.mode() + "/" + request.popShareQueueNum(),
+                        status, stopped ? "Read current request modes before recovery" : null);
+            }
+            return new Receipt(List.copyOf(outcomes));
+        });
+    }
+
+    private boolean matches(Broker broker, Request request) {
+        return broker.explicit() && broker.mode().equals(request.mode())
+                && broker.popShareQueueNum() == request.popShareQueueNum();
+    }
+
+    private Preview inspect(MQAdminExt admin, String topic, String group) throws Exception {
+        var route = admin.examineTopicRouteInfo(topic);
+        var cluster = admin.examineBrokerClusterInfo();
+        if (route == null || route.getQueueDatas() == null || cluster == null || cluster.getBrokerAddrTable() == null) {
+            throw new BusinessException(502, "Topic route or broker registry is unavailable");
+        }
+        var names = new TreeSet<String>();
+        for (var queue : route.getQueueDatas()) {
+            if (queue == null || !StringUtils.hasText(queue.getBrokerName())) {
+                throw new BusinessException(502, "Topic route contains an invalid broker");
+            }
+            names.add(queue.getBrokerName());
+        }
+        if (names.isEmpty()) {
+            throw new BusinessException(404, "Topic has no registered brokers");
+        }
+        var result = new ArrayList<Broker>();
+        for (String name : names) {
+            var broker = cluster.getBrokerAddrTable().get(name);
+            String address = broker == null || broker.getBrokerAddrs() == null ? null : broker.getBrokerAddrs().get(0L);
+            if (!StringUtils.hasText(address)) {
+                throw new BusinessException(409, "Every topic broker must have a registered master");
+            }
+            requireOffline(admin, address, group);
+            result.add(read(admin, name, address, topic, group));
+        }
+        result.sort(Comparator.comparing(Broker::brokerName));
+        return new Preview(topic, group, List.copyOf(result));
+    }
+
+    private Broker read(MQAdminExt admin, String name, String address, String topic, String group) throws Exception {
+        var config = admin.getBrokerConfig(address);
+        if (config == null) {
+            throw new BusinessException(502, "Broker defaults are unavailable");
+        }
+        JsonNode override = reader.read((DefaultMQAdminExt) admin, address, topic, group);
+        String mode;
+        int sharing;
+        if (override == null) {
+            mode = config.getProperty("defaultMessageRequestMode");
+            requireMode(mode, 502);
+            sharing = "POP".equals(mode) ? Integer.parseInt(config.getProperty("defaultPopShareQueueNum")) : 0;
+        } else {
+            if (!override.isObject() || !topic.equals(override.path("topic").asText())
+                    || !group.equals(override.path("consumerGroup").asText())
+                    || !override.path("popShareQueueNum").isIntegralNumber()
+                    || !override.path("popShareQueueNum").canConvertToInt()) {
+                throw new BusinessException(502, "Stored request mode is invalid");
+            }
+            mode = override.path("mode").asText();
+            requireMode(mode, 502);
+            sharing = override.get("popShareQueueNum").intValue();
+        }
+        return new Broker(name, address, mode, sharing, override != null,
+                config.getProperty("serverLoadBalancerEnable", "UNKNOWN"));
+    }
+
+    private void requireOffline(MQAdminExt admin, String address, String group) throws Exception {
+        if (admin.examineSubscriptionGroupConfig(address, group) == null) {
+            throw new BusinessException(409, "Consumer group must exist on every topic master");
+        }
+        try {
+            var connection = admin.examineConsumerConnectionInfo(group, address);
+            if (connection == null || connection.getConnectionSet() == null || !connection.getConnectionSet().isEmpty()) {
+                throw new BusinessException(409, "Stop the consumer group and verify its connection state");
+            }
+        } catch (MQClientException exception) {
+            if (exception.getResponseCode() != ResponseCode.CONSUMER_NOT_ONLINE) {
+                throw exception;
+            }
+        } catch (MQBrokerException exception) {
+            if (exception.getResponseCode() != ResponseCode.CONSUMER_NOT_ONLINE) {
+                throw exception;
+            }
+        }
+    }
+
+    private void validate(String topic, String group) {
+        if (!StringUtils.hasText(topic) || !StringUtils.hasText(group)
+                || topic.startsWith("%RETRY%") || topic.startsWith("%DLQ%")) {
+            throw new BusinessException(400, "A normal topic and consumer group are required");
+        }
+    }
+
+    private void requireMode(String mode, int code) {
+        if (!"POP".equals(mode) && !"PULL".equals(mode)) {
+            throw new BusinessException(code, "Message request mode must be POP or PULL");
+        }
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/MessageRequestModeReader.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/MessageRequestModeReader.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.remoting.protocol.RequestCode;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MessageRequestModeReader {
+    private final ObjectMapper mapper;
+
+    public JsonNode read(DefaultMQAdminExt admin, String address, String topic, String group) throws Exception {
+        // Reuse the instance's authenticated SDK transport; MQAdminExt has no read wrapper for this command.
+        var request = RemotingCommand.createRequestCommand(RequestCode.GET_ALL_MESSAGE_REQUEST_MODE, null);
+        var response = admin.getDefaultMQAdminExtImpl().getMqClientInstance().getMQClientAPIImpl()
+                .getRemotingClient().invokeSync(MixAll.brokerVIPChannel(admin.isVipChannelEnabled(), address), request, 5000);
+        if (response == null || response.getCode() != ResponseCode.SUCCESS || response.getBody() == null) {
+            throw new BusinessException(502, "Broker did not return message request mode configuration");
+        }
+        JsonNode root = mapper.readTree(response.getBody());
+        JsonNode modes = root == null ? null : root.get("messageRequestModeMap");
+        if (modes == null || !modes.isObject()) {
+            throw new BusinessException(502, "Broker returned invalid message request mode configuration");
+        }
+        JsonNode groups = modes.get(topic);
+        if (groups == null) {
+            return null;
+        }
+        if (!groups.isObject()) {
+            throw new BusinessException(502, "Broker returned invalid topic request mode configuration");
+        }
+        return groups.get(group);
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
@@ -366,6 +366,24 @@ class AuthInterceptorTest {
     }
 
     @Test
+    void shouldRejectConsumerRequestModeChangesForNonAdmin() throws Exception {
+        TestSession session = login(false);
+        var response = new MockHttpServletResponse();
+        boolean allowed = session.interceptor().preHandle(authenticatedRequest(
+                "POST", "/api/consumer-request-mode", session.token()), response, new Object());
+        assertThat(allowed).isFalse();
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void shouldAllowConsumerRequestModeChangesForAdmin() throws Exception {
+        TestSession session = login(true);
+        boolean allowed = session.interceptor().preHandle(authenticatedRequest(
+                "POST", "/api/consumer-request-mode", session.token()), new MockHttpServletResponse(), new Object());
+        assertThat(allowed).isTrue();
+    }
+
+    @Test
     void shouldRejectMutatingPostForNonAdminUser() throws Exception {
         TestSession session = login(false);
         MockHttpServletRequest request = authenticatedRequest(

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerRequestModeServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerRequestModeServiceTest.java
@@ -1,0 +1,298 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.message.MessageRequestMode;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.body.Connection;
+import org.apache.rocketmq.remoting.protocol.body.ConsumerConnection;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.remoting.protocol.route.QueueData;
+import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
+import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminProperties;
+import org.apache.rocketmq.studio.cluster.broker.MqClientPool;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.studio.instance.group.ConsumerRequestMode.Outcome;
+import org.apache.rocketmq.studio.instance.group.ConsumerRequestMode.Preview;
+import org.apache.rocketmq.studio.instance.group.ConsumerRequestMode.Request;
+import org.apache.rocketmq.studio.persistence.entity.RmqOperationAudit;
+import org.apache.rocketmq.studio.persistence.mapper.RmqOperationAuditMapper;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ConsumerRequestModeServiceTest {
+    private final DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+    private final InstanceRepository repository = mock(InstanceRepository.class);
+    private final MessageRequestModeReader reader = mock(MessageRequestModeReader.class);
+    private final RmqOperationAuditMapper audits = mock(RmqOperationAuditMapper.class);
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final Properties config = new Properties();
+    private final Map<String, JsonNode> stored = new HashMap<>();
+    private final ClusterInfo cluster = new ClusterInfo();
+    private final TopicRouteData route = new TopicRouteData();
+    private ConsumerRequestModeService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        var factory = new MqAdminExtFactory() {
+            @Override
+            protected DefaultMQAdminExt newAdmin(RPCHook hook) { return admin; }
+        };
+        service = new ConsumerRequestModeService(new RuntimeAdminClientResolver(repository, factory,
+                new MqAdminProperties(), mock(MqClientPool.class)), reader, new OperationAuditService(audits));
+        when(repository.findByIdentifier("instance-a")).thenReturn(Optional.of(
+                InstanceVO.builder().endpoint("ns-a:9876").vendor(InstanceVendor.APACHE).build()));
+        cluster.setBrokerAddrTable(new HashMap<>());
+        route.setQueueDatas(new ArrayList<>());
+        for (String name : List.of("broker-b", "broker-a")) {
+            cluster.getBrokerAddrTable().put(name, new BrokerData("cluster-a", name,
+                    new HashMap<>(Map.of(0L, name + ":10911"))));
+            var data = new QueueData();
+            data.setBrokerName(name);
+            route.getQueueDatas().add(data);
+        }
+        config.setProperty("defaultMessageRequestMode", "PULL");
+        config.setProperty("defaultPopShareQueueNum", "-1");
+        config.setProperty("serverLoadBalancerEnable", "true");
+        when(admin.getBrokerConfig(anyString())).thenReturn(config);
+        when(admin.examineTopicRouteInfo("orders")).thenReturn(route);
+        when(admin.examineBrokerClusterInfo()).thenReturn(cluster);
+        when(admin.examineSubscriptionGroupConfig(anyString(), eq("group-a"))).thenReturn(new SubscriptionGroupConfig());
+        when(admin.examineConsumerConnectionInfo(eq("group-a"), anyString()))
+                .thenThrow(new MQClientException(ResponseCode.CONSUMER_NOT_ONLINE, "offline"));
+        when(reader.read(eq(admin), anyString(), eq("orders"), eq("group-a")))
+                .thenAnswer(invocation -> stored.get(invocation.getArgument(1)));
+        doAnswer(invocation -> {
+            stored.put(invocation.getArgument(0), override(invocation.<MessageRequestMode>getArgument(3).name(),
+                    invocation.getArgument(4)));
+            return null;
+        }).when(admin).setMessageRequestMode(anyString(), eq("orders"), eq("group-a"), any(), anyInt(), eq(5000L));
+    }
+
+    private JsonNode override(String mode, int sharing) {
+        return mapper.createObjectNode().put("topic", "orders").put("consumerGroup", "group-a")
+                .put("mode", mode).put("popShareQueueNum", sharing);
+    }
+
+    private Preview preview() { return service.preview("instance-a", "orders", "group-a"); }
+    private Request request(String mode, int sharing) {
+        return new Request("instance-a", "orders", "group-a", mode, sharing, preview().brokers());
+    }
+
+    @Test
+    void previewsEffectiveDefaultsAndOverridesWithoutWriting() throws Exception {
+        stored.put("broker-b:10911", override("POP", 2));
+        var result = preview();
+        assertThat(result.brokers()).hasSize(2);
+        assertThat(result.brokers().getFirst().mode()).isEqualTo("PULL");
+        assertThat(result.brokers().getFirst().popShareQueueNum()).isZero();
+        assertThat(result.brokers().getFirst().explicit()).isFalse();
+        assertThat(result.brokers().getLast().mode()).isEqualTo("POP");
+        assertThat(result.brokers().getLast().popShareQueueNum()).isEqualTo(2);
+        assertThat(result.brokers().getLast().explicit()).isTrue();
+        verify(admin, never()).setMessageRequestMode(anyString(), anyString(), anyString(), any(), anyInt(), anyLong());
+    }
+
+    @Test
+    void inheritedPopUsesDefaultSharingAndWritesAnExplicitOverride() {
+        config.setProperty("defaultMessageRequestMode", "POP");
+        var before = preview().brokers().getFirst();
+        assertThat(before.popShareQueueNum()).isEqualTo(-1);
+        assertThat(before.explicit()).isFalse();
+        assertThat(service.apply(request("POP", -1)).brokers()).allMatch(row -> "CONFIRMED".equals(row.status()));
+        assertThat(preview().brokers()).allMatch(ConsumerRequestMode.Broker::explicit);
+    }
+
+    @Test
+    void appliesToEveryTopicMasterAndRecordsEachAttempt() throws Exception {
+        var receipt = service.apply(request("POP", 3));
+        assertThat(receipt.brokers()).extracting(Outcome::status).containsExactly("CONFIRMED", "CONFIRMED");
+        verify(admin).setMessageRequestMode("broker-a:10911", "orders", "group-a", MessageRequestMode.POP, 3, 5000);
+        verify(admin).setMessageRequestMode("broker-b:10911", "orders", "group-a", MessageRequestMode.POP, 3, 5000);
+        verify(audits, times(2)).insert(any(RmqOperationAudit.class));
+    }
+
+    @Test
+    void unchangedExplicitValuesAreNotWritten() throws Exception {
+        stored.put("broker-a:10911", override("PULL", 0));
+        stored.put("broker-b:10911", override("PULL", 0));
+        assertThat(service.apply(request("PULL", 0)).brokers()).allMatch(row -> "UNCHANGED".equals(row.status()));
+        verify(admin, never()).setMessageRequestMode(anyString(), anyString(), anyString(), any(), anyInt(), anyLong());
+    }
+
+    @Test
+    void changedDefaultsOrOverridesInvalidateTheReviewedPreview() throws Exception {
+        var request = request("POP", -1);
+        stored.put("broker-b:10911", override("PULL", 0));
+        assertThatThrownBy(() -> service.apply(request)).hasMessageContaining("changed");
+        verify(admin, never()).setMessageRequestMode(anyString(), anyString(), anyString(), any(), anyInt(), anyLong());
+    }
+
+    @Test
+    void aTimeoutStopsFurtherBrokersAndDoesNotRetry() throws Exception {
+        doThrow(new org.apache.rocketmq.remoting.exception.RemotingTimeoutException("broker-a:10911", 5000))
+                .when(admin).setMessageRequestMode(eq("broker-a:10911"), anyString(), anyString(), any(), anyInt(), anyLong());
+        assertThat(service.apply(request("POP", -1)).brokers()).extracting(Outcome::status)
+                .containsExactly("UNKNOWN", "NOT_ATTEMPTED");
+        verify(admin, times(1)).setMessageRequestMode(anyString(), anyString(), anyString(), any(), anyInt(), anyLong());
+    }
+
+    @Test
+    void partialSuccessAndObservedMismatchRemainInTheReceipt() throws Exception {
+        doNothing().when(admin).setMessageRequestMode(eq("broker-b:10911"), anyString(), anyString(), any(), anyInt(), anyLong());
+        var result = service.apply(request("POP", -1));
+        assertThat(result.brokers()).extracting(Outcome::status).containsExactly("CONFIRMED", "UNKNOWN");
+        assertThat(result.brokers().getLast().observed().mode()).isEqualTo("PULL");
+    }
+
+    @Test
+    void auditFailureCannotDiscardConfirmedBrokerUpdates() {
+        doThrow(new IllegalStateException("audit unavailable")).when(audits).insert(any(RmqOperationAudit.class));
+        assertThat(service.apply(request("POP", -1)).brokers()).allMatch(row -> "CONFIRMED".equals(row.status()));
+    }
+
+    @Test
+    void onlineOrUnknownConsumerStateBlocksPreflight() throws Exception {
+        var connection = new ConsumerConnection();
+        connection.getConnectionSet().add(new Connection());
+        doReturn(connection).when(admin).examineConsumerConnectionInfo(eq("group-a"), anyString());
+        assertThatThrownBy(this::preview).hasMessageContaining("Stop the consumer");
+        doReturn(null).when(admin).examineConsumerConnectionInfo(eq("group-a"), anyString());
+        assertThatThrownBy(this::preview).hasMessageContaining("connection state");
+    }
+
+    @Test
+    void onlyOfflineResponseCodesPermitChanges() throws Exception {
+        doThrow(new MQBrokerException(ResponseCode.CONSUMER_NOT_ONLINE, "offline"))
+                .when(admin).examineConsumerConnectionInfo(eq("group-a"), anyString());
+        assertThat(preview().brokers()).hasSize(2);
+        doThrow(new MQBrokerException(ResponseCode.NO_PERMISSION, "denied"))
+                .when(admin).examineConsumerConnectionInfo(eq("group-a"), anyString());
+        assertThatThrownBy(this::preview).hasMessageContaining("denied");
+        doThrow(new MQClientException(ResponseCode.SYSTEM_ERROR, "failed"))
+                .when(admin).examineConsumerConnectionInfo(eq("group-a"), anyString());
+        assertThatThrownBy(this::preview).hasMessageContaining("failed");
+    }
+
+    @Test
+    void missingGroupMasterAndRoutePreventIncompleteScope() throws Exception {
+        when(admin.examineSubscriptionGroupConfig(anyString(), anyString())).thenReturn(null);
+        assertThatThrownBy(this::preview).hasMessageContaining("must exist");
+        cluster.getBrokerAddrTable().get("broker-a").getBrokerAddrs().clear();
+        assertThatThrownBy(this::preview).hasMessageContaining("registered master");
+        route.getQueueDatas().clear();
+        assertThatThrownBy(this::preview).hasMessageContaining("no registered brokers");
+        when(admin.examineTopicRouteInfo("orders")).thenReturn(null);
+        assertThatThrownBy(this::preview).hasMessageContaining("unavailable");
+    }
+
+    @Test
+    void malformedStoredOverridesAreErrorsNotInheritedDefaults() {
+        stored.put("broker-a:10911", mapper.createObjectNode().put("mode", "POP"));
+        assertThatThrownBy(this::preview).hasMessageContaining("Stored request mode is invalid");
+        stored.put("broker-a:10911", override("UNSUPPORTED", 0));
+        assertThatThrownBy(this::preview).hasMessageContaining("must be POP or PULL");
+    }
+
+    @Test
+    void invalidModesSharingAndSystemTopicsAreRejected() {
+        assertThatThrownBy(() -> service.preview("instance-a", "%RETRY%group-a", "group-a"))
+                .hasMessageContaining("normal topic");
+        assertThatThrownBy(() -> service.apply(new Request("instance-a", "orders", "group-a", "OTHER", 0, List.of())))
+                .hasMessageContaining("must be POP or PULL");
+        assertThatThrownBy(() -> service.apply(new Request("instance-a", "orders", "group-a", "PULL", 1, List.of())))
+                .hasMessageContaining("valid POP sharing");
+        assertThatThrownBy(() -> service.apply(new Request("instance-a", "orders", "group-a", "POP", -2, List.of())))
+                .hasMessageContaining("valid POP sharing");
+    }
+
+    @Test
+    void interruptedWriteStopsFurtherBrokersAndRestoresFlag() throws Exception {
+        doThrow(new InterruptedException()).when(admin).setMessageRequestMode(anyString(), anyString(), anyString(), any(), anyInt(), anyLong());
+        try {
+            assertThat(service.apply(request("POP", -1)).brokers().getFirst().status()).isEqualTo("UNKNOWN");
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void previewAndPreflightInterruptionsRestoreFlagBeforeAnyWrite() throws Exception {
+        var request = request("POP", -1);
+        doThrow(new InterruptedException()).when(admin).examineTopicRouteInfo("orders");
+        try {
+            assertThatThrownBy(this::preview).hasMessageContaining("inspection was interrupted");
+            assertThat(Thread.interrupted()).isTrue();
+            assertThatThrownBy(() -> service.apply(request)).hasMessageContaining("preflight was interrupted");
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+            verify(admin, never()).setMessageRequestMode(anyString(), anyString(), anyString(), any(), anyInt(), anyLong());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void missingDefaultsAndInvalidRouteEntriesCannotProduceAPreview() throws Exception {
+        when(admin.getBrokerConfig(anyString())).thenReturn(null);
+        assertThatThrownBy(this::preview).hasMessageContaining("defaults are unavailable");
+        route.getQueueDatas().getFirst().setBrokerName(null);
+        assertThatThrownBy(this::preview).hasMessageContaining("invalid broker");
+    }
+
+    @Test
+    void controllerBindsPreviewAndConfirmedChanges() throws Exception {
+        var mvc = MockMvcBuilders.standaloneSetup(new ConsumerRequestModeController(service)).build();
+        mvc.perform(get("/api/consumer-request-mode").param("instanceId", "instance-a")
+                        .param("topic", "orders").param("group", "group-a"))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.data.brokers[0].explicit").value(false));
+        mvc.perform(post("/api/consumer-request-mode").contentType("application/json")
+                        .content(mapper.writeValueAsString(request("POP", -1))))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.data.brokers[0].status").value("CONFIRMED"));
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/MessageRequestModeReaderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/MessageRequestModeReaderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import org.apache.rocketmq.client.impl.MQClientAPIImpl;
+import org.apache.rocketmq.client.impl.factory.MQClientInstance;
+import org.apache.rocketmq.remoting.RemotingClient;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.remoting.protocol.RequestCode;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExtImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MessageRequestModeReaderTest {
+    private final DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+    private final RemotingClient transport = mock(RemotingClient.class);
+    private final MessageRequestModeReader reader = new MessageRequestModeReader(new ObjectMapper());
+    private final RemotingCommand response = RemotingCommand.createResponseCommand(ResponseCode.SUCCESS, null);
+
+    @BeforeEach
+    void setUp() throws Exception {
+        var implementation = mock(DefaultMQAdminExtImpl.class);
+        var instance = mock(MQClientInstance.class);
+        var api = mock(MQClientAPIImpl.class);
+        when(admin.getDefaultMQAdminExtImpl()).thenReturn(implementation);
+        when(implementation.getMqClientInstance()).thenReturn(instance);
+        when(instance.getMQClientAPIImpl()).thenReturn(api);
+        when(api.getRemotingClient()).thenReturn(transport);
+        when(transport.invokeSync(anyString(), any(), anyLong())).thenReturn(response);
+    }
+
+    private void body(String value) { response.setBody(value.getBytes(StandardCharsets.UTF_8)); }
+
+    @Test
+    void usesExistingSdkTransportAndSelectsOnlyTheRequestedGroup() throws Exception {
+        when(admin.isVipChannelEnabled()).thenReturn(true);
+        body("""
+                {"messageRequestModeMap":{"orders":{"group-a":{"topic":"orders","consumerGroup":"group-a",
+                "mode":"POP","popShareQueueNum":-1},"other":{"mode":"PULL"}}}}
+                """);
+        var result = reader.read(admin, "master:10911", "orders", "group-a");
+        assertThat(result.get("mode").asText()).isEqualTo("POP");
+        assertThat(result.toString()).doesNotContain("other");
+        var request = org.mockito.ArgumentCaptor.forClass(RemotingCommand.class);
+        verify(transport).invokeSync(eq("master:10909"), request.capture(), eq(5000L));
+        assertThat(request.getValue().getCode()).isEqualTo(RequestCode.GET_ALL_MESSAGE_REQUEST_MODE);
+    }
+
+    @Test
+    void absenceOfTopicOrGroupIsAnInheritedDefault() throws Exception {
+        body("{\"messageRequestModeMap\":{}}");
+        assertThat(reader.read(admin, "master:10911", "orders", "group-a")).isNull();
+        body("{\"messageRequestModeMap\":{\"orders\":{}}}");
+        assertThat(reader.read(admin, "master:10911", "orders", "group-a")).isNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "null", "{\"messageRequestModeMap\":[]}",
+        "{\"messageRequestModeMap\":{\"orders\":null}}"})
+    void invalidEnvelopesCannotBeMistakenForAnAbsentOverride(String json) {
+        body(json);
+        assertThatThrownBy(() -> reader.read(admin, "master:10911", "orders", "group-a"))
+                .hasMessageContaining("invalid");
+    }
+
+    @Test
+    void brokerErrorsAndMissingBodiesAreNotDefaultMode() throws Exception {
+        assertThatThrownBy(() -> reader.read(admin, "master:10911", "orders", "group-a"))
+                .hasMessageContaining("did not return");
+        body("{\"messageRequestModeMap\":{}}");
+        response.setCode(ResponseCode.NO_PERMISSION);
+        assertThatThrownBy(() -> reader.read(admin, "master:10911", "orders", "group-a"))
+                .hasMessageContaining("did not return");
+        when(transport.invokeSync(anyString(), any(), anyLong())).thenReturn(null);
+        assertThatThrownBy(() -> reader.read(admin, "master:10911", "orders", "group-a"))
+                .hasMessageContaining("did not return");
+    }
+}

--- a/web/src/api/consumerRequestMode.test.ts
+++ b/web/src/api/consumerRequestMode.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, describe, expect, it } from 'vitest';
+import client from './client';
+import { applyConsumerRequestMode, previewConsumerRequestMode } from './consumerRequestMode';
+
+const mock = new MockAdapter(client);
+const selection = { instanceId: 'instance-a', topic: 'orders', group: 'group-a' };
+const before = {
+  brokerName: 'broker-a',
+  address: 'master:10911',
+  mode: 'PULL' as const,
+  popShareQueueNum: 0,
+  explicit: false,
+  serverLoadBalancerEnable: 'true',
+};
+afterEach(() => mock.reset());
+describe('Consumer request mode API', () => {
+  it('previews through GET without changing broker configuration', async () => {
+    mock.onGet('/consumer-request-mode').reply((config) => {
+      expect(config.params).toEqual(selection);
+      return [200, { code: 0, data: { topic: 'orders', group: 'group-a', brokers: [before] } }];
+    });
+    expect((await previewConsumerRequestMode(selection)).brokers[0].explicit).toBe(false);
+    expect(mock.history.post).toHaveLength(0);
+  });
+  it('posts the exact preview and preserves uncertain outcomes', async () => {
+    const signal = new AbortController().signal;
+    mock.onPost('/consumer-request-mode').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({
+        ...selection,
+        mode: 'POP',
+        popShareQueueNum: -1,
+        expected: [before],
+      });
+      expect(config.signal).toBe(signal);
+      return [200, { code: 0, data: { brokers: [{ before, status: 'UNKNOWN', observed: null }] } }];
+    });
+    expect(
+      (await applyConsumerRequestMode(selection, 'POP', -1, [before], signal)).brokers[0].status,
+    ).toBe('UNKNOWN');
+    expect(mock.history.post).toHaveLength(1);
+  });
+});

--- a/web/src/api/consumerRequestMode.ts
+++ b/web/src/api/consumerRequestMode.ts
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import client from './client';
+
+export type RequestMode = 'POP' | 'PULL';
+export interface RequestModeSelection {
+  instanceId: string;
+  topic: string;
+  group: string;
+}
+export interface BrokerRequestMode {
+  brokerName: string;
+  address: string;
+  mode: RequestMode;
+  popShareQueueNum: number;
+  explicit: boolean;
+  serverLoadBalancerEnable: string;
+}
+export interface RequestModePreview {
+  topic: string;
+  group: string;
+  brokers: BrokerRequestMode[];
+}
+export interface RequestModeReceipt {
+  brokers: {
+    before: BrokerRequestMode;
+    status: 'CONFIRMED' | 'UNCHANGED' | 'UNKNOWN' | 'NOT_ATTEMPTED';
+    observed: BrokerRequestMode | null;
+  }[];
+}
+export async function previewConsumerRequestMode(
+  params: RequestModeSelection,
+  signal?: AbortSignal,
+) {
+  const response = await client.get<{ data: RequestModePreview }>('/consumer-request-mode', {
+    params,
+    signal,
+  });
+  return response.data.data;
+}
+export async function applyConsumerRequestMode(
+  selection: RequestModeSelection,
+  mode: RequestMode,
+  popShareQueueNum: number,
+  expected: BrokerRequestMode[],
+  signal?: AbortSignal,
+) {
+  const response = await client.post<{ data: RequestModeReceipt }>(
+    '/consumer-request-mode',
+    { ...selection, mode, popShareQueueNum, expected },
+    { signal, timeout: 0 },
+  );
+  return response.data.data;
+}

--- a/web/src/components/ConsumerRequestModeDialog.tsx
+++ b/web/src/components/ConsumerRequestModeDialog.tsx
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import { useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Checkbox,
+  InputNumber,
+  Modal,
+  Select,
+  Space,
+  Table,
+  Tag,
+  Typography,
+} from 'antd';
+import {
+  applyConsumerRequestMode,
+  previewConsumerRequestMode,
+  type RequestMode,
+  type BrokerRequestMode,
+  type RequestModePreview,
+  type RequestModeReceipt,
+} from '../api/consumerRequestMode';
+
+export function ConsumerRequestModeDialog({
+  instanceId,
+  topic,
+  group,
+  onClose,
+}: {
+  instanceId: string;
+  topic: string;
+  group: string;
+  onClose: () => void;
+}) {
+  const [mode, setMode] = useState<RequestMode>('POP');
+  const [sharing, setSharing] = useState<number | null>(-1);
+  const [preview, setPreview] = useState<RequestModePreview>();
+  const [receipt, setReceipt] = useState<RequestModeReceipt>();
+  const [confirmed, setConfirmed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const active = useRef(true);
+  const locked = useRef(false);
+  const request = useRef<AbortController>();
+  const valid =
+    sharing !== null && Number.isInteger(sharing) && sharing >= -1 && sharing <= 2147483647;
+  useEffect(() => {
+    active.current = true;
+    return () => {
+      active.current = false;
+      request.current?.abort();
+    };
+  }, []);
+  const invalidate = () => {
+    setPreview(undefined);
+    setReceipt(undefined);
+    setConfirmed(false);
+    setError('');
+  };
+  const run = async (apply: boolean) => {
+    if (locked.current || !valid || (apply && (!preview || !confirmed))) return;
+    locked.current = true;
+    setBusy(true);
+    setError('');
+    const controller = new AbortController();
+    request.current = controller;
+    const selection = { instanceId, topic, group };
+    try {
+      if (apply && preview) {
+        setPreview(undefined);
+        setConfirmed(false);
+        const result = await applyConsumerRequestMode(
+          selection,
+          mode,
+          sharing!,
+          preview.brokers,
+          controller.signal,
+        );
+        if (active.current) setReceipt(result);
+      } else {
+        invalidate();
+        const result = await previewConsumerRequestMode(selection, controller.signal);
+        if (active.current) setPreview(result);
+      }
+    } catch (failure) {
+      if (active.current)
+        setError(
+          apply
+            ? 'Update was not confirmed. Read every broker before recovery; do not assume that no changes were made.'
+            : failure instanceof Error
+              ? failure.message
+              : 'Request mode preview failed',
+        );
+    } finally {
+      locked.current = false;
+      if (active.current) setBusy(false);
+    }
+  };
+  const rows: { before: BrokerRequestMode; status: string; observed: BrokerRequestMode | null }[] =
+    receipt?.brokers ??
+    preview?.brokers.map((before) => ({ before, status: 'PREVIEW', observed: null })) ??
+    [];
+  return (
+    <Modal
+      open
+      title="Consumer request mode"
+      width={1000}
+      style={{ top: 24 }}
+      onCancel={() => {
+        if (!locked.current) onClose();
+      }}
+      closable={!busy}
+      maskClosable={!busy}
+      footer={
+        <Space>
+          <Button disabled={busy} onClick={onClose}>
+            Close
+          </Button>
+          <Button loading={busy} disabled={!valid} onClick={() => void run(false)}>
+            Preview broker modes
+          </Button>
+          <Button
+            danger
+            type="primary"
+            loading={busy}
+            disabled={!preview || !confirmed || !valid}
+            onClick={() => void run(true)}
+          >
+            Apply request mode
+          </Button>
+        </Space>
+      }
+    >
+      <Space
+        direction="vertical"
+        size={16}
+        style={{ width: '100%', maxHeight: 'calc(100vh - 210px)', overflow: 'auto' }}
+      >
+        <Alert
+          type="warning"
+          showIcon
+          message="Stop this consumer group before preview and keep it stopped until verification."
+          description="This writes an explicit topic/group override on every topic master. Compatible clients must use server assignments. It does not convert client SDKs, drain in-flight POP messages, or reset offsets."
+        />
+        <Typography.Text>
+          Topic: <strong>{topic}</strong> · Group: <strong>{group}</strong>
+        </Typography.Text>
+        <Space size={20} wrap>
+          <label>
+            Requested mode{' '}
+            <Select
+              aria-label="Requested mode"
+              value={mode}
+              disabled={busy}
+              style={{ width: 110 }}
+              options={[
+                { value: 'POP', label: 'POP' },
+                { value: 'PULL', label: 'PULL' },
+              ]}
+              onChange={(value) => {
+                setMode(value);
+                setSharing(value === 'PULL' ? 0 : -1);
+                invalidate();
+              }}
+            />
+          </label>
+          <label>
+            POP sharing{' '}
+            <InputNumber
+              aria-label="POP sharing"
+              min={-1}
+              max={2147483647}
+              precision={0}
+              value={sharing}
+              disabled={busy || mode === 'PULL'}
+              onChange={(value) => {
+                setSharing(value);
+                invalidate();
+              }}
+            />
+          </label>
+        </Space>
+        <Typography.Paragraph type="secondary" style={{ margin: 0 }}>
+          POP values -1 and 0 allow each client to access all queues. A positive value shares queues
+          assigned to following clients; it also becomes all queues when it reaches the client-count
+          threshold. PULL stores 0.
+        </Typography.Paragraph>
+        {error && <Alert type="error" showIcon message={error} />}
+        {receipt?.brokers.some((row) => row.status === 'UNKNOWN') && (
+          <Alert
+            type="warning"
+            showIcon
+            message="Update stopped after an unconfirmed broker. Inspect all broker modes before continuing."
+          />
+        )}
+        <Table
+          size="small"
+          pagination={false}
+          dataSource={rows}
+          rowKey={(row) => row.before.brokerName}
+          scroll={{ x: 800 }}
+          columns={[
+            {
+              title: 'Broker / master',
+              render: (_, row) => (
+                <>
+                  {row.before.brokerName}
+                  <br />
+                  <Typography.Text code>{row.before.address}</Typography.Text>
+                </>
+              ),
+            },
+            {
+              title: 'Before / POP sharing',
+              render: (_, row) => `${row.before.mode} / ${row.before.popShareQueueNum}`,
+            },
+            {
+              title: 'Before source',
+              render: (_, row) => (row.before.explicit ? 'Explicit override' : 'Broker default'),
+            },
+            {
+              title: 'Server load balancing',
+              render: (_, row) => row.before.serverLoadBalancerEnable,
+            },
+            {
+              title: 'Observed after',
+              render: (_, row) =>
+                row.observed
+                  ? `${row.observed.mode} / ${row.observed.popShareQueueNum}`
+                  : 'Unavailable',
+            },
+            { title: 'State', dataIndex: 'status', render: (value) => <Tag>{value}</Tag> },
+          ]}
+        />
+        {preview && (
+          <Checkbox
+            checked={confirmed}
+            disabled={busy}
+            onChange={(event) => setConfirmed(event.target.checked)}
+          >
+            I reviewed every broker and planned client compatibility, in-flight delivery and
+            recovery.
+          </Checkbox>
+        )}
+        <Typography.Text type="secondary">
+          Restoring a previous default value creates an explicit override; this API cannot remove an
+          override. Closing the browser or switching instances cannot cancel broker writes.
+        </Typography.Text>
+      </Space>
+    </Modal>
+  );
+}

--- a/web/src/components/__tests__/ConsumerRequestModeDialog.test.tsx
+++ b/web/src/components/__tests__/ConsumerRequestModeDialog.test.tsx
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { ConfigProvider } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConsumerRequestModeDialog } from '../ConsumerRequestModeDialog';
+import {
+  applyConsumerRequestMode,
+  previewConsumerRequestMode,
+  type RequestModePreview,
+} from '../../api/consumerRequestMode';
+
+vi.mock('../../api/consumerRequestMode', () => ({
+  applyConsumerRequestMode: vi.fn(),
+  previewConsumerRequestMode: vi.fn(),
+}));
+const before = {
+  brokerName: 'broker-a',
+  address: 'master:10911',
+  mode: 'PULL' as const,
+  popShareQueueNum: 0,
+  explicit: false,
+  serverLoadBalancerEnable: 'true',
+};
+const sample: RequestModePreview = { topic: 'orders', group: 'group-a', brokers: [before] };
+const observed = { ...before, mode: 'POP' as const, popShareQueueNum: -1, explicit: true };
+const open = (onClose = vi.fn()) =>
+  render(
+    <ConfigProvider theme={{ token: { motion: false } }}>
+      <ConsumerRequestModeDialog
+        instanceId="instance-a"
+        topic="orders"
+        group="group-a"
+        onClose={onClose}
+      />
+    </ConfigProvider>,
+  );
+const preview = async () => {
+  fireEvent.click(screen.getByRole('button', { name: /Preview broker modes/ }));
+  await screen.findByText('Broker default');
+};
+const confirm = () => fireEvent.click(screen.getByRole('checkbox'));
+const apply = () => fireEvent.click(screen.getByRole('button', { name: /Apply request mode/ }));
+
+describe('Consumer request mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: false,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+    vi.mocked(previewConsumerRequestMode).mockResolvedValue(sample);
+    vi.mocked(applyConsumerRequestMode).mockResolvedValue({
+      brokers: [{ before, status: 'CONFIRMED', observed }],
+    });
+  });
+
+  it('requires preview and confirmation and submits the reviewed topic scope', async () => {
+    open();
+    expect(previewConsumerRequestMode).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /Apply request mode/ })).toBeDisabled();
+    await preview();
+    expect(previewConsumerRequestMode).toHaveBeenCalledWith(
+      { instanceId: 'instance-a', topic: 'orders', group: 'group-a' },
+      expect.any(AbortSignal),
+    );
+    expect(screen.getByRole('button', { name: /Apply request mode/ })).toBeDisabled();
+    confirm();
+    apply();
+    await screen.findByText('CONFIRMED');
+    expect(applyConsumerRequestMode).toHaveBeenCalledWith(
+      { instanceId: 'instance-a', topic: 'orders', group: 'group-a' },
+      'POP',
+      -1,
+      [before],
+      expect.any(AbortSignal),
+    );
+    expect(screen.getByText('POP / -1')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Apply request mode/ })).toBeDisabled();
+  });
+
+  it('invalidates the preview when POP sharing changes', async () => {
+    open();
+    await preview();
+    confirm();
+    fireEvent.change(screen.getByLabelText('POP sharing'), { target: { value: '3' } });
+    expect(screen.queryByText('Broker default')).not.toBeInTheDocument();
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Apply request mode/ })).toBeDisabled();
+  });
+
+  it('sets sharing to zero and invalidates confirmation when switching to PULL', async () => {
+    open();
+    await preview();
+    confirm();
+    fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Requested mode' }));
+    const option = await screen.findByText('PULL', { selector: '.ant-select-item-option-content' });
+    fireEvent.click(option);
+    expect(screen.getByLabelText('POP sharing')).toHaveValue('0');
+    expect(screen.getByLabelText('POP sharing')).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Apply request mode/ })).toBeDisabled();
+  });
+
+  it('locks writes and form edits during an apply request', async () => {
+    let resolve!: (value: Awaited<ReturnType<typeof applyConsumerRequestMode>>) => void;
+    vi.mocked(applyConsumerRequestMode).mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    const close = vi.fn();
+    open(close);
+    await preview();
+    confirm();
+    apply();
+    apply();
+    expect(applyConsumerRequestMode).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText('POP sharing')).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(close).not.toHaveBeenCalled();
+    await act(async () => resolve({ brokers: [{ before, status: 'CONFIRMED', observed }] }));
+  });
+
+  it('never offers the consumed preview after a lost response', async () => {
+    vi.mocked(applyConsumerRequestMode).mockRejectedValue(new Error('timeout'));
+    open();
+    await preview();
+    confirm();
+    apply();
+    await screen.findByText(/Update was not confirmed/);
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Apply request mode/ })).toBeDisabled();
+  });
+
+  it('preserves partial outcomes without showing all brokers as failed', async () => {
+    vi.mocked(applyConsumerRequestMode).mockResolvedValue({
+      brokers: [
+        { before, status: 'CONFIRMED', observed },
+        { before: { ...before, brokerName: 'broker-b' }, status: 'UNKNOWN', observed: null },
+        { before: { ...before, brokerName: 'broker-c' }, status: 'NOT_ATTEMPTED', observed: null },
+      ],
+    });
+    open();
+    await preview();
+    confirm();
+    apply();
+    await screen.findByText('CONFIRMED');
+    expect(screen.getByText('UNKNOWN')).toBeInTheDocument();
+    expect(screen.getByText('NOT_ATTEMPTED')).toBeInTheDocument();
+    expect(screen.getByText(/Update stopped after/)).toBeInTheDocument();
+  });
+
+  it('cancels a preview on unmount and ignores its late completion', async () => {
+    let resolve!: (value: RequestModePreview) => void;
+    vi.mocked(previewConsumerRequestMode).mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    const view = open();
+    fireEvent.click(screen.getByRole('button', { name: /Preview broker modes/ }));
+    const signal = vi.mocked(previewConsumerRequestMode).mock.calls[0][1];
+    view.unmount();
+    expect(signal?.aborted).toBe(true);
+    await act(async () => resolve(sample));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('keeps changes disabled when the preview is rejected', async () => {
+    vi.mocked(previewConsumerRequestMode).mockRejectedValue(new Error('Stop the consumer group'));
+    open();
+    fireEvent.click(screen.getByRole('button', { name: /Preview broker modes/ }));
+    await screen.findByText('Stop the consumer group');
+    expect(applyConsumerRequestMode).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -65,6 +65,8 @@ import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
 
 import PageHeader from '../../components/PageHeader';
+import { ConsumerRequestModeDialog } from '../../components/ConsumerRequestModeDialog';
+import { isMockMode } from '../../services/dataMode';
 import { InstanceSelect } from '../../components/InstanceSelect';
 import { useLang } from '../../i18n/LangContext';
 import { TOPIC_TYPE_MAP, PROTOCOL_MAP } from '../../constants/theme';
@@ -271,6 +273,7 @@ const ConsumerPageContent = ({
   const [modeFilter, setModeFilter] = useState<string>('ALL');
   const [modalOpen, setModalOpen] = useState(false);
   const [selectedGroup, setSelectedGroup] = useState<ConsumerGroup | null>(null);
+  const [requestModeTarget, setRequestModeTarget] = useState<{ topic: string; group: string }>();
   const [settingsGroup, setSettingsGroup] = useState<ConsumerGroup | null>(null);
   const [settingsLoading, setSettingsLoading] = useState(false);
   const [settingsSubmitting, setSettingsSubmitting] = useState(false);
@@ -1220,6 +1223,26 @@ const ConsumerPageContent = ({
      Modal: Queue Progress Tab
      ═══════════════════════════════════════════ */
   const queueColumns: ColumnsType<QueueProgress> = [
+    ...(!isCloudInstance && selectedInstance && !isMockMode()
+      ? [
+          {
+            title: 'Request mode',
+            key: 'request-mode',
+            width: 150,
+            render: (_: unknown, row: QueueProgress) => (
+              <Button
+                size="small"
+                onClick={() => {
+                  if (selectedGroupName)
+                    setRequestModeTarget({ topic: row.topic, group: selectedGroupName });
+                }}
+              >
+                Configure POP/PULL
+              </Button>
+            ),
+          },
+        ]
+      : []),
     {
       title: 'Topic 主题',
       dataIndex: 'topic',
@@ -1405,6 +1428,14 @@ const ConsumerPageContent = ({
      ═══════════════════════════════════════════ */
   return (
     <div style={{ padding: 24 }}>
+      {requestModeTarget && selectedInstanceId && (
+        <ConsumerRequestModeDialog
+          key={selectedInstanceId + requestModeTarget.topic + requestModeTarget.group}
+          instanceId={selectedInstanceId}
+          {...requestModeTarget}
+          onClose={() => setRequestModeTarget(undefined)}
+        />
+      )}
       {/* ─── Header ─── */}
       <PageHeader
         title={t('group.title')}


### PR DESCRIPTION
现有消费组页面可以展示请求模式，但缺少按 Topic/消费组配置 POP、PULL 的完整流程。本 PR 增加覆盖所有 Topic 主 Broker 的预览、确认、写入与回读，明确 Broker 默认值和显式覆盖的区别。

## 改动说明

- 预览使用所选实例的登记信息与 Topic 路由，检查消费组在每个主 Broker 上存在且离线，再读取有效请求模式、POP 共享参数、配置来源及服务端负载均衡开关。
- 没有显式条目时采用 Broker 默认模式；默认 PULL 的共享值为 0，默认 POP 使用 defaultPopShareQueueNum。读取失败、缺失或格式异常不会当作继承默认。
- 提交前重新核对所有 Broker 配置和路由，逐节点调用原生 setMessageRequestMode 并回读。保留 CONFIRMED、UNCHANGED、UNKNOWN、NOT_ATTEMPTED；首次不确定结果停止后续更新，不自动重试，审计异常不丢失回执。
- UI 展示整个 Topic 范围，需明确确认；POP -1/0 的全部队列语义、PULL 归零、客户端兼容性和在途消息限制均有说明。关闭或切换实例不能撤回已发出的 Broker 写入。

MQAdminExt 没有读取封装，因此通过公开 SDK 访问器复用现有认证传输与 VIP 通道，发送官方 GET_ALL_MESSAGE_REQUEST_MODE 命令；没有反射或新建未认证客户端。协议依据：[MessageRequestModeManager](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/loadbalance/MessageRequestModeManager.java)、[QueryAssignmentProcessor](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/QueryAssignmentProcessor.java) 和 [AdminBrokerProcessor](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java#L2037)。

## 原提交验证记录

本地后端 75 项、前端 41 项测试通过；服务 111/111 行覆盖，读取封装 15/15 行、15/16 分支。Checkstyle、TypeScript/Vite 构建及后端打包通过；ESLint 0 错误、10 条现有告警。浏览器同一脚本明确拦截本地 GET/POST，验证默认 PULL 预览、POP -1 请求及确认回执，另验证选择 PULL 后共享值归零且禁用输入。没有修改真实 Broker。

去重检索覆盖全部 Issue/PR 快照和在线 setMessageRequestMode、message request mode、popShareQueueNum、popWorkGroupSize、POP/PULL 关键词。#4053、#1964 等涉及模式展示或筛选，不提供该配置流程；精确功能检索没有重复。接口、界面、协议及故障测试、权限测试和中文文档在一个 PR 中完成。

## 兼容性与回滚

无新增依赖或数据库迁移。恢复原默认值会创建显式覆盖，原生接口不能删除覆盖以重新继承后续默认值；多 Broker 配置无事务保证。代码可撤销本提交，已经修改的配置按保存的预览和文档恢复。真实 POP 客户端切换、压力、容量及网络分区验证未执行。既有全量测试失败与依赖审计缺口继续记录，不宣称全量门槛通过；按用户授权做增量验证。提交含 [skip ci]，未运行远端工作流。核验日期：2026-09-08。
