### PR TITLE
[ISSUE #4141] fix(mock): scope Topic mutations by instance

### DIFF
--- a/web/src/services/topicService.test.ts
+++ b/web/src/services/topicService.test.ts
@@ -17,12 +17,15 @@
 
 import {
   createTopic,
+  deleteTopic,
   getTopicConsumerPage,
   getTopicConsumers,
   getTopicRoutes,
   listAllTopics,
   listTopics,
+  updateTopic,
 } from './topicService';
+import { topics as mockTopics } from '../mock/topics';
 
 vi.mock('./dataMode', () => ({ isMockMode: () => true }));
 vi.mock('../config', () => ({
@@ -30,6 +33,12 @@ vi.mock('../config', () => ({
 }));
 
 describe('topic service mock data', () => {
+  afterEach(() => {
+    for (let idx = mockTopics.length - 1; idx >= 0; idx -= 1) {
+      if (mockTopics[idx].name.startsWith('instance-scope-test-')) mockTopics.splice(idx, 1);
+    }
+  });
+
   it('returns copied topic rows', async () => {
     const first = await listTopics({ search: 'order-create' });
     expect(first[0].name).toBe('order-create');
@@ -118,5 +127,76 @@ describe('topic service mock data', () => {
 
     const after = await listTopics({ clusterId: existing.clusterId });
     expect(after).toEqual(before);
+  });
+
+  it('allows the same topic name and cluster in different mock instances', async () => {
+    const topic = {
+      name: 'instance-scope-test-create',
+      clusterId: 'rmq-cn-v5-prod-01',
+      namespace: 'trade',
+      type: 'NORMAL',
+      writeQueues: 4,
+      readQueues: 4,
+      perm: 'RW',
+    };
+
+    const first = await createTopic({ ...topic, instanceId: 'instance-proxy-1' });
+    const second = await createTopic({ ...topic, instanceId: 'instance-proxy-2' });
+
+    expect(first.instanceId).toBe('instance-proxy-1');
+    expect(second.instanceId).toBe('instance-proxy-2');
+    await expect(createTopic({ ...topic, instanceId: 'instance-proxy-1' })).rejects.toThrow(
+      `Topic already exists: ${topic.name}`,
+    );
+  });
+
+  it('updates only the matching mock topic instance when instance ID is supplied', async () => {
+    const topic = {
+      name: 'instance-scope-test-update',
+      clusterId: 'rmq-cn-v5-prod-01',
+      namespace: 'trade',
+      type: 'NORMAL',
+      writeQueues: 4,
+      readQueues: 4,
+      perm: 'RW',
+      remark: 'original',
+    };
+    await createTopic({ ...topic, instanceId: 'instance-proxy-1' });
+    await createTopic({ ...topic, instanceId: 'instance-proxy-2' });
+
+    const updated = await updateTopic({
+      name: topic.name,
+      instanceId: 'instance-proxy-2',
+      remark: 'updated second instance',
+    });
+
+    expect(updated.remark).toBe('updated second instance');
+    const firstInstance = await listTopics({ instanceId: 'instance-proxy-1', search: topic.name });
+    const secondInstance = await listTopics({ instanceId: 'instance-proxy-2', search: topic.name });
+    expect(firstInstance).toHaveLength(1);
+    expect(secondInstance).toHaveLength(1);
+    expect(firstInstance[0].remark).toBe('original');
+    expect(secondInstance[0].remark).toBe('updated second instance');
+  });
+
+  it('deletes only the matching mock topic instance when instance ID is supplied', async () => {
+    const topic = {
+      name: 'instance-scope-test-delete',
+      clusterId: 'rmq-cn-v5-prod-01',
+      namespace: 'trade',
+      type: 'NORMAL',
+      writeQueues: 4,
+      readQueues: 4,
+      perm: 'RW',
+    };
+    await createTopic({ ...topic, instanceId: 'instance-proxy-1' });
+    await createTopic({ ...topic, instanceId: 'instance-proxy-2' });
+
+    await deleteTopic(topic.name, 'instance-proxy-2');
+
+    const firstInstance = await listTopics({ instanceId: 'instance-proxy-1', search: topic.name });
+    const secondInstance = await listTopics({ instanceId: 'instance-proxy-2', search: topic.name });
+    expect(firstInstance).toHaveLength(1);
+    expect(secondInstance).toHaveLength(0);
   });
 });

--- a/web/src/services/topicService.ts
+++ b/web/src/services/topicService.ts
@@ -42,6 +42,8 @@ const cloneRoutes = (routes: BrokerRoute[]): BrokerRoute[] =>
   }));
 const cloneConsumers = (consumers: ConsumerGroupInfo[]): ConsumerGroupInfo[] =>
   consumers.map((consumer) => ({ ...consumer }));
+const matchesTopicInstance = (topic: Topic, instanceId?: string): boolean =>
+  !instanceId || topic.instanceId === instanceId;
 
 function filterMockTopics(params?: TopicQuery): Topic[] {
   let result = [...mockTopics];
@@ -107,7 +109,10 @@ export const listAllTopics = async (params: TopicQuery = {}): Promise<Topic[]> =
 export async function createTopic(data: Partial<Topic>): Promise<Topic> {
   if (isMockMode()) {
     const duplicate = mockTopics.some(
-      (topic) => topic.name === data.name && topic.clusterId === data.clusterId,
+      (topic) =>
+        topic.name === data.name &&
+        topic.clusterId === data.clusterId &&
+        matchesTopicInstance(topic, data.instanceId),
     );
     if (duplicate) throw new Error(`Topic already exists: ${data.name}`);
 
@@ -158,7 +163,9 @@ export async function exportTopics(params: TopicExportQuery = {}): Promise<strin
 
 export async function updateTopic(data: Partial<Topic>): Promise<Topic> {
   if (isMockMode()) {
-    const idx = mockTopics.findIndex((t) => t.name === data.name);
+    const idx = mockTopics.findIndex(
+      (t) => t.name === data.name && matchesTopicInstance(t, data.instanceId),
+    );
     if (idx < 0) throw new Error(`Topic not found: ${data.name}`);
     Object.assign(mockTopics[idx], data, { gmtModified: new Date().toISOString() });
     return cloneTopic(mockTopics[idx] as unknown as Topic);
@@ -168,7 +175,9 @@ export async function updateTopic(data: Partial<Topic>): Promise<Topic> {
 
 export async function deleteTopic(name: string, instanceId?: string): Promise<void> {
   if (isMockMode()) {
-    const idx = mockTopics.findIndex((t) => t.name === name);
+    const idx = mockTopics.findIndex(
+      (t) => t.name === name && matchesTopicInstance(t, instanceId),
+    );
     if (idx >= 0) mockTopics.splice(idx, 1);
     return;
   }


### PR DESCRIPTION
## Summary

- align mock Topic identity with the persisted `(cluster_id, instance_id, name)` model
- allow the same Topic name and cluster in different mock instances
- scope mock update and delete operations to the supplied `instanceId`
- add regression coverage for cross-instance create, update, and delete behavior

## Scope

This changes only the frontend mock service and its focused tests. The real backend API and database schema are unchanged. Calls that omit `instanceId` keep the previous fallback behavior.

## Verification

- `npm test -- --run src/services/topicService.test.ts src/services/topicService.batchDelete.test.ts src/pages/instance/__tests__/TopicPage.test.tsx` — 34 tests passed
- `npm run lint` — 0 errors, 10 existing warnings
- `npm run build`
- `git diff --check`

Closes #4141