### PR TITLE
[ISSUE #4143] feat(ai): support custom message trace topics

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandler.java
@@ -47,7 +47,8 @@ public class MessageTraceToolHandler implements ToolHandler {
         String instanceId = (String) input.get("cluster");
         String msgId = (String) input.get("msgId");
         String topic = (String) input.get("topic");
-        TraceRecordVO trace = messageService.getMessageTrace(instanceId, msgId, topic);
+        String traceTopic = (String) input.get("traceTopic");
+        TraceRecordVO trace = messageService.getMessageTrace(instanceId, msgId, topic, traceTopic);
         return project(msgId, trace);
     }
 

--- a/server/src/main/resources/tool-catalog/rmq-tools.yaml
+++ b/server/src/main/resources/tool-catalog/rmq-tools.yaml
@@ -432,6 +432,8 @@ tools:
           minLength: 1
         topic:
           type: string
+        traceTopic:
+          type: string
     outputSchema:
       type: object
       required:

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandlerTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -61,7 +62,8 @@ class MessageTraceToolHandlerTest {
                         .retryCount(0)
                         .build()))
                 .build();
-        when(messageService.getMessageTrace(eq("instance-a"), eq("msg-1"), eq("TopicA")))
+        when(messageService.getMessageTrace(
+                        eq("instance-a"), eq("msg-1"), eq("TopicA"), isNull()))
                 .thenReturn(trace);
 
         Object result = handler.execute(Map.of(
@@ -81,6 +83,25 @@ class MessageTraceToolHandlerTest {
         assertThat(status.get("group")).isEqualTo("group-a");
         assertThat(status.get("deliveryStatus")).isEqualTo("success");
 
-        verify(messageService).getMessageTrace("instance-a", "msg-1", "TopicA");
+        verify(messageService).getMessageTrace("instance-a", "msg-1", "TopicA", null);
+    }
+
+    @Test
+    void executeShouldForwardCustomTraceTopic() {
+        TraceRecordVO trace = TraceRecordVO.builder()
+                .nodes(List.of())
+                .consumerStatus(List.of())
+                .build();
+        when(messageService.getMessageTrace(
+                        eq("instance-a"), eq("msg-1"), eq("TopicA"), eq("CUSTOM_TRACE")))
+                .thenReturn(trace);
+
+        handler.execute(Map.of(
+                "cluster", "instance-a",
+                "msgId", "msg-1",
+                "topic", "TopicA",
+                "traceTopic", "CUSTOM_TRACE"));
+
+        verify(messageService).getMessageTrace("instance-a", "msg-1", "TopicA", "CUSTOM_TRACE");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolCatalogTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolCatalogTest.java
@@ -53,6 +53,23 @@ class ToolCatalogTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void messageTraceAdvertisesOptionalCustomTraceTopic() {
+        ToolDefinition trace = ToolCatalog.load(canonicalCatalog(), canonicalSchema())
+                .find("rmq.message.trace")
+                .orElseThrow();
+        Map<String, Object> properties =
+                (Map<String, Object>) trace.inputSchema().get("properties");
+        List<String> required =
+                (List<String>) trace.inputSchema().get("required");
+
+        assertThat(properties).containsKey("traceTopic");
+        assertThat((Map<String, Object>) properties.get("traceTopic"))
+                .containsEntry("type", "string");
+        assertThat(required).doesNotContain("traceTopic");
+    }
+
+    @Test
     void rejectsCatalogThatDoesNotMatchItsJsonSchema() {
         Resource invalid = utf8Resource("""
                 version: 1.0.0


### PR DESCRIPTION
## Summary

- expose optional `traceTopic` in the canonical `rmq.message.trace` input schema
- forward the supplied value through `MessageTraceToolHandler` to the existing four-argument `MessageService` path
- preserve the current default behavior when the field is omitted or blank
- add handler and catalog contract coverage

## Scope

This change only extends message-id trace lookup. It does not add trace-by-key behavior, change the output schema, or introduce provider-specific logic. `MessageService` remains responsible for normalization and fallback to the legacy provider path.

## TDD evidence

Before the implementation, the new tests failed because the catalog did not contain `traceTopic` and the handler invoked the three-argument service method. After the minimal implementation, both contracts pass.

## Verification

- `mvn -B -ntp -f server/pom.xml -Dtest=MessageTraceToolHandlerTest,ToolCatalogTest,MessageServiceTest,ToolGatewayServiceTest test` — 58 tests passed
- `mvn -B -ntp -f server/pom.xml -DskipTests package`
- Checkstyle — 0 violations
- `git diff --check`

Closes #4143