### PR TITLE
[studio] fix(ci): replace unapproved Docker actions with plain docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,14 +84,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build frontend Docker image (cached)
-        uses: docker/build-push-action@v6
-        with:
-          context: ./web
-          push: false
-          tags: rocketmq-studio-web-ci:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Build frontend Docker image
+        run: docker build -t rocketmq-studio-web-ci:latest ./web


### PR DESCRIPTION
## Summary

- The `frontend-docker-build` job in `.github/workflows/ci.yml` used `docker/setup-buildx-action@v3` and `docker/build-push-action@v6`, which are not on the Apache organization's GitHub Actions allowlist.
- This blocked the **entire CI workflow** at startup - no jobs (backend build, backend tests, frontend build, or docker build) ever executed on any push or PR.
- Replace the third-party Docker actions with a plain `docker build` command. The Dockerfile is a simple two-stage build that does not require buildx features.
- This sacrifices the GHA layer cache but unblocks all four CI jobs, restoring build/test visibility for every PR.

Closes #4136

## Test plan

- [ ] Verify the CI workflow runs successfully on this PR (all four jobs should execute)
- [ ] Verify the frontend Docker image still builds with `docker build -t rocketmq-studio-web-ci:latest ./web`