### PR TITLE
fix(cloud): guarantee non-null topic type and perm in cloud topic converters

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
@@ -29,6 +29,7 @@ import com.aliyun.sdk.service.rocketmq20220801.models.ListTopicSubscriptionsResp
 import com.aliyun.sdk.service.rocketmq20220801.models.ListTopicsResponseBody;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
+import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.common.util.SubscriptionFilterModes;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
@@ -118,6 +119,9 @@ final class AliyunConverters {
         vo.setName(data.getTopicName());
         vo.setInstanceId(studioInstanceId);
         vo.setType(toTopicType(data.getMessageType()));
+        // Aliyun's ListTopics API does not return permissions; console-created cloud
+        // topics are read-write, matching the Tencent provider's mapping.
+        vo.setPerm(TopicPerm.RW);
         vo.setRemark(data.getRemark());
         vo.setGmtCreate(parseDateTime(data.getCreateTime()));
         vo.setGmtModified(parseDateTime(data.getUpdateTime()));
@@ -127,8 +131,8 @@ final class AliyunConverters {
     }
 
     static TopicType toTopicType(String messageType) {
-        if (messageType == null) {
-            return null;
+        if (messageType == null || messageType.isBlank()) {
+            return TopicType.NORMAL;
         }
         switch (messageType.toUpperCase(Locale.ROOT)) {
             case "NORMAL":
@@ -140,7 +144,10 @@ final class AliyunConverters {
             case "TRANSACTION":
                 return TopicType.TRANSACTION;
             default:
-                return null;
+                // Unknown message types fall back to NORMAL so read paths (web
+                // detail, AI rmq.topic.list) never see a null type, matching the
+                // Apache provider's parseTopicType fallback.
+                return TopicType.NORMAL;
         }
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -1036,12 +1036,15 @@ public class TencentInstanceProvider implements InstanceProvider {
 
     private static TopicType toTopicType(String raw) {
         if (!StringUtils.hasText(raw)) {
-            return null;
+            return TopicType.NORMAL;
         }
         try {
             return TopicType.valueOf(raw.trim().toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException ignored) {
-            return null;
+        } catch (IllegalArgumentException ex) {
+            // Unknown topic types fall back to NORMAL so read paths (web detail,
+            // AI rmq.topic.list) never see a null type, matching the Apache
+            // provider's parseTopicType fallback.
+            return TopicType.NORMAL;
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -38,6 +38,7 @@ import com.aliyun.sdk.service.rocketmq20220801.models.ResetConsumeOffsetResponse
 import com.aliyun.sdk.service.rocketmq20220801.models.ResetConsumeOffsetResponseBody;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
@@ -129,16 +130,35 @@ class AliyunInstanceProviderTest {
         assertThat(all).hasSize(3);
         assertThat(all.get(0).getName()).isEqualTo("topic-normal");
         assertThat(all.get(0).getType()).isEqualTo(TopicType.NORMAL);
+        assertThat(all.get(0).getPerm()).isEqualTo(TopicPerm.RW);
         assertThat(all.get(0).getInstanceId()).isEqualTo(STUDIO_INSTANCE_PK);
         assertThat(all.get(0).getWriteQueues()).isZero();
         assertThat(all.get(0).getReadQueues()).isZero();
         assertThat(all.get(0).getRemark()).isEqualTo("remark-topic-normal");
-        assertThat(all.get(2).getType()).isNull();
+        assertThat(all.get(2).getType()).isEqualTo(TopicType.NORMAL);
 
         List<TopicVO> fifos = provider.listTopics(STUDIO_INSTANCE_ID, "FIFO", null);
 
         assertThat(fifos).hasSize(1);
         assertThat(fifos.get(0).getType()).isEqualTo(TopicType.FIFO);
+    }
+
+    @Test
+    void listTopicsShouldGuaranteeTypeAndPermForAiToolProjectionTest() {
+        stubInstance();
+        stubCallThrough();
+        when(asyncClient.listTopics(any(ListTopicsRequest.class))).thenReturn(CompletableFuture.completedFuture(
+                topicsResponse(
+                        topicRow("topic-untyped", null),
+                        topicRow("topic-unknown", "NEW_TYPE"))));
+
+        List<TopicVO> topics = provider.listTopics(STUDIO_INSTANCE_ID, null, null);
+
+        assertThat(topics).hasSize(2);
+        assertThat(topics).allSatisfy(topic -> {
+            assertThat(topic.getType()).isEqualTo(TopicType.NORMAL);
+            assertThat(topic.getPerm()).isEqualTo(TopicPerm.RW);
+        });
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -46,6 +46,7 @@ import com.tencentcloudapi.trocket.v20230308.TrocketClient;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
@@ -208,6 +209,25 @@ class TencentInstanceProviderTest {
                 .containsExactly("TopicName", "TopicType");
         assertThat(captor.getValue().getFilters()[0].getValues()).containsExactly("fifo");
         assertThat(captor.getValue().getFilters()[1].getValues()).containsExactly("FIFO");
+    }
+
+    @Test
+    void listTopicsShouldFallBackToNormalTypeWhenTopicTypeMissingTest() throws Exception {
+        when(client.DescribeTopicList(any())).thenAnswer(invocation -> {
+            DescribeTopicListResponse response = new DescribeTopicListResponse();
+            response.setData(new TopicItem[]{
+                    topicItem("orders-untyped", null, 4L),
+                    topicItem("orders-unknown", "NEW_TYPE", 4L)});
+            return response;
+        });
+        DescribeTopicResponse detail = new DescribeTopicResponse();
+        when(client.DescribeTopic(any())).thenReturn(detail);
+
+        List<TopicVO> topics = provider.listTopics(STUDIO_INSTANCE_ID, null, null);
+
+        assertThat(topics).hasSize(2);
+        assertThat(topics).allSatisfy(topic -> assertThat(topic.getType()).isEqualTo(TopicType.NORMAL));
+        assertThat(topics).allSatisfy(topic -> assertThat(topic.getPerm()).isEqualTo(TopicPerm.RW));
     }
 
     @Test


### PR DESCRIPTION
## Motivation

The `rmq.topic.list` AI tool projection (`TopicListToolHandler.safeProjection`) resolves `topic.type` and `topic.perm` through `requiredEnumName`, which throws `IllegalStateException` on null values (contract introduced with the AI resource tools in #642). Both cloud converters can still produce nulls, so listing topics through the AI tool is broken on cloud instances:

- `AliyunConverters.toTopicVO` never sets `perm` at all, and `AliyunInstanceProvider.toTopics` adds no enrichment afterwards — **every** Aliyun topic carries `perm=null`, so the projection fails on the first listed topic, deterministically.
- `AliyunConverters.toTopicType` returns `null` for a null or unmapped `messageType`, and `TencentInstanceProvider.toTopicType` returns `null` for a blank or unmapped topic type, so the same projection fails whenever the cloud API omits the field or returns a value the switch does not map (e.g. a newly introduced cloud type).

## Modification

- `AliyunConverters.toTopicVO` now defaults `perm` to `TopicPerm.RW`: Aliyun's `ListTopics` API does not return permissions, and console-managed cloud topics are read-write — the same convention `TencentInstanceProvider.toTopic` already applies.
- `AliyunConverters.toTopicType` and `TencentInstanceProvider.toTopicType` now fall back to `TopicType.NORMAL` for blank/unknown values, mirroring the Apache provider's `parseTopicType` fallback so read paths (web detail, AI `rmq.topic.list`) never see a null type.

## Verification

Fail-before (source fix stashed, tests kept) — 4 failures, all `expected: NORMAL but was: null` / missing perm:

```
[ERROR] Tests run: 71, Failures: 4, Errors: 0
AliyunInstanceProviderTest.listTopicsShouldMapMessageTypeAndFilterTest  (unmapped type now expected NORMAL; perm expected RW)
AliyunInstanceProviderTest.listTopicsShouldGuaranteeTypeAndPermForAiToolProjectionTest
TencentInstanceProviderTest.listTopicsShouldFallBackToNormalTypeWhenTopicTypeMissingTest
```

Pass-after (fix applied):

```
AliyunInstanceProviderTest        Tests run: 27, Failures: 1  (only getGroupProgressShouldMapLagRowsTest — pre-existing on rocketmq-studio, fixed by #4135)
TencentInstanceProviderTest       Tests run: 44, Failures: 0
```

The one remaining `getGroupProgressShouldMapLagRowsTest` failure is the pre-existing base failure on `rocketmq-studio` (stale test vs the intentional #2907 production change), already fixed by open PR #4135; it is unrelated to this change.

New/updated tests:

- `AliyunInstanceProviderTest.listTopicsShouldGuaranteeTypeAndPermForAiToolProjectionTest` — null and unmapped `messageType` both map to `NORMAL` with `perm=RW`.
- `AliyunInstanceProviderTest.listTopicsShouldMapMessageTypeAndFilterTest` — the unmapped-type row now asserts `NORMAL` (was documenting the old `null`) and mapped rows assert `perm=RW`.
- `TencentInstanceProviderTest.listTopicsShouldFallBackToNormalTypeWhenTopicTypeMissingTest` — blank and unmapped topic types map to `NORMAL`, `perm` stays `RW`.