### PR TITLE
[studio] fix(ci): run frontend unit tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run frontend tests
+        run: npm run test
+
       - name: Build frontend
         run: npm run build
 


### PR DESCRIPTION
## Summary

- The `frontend-build` job in `.github/workflows/ci.yml` ran `npm ci` and `npm run build` but **never ran `npm run test`** (vitest).
- This means the repo's roughly 936 frontend unit tests do not gate any PR or push to `rocketmq-studio`.
- Add a `npm run test` step between install and build - a one-line addition that enforces the existing test suite on every change.

Depends on #4138 (CI startup fix) being merged first, otherwise the workflow still fails at startup and no jobs run at all.

Closes #4139

## Test plan

- [ ] After #4138 is merged, verify the CI workflow runs `npm run test` successfully on this PR
- [ ] Verify that a breaking change to a frontend test now fails the CI check