### PR TITLE
fix(alert): mark proxy discovery failure as a whole-scope failure

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqProxyMetricsCollector.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqProxyMetricsCollector.java
@@ -79,7 +79,9 @@ public class ApacheRocketMqProxyMetricsCollector implements ClusterMetricsCollec
             return samples;
         } catch (RuntimeException error) {
             log.warn("Failed to discover proxies for instance {}: {}", instance.getName(), error.getMessage());
-            return List.of(unavailable(instance, null, Map.of("proxyAddr", "unknown"), collectedAt));
+            // no proxy is known at this point: emit the whole-scope failure marker (empty labels)
+            // so NativeAlertProcessor skips reconciliation instead of resolving active proxy alerts
+            return List.of(unavailable(instance, null, Map.of(), collectedAt));
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqProxyMetricsCollectorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqProxyMetricsCollectorTest.java
@@ -82,7 +82,7 @@ class ApacheRocketMqProxyMetricsCollectorTest {
     }
 
     @Test
-    void recordsUnavailableSampleWhenProxyDiscoveryFailsTest() {
+    void recordsWholeScopeFailureSampleWhenProxyDiscoveryFailsTest() {
         ClusterService clusterService = mock(ClusterService.class);
         InstanceVO instance = InstanceVO.builder().name("local").endpoint("localhost:9876").build();
         doThrow(new IllegalStateException("nameserver unavailable")).when(clusterService).listClusters("local");
@@ -93,7 +93,9 @@ class ApacheRocketMqProxyMetricsCollectorTest {
         assertThat(samples).singleElement().satisfies(sample -> {
             assertThat(sample.metricKey()).isEqualTo("proxy.availability");
             assertThat(sample.availability()).isEqualTo(MetricAvailability.UNAVAILABLE);
-            assertThat(sample.labels()).containsEntry("proxyAddr", "unknown");
+            // empty labels mark the whole-scope failure, keeping NativeAlertProcessor
+            // from reconciling (and falsely resolving) active proxy alerts
+            assertThat(sample.labels()).isEmpty();
         });
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertProcessorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertProcessorTest.java
@@ -550,6 +550,44 @@ class NativeAlertProcessorTest {
         verify(alerts, never()).saveAlert(any(SystemAlertVO.class));
     }
 
+    @Test
+    void doesNotResolveActiveProxyAlertsWhenProxyDiscoveryFailsTest() {
+        AlertService service = mock(AlertService.class);
+        AlertRuleVO rule = AlertRuleVO.builder().id(1L).domain(AlertDomain.CLUSTER).name("Proxy down")
+                .metric("proxy.availability").operator("UNAVAILABLE").enabled(true)
+                .instanceId("local").consecutiveSamples(1).build();
+        when(service.listRules(AlertDomain.CLUSTER)).thenReturn(List.of(rule));
+        Map<String, String> proxyLabels = Map.of("proxyAddr", "proxy-a:8080");
+        AlertStateKey proxyKey = new AlertStateKey(rule.getId(),
+                AlertFingerprint.of(rule.getId(), "local", proxyLabels));
+        ActiveAlertState active = new ActiveAlertState(proxyKey,
+                new AlertRuleState(AlertStateStatus.FIRING, 1, null, Instant.now().minusSeconds(60),
+                        Instant.now().minusSeconds(60), Instant.now().minusSeconds(60), null),
+                "local", proxyLabels);
+        AlertStateRepository states = mock(AlertStateRepository.class);
+        when(states.find(any(AlertStateKey.class))).thenReturn(Optional.empty());
+        when(states.save(any(AlertStateKey.class), any(AlertRuleState.class))).thenReturn(true);
+        when(states.findActive(any(MetricCollectionScope.class), eq(List.of(rule)))).thenReturn(List.of(active));
+        AlertRepository alerts = mock(AlertRepository.class);
+        when(alerts.saveAlert(any(SystemAlertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        NotificationOutboxService outbox = mock(NotificationOutboxService.class);
+
+        // the sample ApacheRocketMqProxyMetricsCollector emits when proxy discovery fails:
+        // one unavailable sample with empty labels, no real proxy is known
+        MetricSample discoveryFailure = new MetricSample("proxy.availability", AlertDomain.CLUSTER, "local",
+                null, Map.of(), null, MetricAvailability.UNAVAILABLE, Instant.now());
+
+        new NativeAlertProcessor(service,
+                new NativeAlertEvaluationService(new AlertRuleEvaluator(), new AlertStateMachine(), states,
+                        mock(MetricSnapshotRepository.class), alerts, outbox, suppression()),
+                new AlertStateMachine(), states, alerts, outbox, suppression())
+                .processSuccessfulCollection(new MetricCollectionScope(AlertDomain.CLUSTER, "local",
+                        java.util.Set.of("proxy.availability")), List.of(discoveryFailure));
+
+        // the firing state of the real proxy must survive the discovery outage
+        verify(states, never()).save(eq(proxyKey), any(AlertRuleState.class));
+    }
+
     private static AlertNotificationSuppressionService suppression() {
         AlertNotificationSuppressionService service = mock(AlertNotificationSuppressionService.class);
         when(service.findSuppressingClusterAlert(any(SystemAlertVO.class))).thenReturn(Optional.empty());


### PR DESCRIPTION
## Motivation

`ApacheRocketMqProxyMetricsCollector.collect` returns a single unavailable sample with the placeholder label `proxyAddr=unknown` when proxy discovery fails for the whole instance (e.g. nameserver outage):

```java
} catch (RuntimeException error) {
    return List.of(unavailable(instance, null, Map.of("proxyAddr", "unknown"), collectedAt));
}
```

#2957 added `NativeAlertProcessor.containsWholeScopeFailure` to skip reconciliation when a collection reports a whole-scope failure — detected as an unavailable sample with **empty labels** (the marker `ApacheRocketMqClusterMetricsCollector` already emits for nameserver failures). The proxy discovery-failure sample predates that convention (#2533) and was not aligned, so:

1. `containsWholeScopeFailure` returns false (labels are non-empty) and `reconcileMissingActiveStates` runs;
2. the placeholder fingerprint (`proxyAddr=unknown`) never matches the active states of the **real** proxies;
3. every firing `proxy.availability` alert for the instance is **falsely resolved** — resolution events are emitted and notifications enqueued — while in reality the collector could not discover a single proxy and knows nothing about their status.

So a nameserver hiccup turns all "proxy down" alerts into "resolved" notifications, masking real outages.

## Modification

Emit the whole-scope failure marker (empty labels) for the discovery failure, matching `ApacheRocketMqClusterMetricsCollector`\'s nameserver failure sample and the detection added in #2957:

```java
return List.of(unavailable(instance, null, Map.of(), collectedAt));
```

The per-proxy failure paths (probe unreachable / probe error / malformed address) keep their real `proxyAddr` labels, so per-target unavailability still reconciles correctly and availability rules keep firing per real proxy. After discovery recovers, any state fired for the whole-scope marker carries the empty fingerprint and is resolved by the next successful reconciliation.

## Verification

`mvn -f server/pom.xml test -Dtest='ApacheRocketMqProxyMetricsCollectorTest,NativeAlertProcessorTest'`

fail-before (fix reverted, tests kept):

```
ApacheRocketMqProxyMetricsCollectorTest.recordsWholeScopeFailureSampleWhenProxyDiscoveryFailsTest  <<< FAILURE!
Expecting empty but was: {"proxyAddr"="unknown"}
Tests run: 22, Failures: 1, Errors: 0
```

pass-after:

```
Tests run: 3, Failures: 0 ... in ApacheRocketMqProxyMetricsCollectorTest
Tests run: 19, Failures: 0 ... in NativeAlertProcessorTest
Tests run: 22, Failures: 0, Errors: 0
BUILD SUCCESS
```

Also updated the existing discovery-failure test to pin the whole-scope marker (it previously asserted the placeholder label) and added a processor-level test showing the firing state of a real proxy survives a discovery outage.

Follow-up to #2957; no associated issue — found by code inspection.