### PR TITLE
fix(ai): populate subscriptionMode and consumeType for cloud consumer groups

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
@@ -29,6 +29,7 @@ import com.aliyun.sdk.service.rocketmq20220801.models.ListTopicSubscriptionsResp
 import com.aliyun.sdk.service.rocketmq20220801.models.ListTopicsResponseBody;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
+import org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.common.util.SubscriptionFilterModes;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
@@ -157,22 +158,20 @@ final class AliyunConverters {
         vo.setName(data.getConsumerGroupId());
         vo.setInstanceId(studioInstanceId);
         vo.setConsumeType(toConsumeType(data.getMessageModel()));
+        // Aliyun's messageModel carries the consume model, not the subscription mode; cloud TCP
+        // consumer groups are push consumers. Read paths (web detail, AI rmq.group.list) require
+        // a non-null subscriptionMode, mirroring the Apache provider invariant.
+        vo.setSubscriptionMode(SubscriptionMode.Push);
         vo.setGmtCreate(parseDateTime(data.getCreateTime()));
         vo.setGmtModified(parseDateTime(data.getUpdateTime()));
         return vo;
     }
 
     static ConsumeType toConsumeType(String messageModel) {
-        if (messageModel == null) {
-            return null;
-        }
-        if ("Clustering".equalsIgnoreCase(messageModel)) {
-            return ConsumeType.CLUSTERING;
-        }
         if ("Broadcasting".equalsIgnoreCase(messageModel)) {
             return ConsumeType.BROADCASTING;
         }
-        return null;
+        return ConsumeType.CLUSTERING;
     }
 
     static List<QueueProgressVO> toQueueProgressRows(GetConsumerGroupLagResponseBody.Data data) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -48,6 +48,7 @@ import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -944,6 +945,9 @@ public class TencentInstanceProvider implements InstanceProvider {
         group.setClusterId(item.getClusterIdV4());
         group.setNamespace(item.getNamespaceV4());
         group.setConsumeType(toConsumeType(item.getConsumeMessageOrderly()));
+        // Tencent consumer groups are TCP push consumers; read paths (web detail,
+        // AI rmq.group.list) require a non-null subscriptionMode.
+        group.setSubscriptionMode(SubscriptionMode.Push);
         group.setDeliveryOrderType(item.getConsumeMessageOrderly() == null || !item.getConsumeMessageOrderly()
                 ? "Concurrently" : "Orderly");
         group.setRetryMaxTimes(toInt(item.getMaxRetryTimes()));

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -37,6 +37,7 @@ import com.aliyun.sdk.service.rocketmq20220801.models.ResetConsumeOffsetRequest;
 import com.aliyun.sdk.service.rocketmq20220801.models.ResetConsumeOffsetResponse;
 import com.aliyun.sdk.service.rocketmq20220801.models.ResetConsumeOffsetResponseBody;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
+import org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -222,6 +223,37 @@ class AliyunInstanceProviderTest {
         assertThat(groups.get(0).getName()).isEqualTo("GID_test");
         assertThat(groups.get(0).getInstanceId()).isEqualTo(STUDIO_INSTANCE_PK);
         assertThat(groups.get(0).getConsumeType()).isEqualTo(ConsumeType.CLUSTERING);
+        assertThat(groups.get(0).getSubscriptionMode()).isEqualTo(SubscriptionMode.Push);
+    }
+
+    @Test
+    void listConsumerGroupsShouldFallBackWhenMessageModelMissingTest() {
+        stubInstance();
+        stubCallThrough();
+        ListConsumerGroupsResponse response = ListConsumerGroupsResponse.create().toBuilder()
+                .statusCode(200)
+                .body(ListConsumerGroupsResponseBody.builder()
+                        .data(ListConsumerGroupsResponseBody.Data.builder()
+                                .list(java.util.Arrays.asList(ListConsumerGroupsResponseBody.List.builder()
+                                        .consumerGroupId("GID_plain")
+                                        .status("RUNNING")
+                                        .build()))
+                                .pageNumber(1L)
+                                .pageSize(100L)
+                                .totalCount(1L)
+                                .build())
+                        .build())
+                .build();
+        when(asyncClient.listConsumerGroups(any()))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        List<ConsumerGroupVO> groups = provider.listConsumerGroups(STUDIO_INSTANCE_ID, null);
+
+        assertThat(groups).singleElement().satisfies(group -> {
+            // read paths (web detail, AI rmq.group.list) require both enums to be non-null
+            assertThat(group.getConsumeType()).isEqualTo(ConsumeType.CLUSTERING);
+            assertThat(group.getSubscriptionMode()).isEqualTo(SubscriptionMode.Push);
+        });
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -44,6 +44,7 @@ import com.tencentcloudapi.trocket.v20230308.models.SubscriptionData;
 import com.tencentcloudapi.trocket.v20230308.models.TopicItem;
 import com.tencentcloudapi.trocket.v20230308.TrocketClient;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
+import org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
@@ -536,6 +537,7 @@ class TencentInstanceProviderTest {
         assertThat(groups.get(0).getRetryMaxTimes()).isEqualTo(16);
         assertThat(groups.get(0).getGmtCreate()).isNotNull();
         assertThat(groups.get(0).getConsumeType()).isEqualTo(ConsumeType.CLUSTERING);
+        assertThat(groups.get(0).getSubscriptionMode()).isEqualTo(SubscriptionMode.Push);
         assertThat(groups.get(0).getInstances()).isNotNull().isEmpty();
     }
 


### PR DESCRIPTION
## Motivation

The `rmq.group.list` AI tool is **deterministically broken for Aliyun and Tencent instances**:

- `ConsumerGroupListToolHandler.safeProjection` requires both `subscriptionMode` and `consumeType` (`requiredEnumName` throws `IllegalStateException` on the first null).
- `AliyunConverters.toConsumerGroupVO` **never sets `subscriptionMode`** and its `toConsumeType` returns null when the OpenAPI response omits `messageModel`.
- `TencentInstanceProvider.toConsumerGroup` **never sets `subscriptionMode`** either (its consume type is always CLUSTERING).

So the first group of any cloud instance trips `IllegalStateException: Consumer group subscriptionMode is unavailable: <name>` and the whole tool call fails.

This contradicts the invariant the Apache provider already established in `RocketMQMetadataProvider.toConsumerGroupVO`:

```java
// messageModel stores the subscription mode ("Push"/"Pop"); surface it so read paths
// (web detail, AI rmq.group.list) never see a null subscriptionMode.
vo.setSubscriptionMode(parseSubscriptionMode(entity.getMessageModel()));
```

The invariant was fixed for Apache only; both cloud converters were missed. Existing tests never catch it because they always pre-set the enum (e.g. `ToolGatewayServiceTest` builds groups with `SubscriptionMode.Push`).

## Modification

- Both cloud converters emit `SubscriptionMode.Push`: cloud TCP consumer groups are push consumers (Aliyun's `messageModel` carries the consume model, not the subscription mode; Tencent has no POP groups).
- `AliyunConverters.toConsumeType` falls back to `CLUSTERING` for a missing/unrecognized `messageModel`, mirroring `RocketMQMetadataProvider.parseConsumeType` ("falling back to CLUSTERING").

## Verification

`mvn -f server/pom.xml test -Dtest='AliyunInstanceProviderTest,TencentInstanceProviderTest'`

fail-before (fix reverted, tests kept):

```
AliyunInstanceProviderTest.listConsumerGroupsShouldMapGroupIdTest         <<< FAILURE! (subscriptionMode was null)
AliyunInstanceProviderTest.listConsumerGroupsShouldFallBackWhenMessageModelMissingTest <<< FAILURE!
TencentInstanceProviderTest.listConsumerGroupsShouldMapAndFilterTest      <<< FAILURE! (subscriptionMode was null)
```

pass-after:

```
TencentInstanceProviderTest: Tests run: 43, Failures: 0
AliyunInstanceProviderTest: 27 tests, only getGroupProgressShouldMapLagRowsTest failing —
    verified pre-existing on a clean rocketmq-studio checkout (unrelated to this change)
```

Follow-up to the Apache-side invariant; no associated issue — found by code inspection.