### PR TITLE
feat: inspect static topic queue mapping history

### DIFF
--- a/docs/zh/static-topic-mapping.md
+++ b/docs/zh/static-topic-mapping.md
@@ -1,0 +1,72 @@
+# 静态 Topic 队列映射诊断
+
+## 场景与入口
+
+静态 Topic 将逻辑队列映射到 Broker 的物理队列，迁移后同一逻辑队列可能有多个历史分段。
+普通路由表只能展示队列数量及权限，不能解释逻辑偏移属于哪个历史物理队列。
+Apache 实例 Topic 列表的 `Static mapping` 打开只读诊断窗口，点击
+`Read mappings` 后读取路由摘要及各路由 Broker 的完整本地映射。
+
+接口为 `GET /api/static-topic-mappings?instanceId=...&topic=...`。
+没有创建静态 Topic、迁移队列、修复映射、重置位点或修改配置的写操作。
+
+## 数据来源与范围
+
+服务先读取所选实例的 Topic 路由及 Broker 登记，再取路由 Broker 名称与
+`topicQueueMappingByBroker` 名称的并集，逐个读取已登记主节点的 Topic 配置。
+地址必须来自当前实例登记，不直接信任客户端地址或路由里的地址。
+主节点缺失时明确显示不可用，不自动改读副本。
+
+SDK 的 `examineTopicConfig` 返回声明类型为 `TopicConfig`，实际协议解析为
+`TopicConfigAndQueueMapping`，请求带 `lo=true`，包含完整 `mappingDetail`。
+只有明确的扩展返回类型中 `mappingDetail=null` 才显示 `NO_MAPPING`；
+响应缺失、普通基类响应、Topic 或 Broker 身份不符均不能视为没有映射。
+
+历史分段里出现但不在当前路由或映射广播中的 Broker 不会额外查询。
+因此结果不是全历史 Broker 扫描，也不能证明全集群队列归属完整。
+
+## 阅读结果
+
+| 字段 | 含义 |
+| --- | --- |
+| Route epoch / scope / total logical queues | NameServer 广播的映射摘要 |
+| Advertised current queue IDs | 该广播中的逻辑队列 ID 到物理队列 ID 映射 |
+| Local epoch / scope / total logical queues | 所选主节点本地映射的版本、范围和总逻辑队列数 |
+| Local dirty flag | Broker 原始 dirty 标记，不自行推断其根因 |
+| Logical queue | 本地 hostedQueues 中的全局逻辑队列 ID |
+| Last mapped broker | 该本地分段列表最后一项的 Broker，不等同于已确认的全局当前所有者 |
+| Generation | 分段代数，按 Broker 返回的历史顺序展示 |
+| Logical start | 分段逻辑起始位点；-1 表示尚未决定 |
+| Physical start / end | 物理队列位点，末尾不包含在区间内；-1 的末尾表示开放边界 |
+
+这里的物理位点仍是队列位点，不是 CommitLog 字节地址。
+已确定分段的换算关系为：逻辑位点 = 逻辑起点 + 物理位点 − 物理起点。
+界面不推算开放分段长度，也不把映射范围当作当前保留消息范围。
+SDK 中预留的起止时间字段不作为可靠时间线展示。
+
+所有 64 位版本号与位点以十进制字符串传输及显示，避免超过 JavaScript 安全整数范围后失真。
+普通整数 ID 保持整数；不按位点数值重新排序历史分段。
+
+## 不一致与失败
+
+各 Broker 返回 `MAPPING`、`NO_MAPPING` 或 `UNAVAILABLE`。
+一个节点读取失败时保留其它节点样本，同时标记部分数据不可用。
+路由摘要与本地版本、范围或总队列数不同会提示差异；两者是分时采样，
+差异可能发生在迁移或广播更新期间，不能直接断言某份元数据损坏。
+
+整个路由或登记不可读时显示错误，不能伪造空的健康结果。
+重新读取先清理旧样本，切换实例或关闭窗口中止浏览器等待并忽略迟到结果。
+没有自动轮询或自动修复；应结合迁移记录、Broker 日志和当前路由再次核对。
+
+## 验证与回滚
+
+本地测试覆盖历史顺序、超大位点、开放和未定边界、路由与本地版本差异、
+未登记主节点、部分通信失败、空映射与不可用映射区别、中断、HTTP 契约及界面刷新。
+浏览器验证使用本地只读响应拦截，未修改真实集群。
+真实静态 Topic 迁移、保留期变化、并发选主、性能、压力、容量及混沌测试未执行。
+
+无新增依赖或数据库迁移。撤销代码提交即可移除入口和接口，不需要恢复 Broker 数据。
+核验日期：2026-09-08。协议依据：
+[MQClientAPIImpl.getTopicConfig](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java#L3274)、
+[TopicQueueMappingDetail](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/statictopic/TopicQueueMappingDetail.java)
+和 [LogicQueueMappingItem](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/statictopic/LogicQueueMappingItem.java)。

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/StaticTopicMappingController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/StaticTopicMappingController.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.topic;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.Result;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/static-topic-mappings")
+public class StaticTopicMappingController {
+    private final StaticTopicMappingService service;
+
+    @GetMapping
+    public Result<StaticTopicMappingService.Snapshot> inspect(@RequestParam String instanceId, @RequestParam String topic) {
+        return Result.ok(service.inspect(instanceId, topic));
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/StaticTopicMappingService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/StaticTopicMappingService.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.topic;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.remoting.protocol.statictopic.TopicConfigAndQueueMapping;
+import org.apache.rocketmq.remoting.protocol.statictopic.TopicQueueMappingDetail;
+import org.apache.rocketmq.remoting.protocol.statictopic.TopicQueueMappingInfo;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class StaticTopicMappingService {
+    private final RuntimeAdminClientResolver resolver;
+
+    public record CurrentQueue(int logicalQueueId, int physicalQueueId) { }
+    public record RouteMapping(String epoch, String scope, int totalQueues, List<CurrentQueue> currentQueues) { }
+    public record Segment(int generation, String brokerName, int physicalQueueId, String logicalStart,
+            String physicalStart, String physicalEndExclusive) { }
+    public record QueueHistory(int logicalQueueId, String lastMappedBroker, List<Segment> segments) { }
+    public record LocalMapping(String epoch, String scope, int totalQueues, boolean dirty, List<QueueHistory> queues) { }
+    public record Node(String brokerName, String address, String status, String error,
+            RouteMapping advertised, LocalMapping local) { }
+    public record Snapshot(String topic, Instant startedAt, Instant finishedAt, boolean partial, List<Node> nodes) { }
+
+    public Snapshot inspect(String instanceId, String topic) {
+        if (!StringUtils.hasText(topic)) {
+            throw new BusinessException(400, "Topic is required");
+        }
+        return resolver.execute(instanceId, admin -> {
+            try {
+                return read(admin, topic);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new BusinessException(502, "Static topic mapping inspection was interrupted");
+            }
+        });
+    }
+
+    private Snapshot read(MQAdminExt admin, String topic) throws Exception {
+        Instant startedAt = Instant.now();
+        var route = admin.examineTopicRouteInfo(topic);
+        var cluster = admin.examineBrokerClusterInfo();
+        if (route == null || route.getBrokerDatas() == null || cluster == null || cluster.getBrokerAddrTable() == null) {
+            throw new BusinessException(502, "Topic route or broker registry is unavailable");
+        }
+        Set<String> brokerNames = new TreeSet<>();
+        for (var broker : route.getBrokerDatas()) {
+            if (broker == null || !StringUtils.hasText(broker.getBrokerName())) {
+                throw new BusinessException(502, "Topic route contains an invalid broker identity");
+            }
+            brokerNames.add(broker.getBrokerName());
+        }
+        var advertisements = route.getTopicQueueMappingByBroker();
+        if (advertisements != null) {
+            for (String name : advertisements.keySet()) {
+                if (!StringUtils.hasText(name)) {
+                    throw new BusinessException(502, "Topic route contains an invalid mapping identity");
+                }
+                brokerNames.add(name);
+            }
+        }
+        if (brokerNames.isEmpty()) {
+            throw new BusinessException(404, "No route brokers are available for this topic");
+        }
+        List<Node> nodes = new ArrayList<>();
+        for (String name : brokerNames) {
+            String address = null;
+            RouteMapping advertised = null;
+            try {
+                advertised = advertisement(topic, name, advertisements == null ? null : advertisements.get(name));
+                var broker = cluster.getBrokerAddrTable().get(name);
+                if (broker == null || broker.getBrokerAddrs() == null || !StringUtils.hasText(broker.getBrokerAddrs().get(0L))) {
+                    throw new BusinessException(404, "No registered master address for this route broker");
+                }
+                address = broker.getBrokerAddrs().get(0L);
+                var config = admin.examineTopicConfig(address, topic);
+                if (!(config instanceof TopicConfigAndQueueMapping full) || !topic.equals(config.getTopicName())) {
+                    throw new BusinessException(502, "Broker response does not contain the requested mapping-capable topic config");
+                }
+                var detail = full.getMappingDetail();
+                LocalMapping local = detail == null ? null : mapping(topic, name, detail);
+                nodes.add(new Node(name, address, local == null ? "NO_MAPPING" : "MAPPING", null, advertised, local));
+            } catch (InterruptedException exception) {
+                throw exception;
+            } catch (Exception exception) {
+                // Preserve other brokers' samples, without exposing arbitrary remote exception text.
+                String error = exception instanceof BusinessException ? exception.getMessage() : exception.getClass().getSimpleName();
+                nodes.add(new Node(name, address, "UNAVAILABLE", error, advertised, null));
+            }
+        }
+        return new Snapshot(topic, startedAt, Instant.now(), nodes.stream().anyMatch(node -> "UNAVAILABLE".equals(node.status())),
+                List.copyOf(nodes));
+    }
+
+    private RouteMapping advertisement(String topic, String broker, TopicQueueMappingInfo info) {
+        if (info == null) {
+            return null;
+        }
+        validateIdentity(topic, broker, info);
+        if (info.getCurrIdMap() == null) {
+            throw new BusinessException(502, "Advertised logical queue map is unavailable");
+        }
+        List<CurrentQueue> queues = info.getCurrIdMap().entrySet().stream().sorted(java.util.Map.Entry.comparingByKey())
+                .map(entry -> new CurrentQueue(entry.getKey(), entry.getValue())).toList();
+        return new RouteMapping(Long.toString(info.getEpoch()), info.getScope(), info.getTotalQueues(), queues);
+    }
+
+    private LocalMapping mapping(String topic, String broker, TopicQueueMappingDetail detail) {
+        validateIdentity(topic, broker, detail);
+        if (detail.getHostedQueues() == null) {
+            throw new BusinessException(502, "Hosted queue history is unavailable");
+        }
+        List<QueueHistory> queues = new ArrayList<>();
+        for (var entry : new java.util.TreeMap<>(detail.getHostedQueues()).entrySet()) {
+            List<Segment> segments = new ArrayList<>();
+            if (entry.getKey() < 0 || entry.getValue().isEmpty()) {
+                throw new BusinessException(502, "Broker returned an invalid logical queue history");
+            }
+            for (var item : entry.getValue()) {
+                if (item == null || !StringUtils.hasText(item.getBname()) || item.getQueueId() < 0) {
+                    throw new BusinessException(502, "Broker returned an invalid mapping segment");
+                }
+                segments.add(new Segment(item.getGen(), item.getBname(), item.getQueueId(), Long.toString(item.getLogicOffset()),
+                        Long.toString(item.getStartOffset()), Long.toString(item.getEndOffset())));
+            }
+            // Order is the broker's mapping history. The final item determines its local view of ownership.
+            queues.add(new QueueHistory(entry.getKey(), segments.get(segments.size() - 1).brokerName(), List.copyOf(segments)));
+        }
+        return new LocalMapping(Long.toString(detail.getEpoch()), detail.getScope(), detail.getTotalQueues(), detail.isDirty(), queues);
+    }
+
+    private void validateIdentity(String topic, String broker, TopicQueueMappingInfo info) {
+        if (!topic.equals(info.getTopic()) || !broker.equals(info.getBname())) {
+            throw new BusinessException(502, "Mapping identity does not match the requested topic and broker");
+        }
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/StaticTopicMappingServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/StaticTopicMappingServiceTest.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.rocketmq.common.TopicConfig;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
+import org.apache.rocketmq.remoting.protocol.statictopic.TopicConfigAndQueueMapping;
+import org.apache.rocketmq.remoting.protocol.statictopic.TopicQueueMappingDetail;
+import org.apache.rocketmq.remoting.protocol.statictopic.LogicQueueMappingItem;
+import org.apache.rocketmq.studio.instance.topic.StaticTopicMappingController;
+import org.apache.rocketmq.studio.instance.topic.StaticTopicMappingService;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class StaticTopicMappingServiceTest {
+    private final DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+    private final InstanceRepository repository = mock(InstanceRepository.class);
+    private final ClusterInfo cluster = new ClusterInfo();
+    private final TopicRouteData route = new TopicRouteData();
+    private final TopicQueueMappingDetail detail = new TopicQueueMappingDetail("orders", 2, "broker-a", 9007199254740993L);
+    private StaticTopicMappingService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        var factory = new MqAdminExtFactory() {
+            @Override
+            protected DefaultMQAdminExt newAdmin(RPCHook hook) { return admin; }
+        };
+        service = new StaticTopicMappingService(new RuntimeAdminClientResolver(repository, factory,
+                new MqAdminProperties(), mock(MqClientPool.class)));
+        when(repository.findByIdentifier("instance-a")).thenReturn(Optional.of(
+                InstanceVO.builder().endpoint("ns-a:9876").vendor(InstanceVendor.APACHE).build()));
+        cluster.setBrokerAddrTable(new HashMap<>());
+        cluster.getBrokerAddrTable().put("broker-a", new BrokerData("cluster-a", "broker-a",
+                new HashMap<>(Map.of(0L, "master:10911", 1L, "replica:10911"))));
+        when(admin.examineBrokerClusterInfo()).thenReturn(cluster);
+        route.setBrokerDatas(new java.util.ArrayList<>(List.of(cluster.getBrokerAddrTable().get("broker-a"),
+                new BrokerData("cluster-a", "broker-b", new HashMap<>(Map.of(0L, "route-untrusted:10911"))))));
+        cluster.getBrokerAddrTable().put("broker-b", new BrokerData("cluster-a", "broker-b",
+                new HashMap<>(Map.of(0L, "registered-b:10911"))));
+        detail.getHostedQueues().put(0, List.of(
+                new LogicQueueMappingItem(0, 1, "old-broker", 0, 0, 9007199254740993L, -1, -1),
+                new LogicQueueMappingItem(1, 3, "broker-a", 9007199254740993L, 0, -1, -1, -1)));
+        route.setTopicQueueMappingByBroker(new HashMap<>(Map.of("broker-a",
+                TopicQueueMappingDetail.cloneAsMappingInfo(detail))));
+        when(admin.examineTopicRouteInfo("orders")).thenReturn(route);
+        when(admin.examineTopicConfig("master:10911", "orders"))
+                .thenReturn(new TopicConfigAndQueueMapping(new TopicConfig("orders"), detail));
+        when(admin.examineTopicConfig("registered-b:10911", "orders"))
+                .thenReturn(new TopicConfigAndQueueMapping(new TopicConfig("orders"), null));
+    }
+
+    private StaticTopicMappingService.Snapshot inspect() {
+        return service.inspect("instance-a", "orders");
+    }
+
+    @Test
+    void preservesExactOffsetsAndHistoryOrderUsingRegisteredAddresses() throws Exception {
+        var snapshot = inspect();
+        assertThat(snapshot.partial()).isFalse();
+        assertThat(snapshot.startedAt()).isBeforeOrEqualTo(snapshot.finishedAt());
+        assertThat(snapshot.nodes()).extracting(StaticTopicMappingService.Node::brokerName).containsExactly("broker-a", "broker-b");
+        var node = snapshot.nodes().get(0);
+        assertThat(node.local().epoch()).isEqualTo("9007199254740993");
+        assertThat(node.local().queues().get(0).lastMappedBroker()).isEqualTo("broker-a");
+        assertThat(node.local().queues().get(0).segments()).extracting(StaticTopicMappingService.Segment::brokerName)
+                .containsExactly("old-broker", "broker-a");
+        assertThat(node.local().queues().get(0).segments().get(0).physicalEndExclusive()).isEqualTo("9007199254740993");
+        assertThat(node.local().queues().get(0).segments().get(1).physicalEndExclusive()).isEqualTo("-1");
+        assertThat(node.advertised().currentQueues()).containsExactly(new StaticTopicMappingService.CurrentQueue(0, 3));
+        assertThat(snapshot.nodes().get(1).status()).isEqualTo("NO_MAPPING");
+        verify(admin).examineTopicConfig("registered-b:10911", "orders");
+        verify(admin, never()).examineTopicConfig("route-untrusted:10911", "orders");
+        verify(admin, never()).examineTopicConfig("old-broker", "orders");
+    }
+
+    @Test
+    void partialFailureRetainsOtherBrokerSamplesAndAdvertisements() throws Exception {
+        doThrow(new org.apache.rocketmq.remoting.exception.RemotingTimeoutException("master:10911", 5000))
+                .when(admin).examineTopicConfig("master:10911", "orders");
+        var result = inspect();
+        assertThat(result.partial()).isTrue();
+        assertThat(result.nodes().get(0).status()).isEqualTo("UNAVAILABLE");
+        assertThat(result.nodes().get(0).advertised()).isNotNull();
+        assertThat(result.nodes().get(0).error()).isEqualTo("RemotingTimeoutException");
+        assertThat(result.nodes().get(1).status()).isEqualTo("NO_MAPPING");
+    }
+
+    @Test
+    void mappingAdvertisementAddsMissingRouteBrokerWithoutGuessingItsAddress() {
+        var missing = new org.apache.rocketmq.remoting.protocol.statictopic.TopicQueueMappingInfo("orders", 2, "broker-c", 1);
+        route.getTopicQueueMappingByBroker().put("broker-c", missing);
+        var result = inspect();
+        assertThat(result.partial()).isTrue();
+        assertThat(result.nodes().get(2).brokerName()).isEqualTo("broker-c");
+        assertThat(result.nodes().get(2).address()).isNull();
+        assertThat(result.nodes().get(2).error()).contains("No registered master");
+    }
+
+    @Test
+    void neverFallsBackToReplicaWhenMasterIsMissing() throws Exception {
+        cluster.getBrokerAddrTable().get("broker-a").getBrokerAddrs().remove(0L);
+        assertThat(inspect().nodes().get(0).status()).isEqualTo("UNAVAILABLE");
+        verify(admin, never()).examineTopicConfig("replica:10911", "orders");
+    }
+
+    @Test
+    void plainOrMissingConfigIsNotEvidenceOfAnOrdinaryTopic() throws Exception {
+        when(admin.examineTopicConfig("master:10911", "orders")).thenReturn(new TopicConfig("orders"));
+        assertThat(inspect().nodes().get(0).status()).isEqualTo("UNAVAILABLE");
+        when(admin.examineTopicConfig("master:10911", "orders")).thenReturn(null);
+        assertThat(inspect().nodes().get(0).status()).isEqualTo("UNAVAILABLE");
+        when(admin.examineTopicConfig("master:10911", "orders"))
+                .thenReturn(new TopicConfigAndQueueMapping(new TopicConfig("other"), null));
+        assertThat(inspect().nodes().get(0).status()).isEqualTo("UNAVAILABLE");
+    }
+
+    @Test
+    void routeAndLocalEpochsRemainIndependentIncludingDirtyFlag() {
+        detail.setEpoch(9007199254740994L);
+        detail.setDirty(true);
+        detail.setScope("scope-new");
+        var node = inspect().nodes().get(0);
+        assertThat(node.advertised().epoch()).isEqualTo("9007199254740993");
+        assertThat(node.local().epoch()).isEqualTo("9007199254740994");
+        assertThat(node.local().dirty()).isTrue();
+        assertThat(node.local().scope()).isEqualTo("scope-new");
+    }
+
+    @Test
+    void undecidedOffsetsAndEmptyHostedMapArePreserved() {
+        detail.getHostedQueues().put(1, List.of(new LogicQueueMappingItem(2, 4, "broker-a", -1, 0, -1, -1, -1)));
+        assertThat(inspect().nodes().get(0).local().queues().get(1).segments().get(0).logicalStart()).isEqualTo("-1");
+        detail.getHostedQueues().clear();
+        assertThat(inspect().nodes().get(0).local().queues()).isEmpty();
+    }
+
+    @Test
+    void invalidMappingIdentityAndHistoryAreUnavailableWithoutDiscardingOtherNodes() {
+        detail.setTopic("other");
+        assertThat(inspect().nodes().get(0).error()).contains("identity does not match");
+        detail.setTopic("orders");
+        detail.getHostedQueues().put(0, List.of());
+        assertThat(inspect().nodes().get(0).error()).contains("invalid logical queue history");
+        detail.getHostedQueues().put(0, java.util.Arrays.asList((LogicQueueMappingItem) null));
+        assertThat(inspect().nodes().get(0).error()).contains("invalid mapping segment");
+        detail.getHostedQueues().put(0, List.of(new LogicQueueMappingItem(0, -1, "broker-a", 0, 0, -1, -1, -1)));
+        assertThat(inspect().nodes().get(0).error()).contains("invalid mapping segment");
+        detail.setHostedQueues(null);
+        assertThat(inspect().nodes().get(0).error()).contains("history is unavailable");
+    }
+
+    @Test
+    void missingAdvertisementIsDistinctFromUnreadableAdvertisement() {
+        route.setTopicQueueMappingByBroker(null);
+        assertThat(inspect().nodes().get(0).advertised()).isNull();
+        var advertised = TopicQueueMappingDetail.cloneAsMappingInfo(detail);
+        advertised.setCurrIdMap(null);
+        route.setTopicQueueMappingByBroker(Map.of("broker-a", advertised));
+        assertThat(inspect().nodes().get(0).error()).contains("logical queue map is unavailable");
+    }
+
+    @Test
+    void malformedOrMissingRouteCannotProduceAnEmptyHealthySnapshot() throws Exception {
+        route.getBrokerDatas().clear();
+        route.setTopicQueueMappingByBroker(null);
+        assertThatThrownBy(this::inspect).hasMessageContaining("No route brokers");
+        route.getBrokerDatas().add(null);
+        assertThatThrownBy(this::inspect).hasMessageContaining("invalid broker identity");
+        route.getBrokerDatas().clear();
+        route.setTopicQueueMappingByBroker(new HashMap<>());
+        route.getTopicQueueMappingByBroker().put("", null);
+        assertThatThrownBy(this::inspect).hasMessageContaining("invalid mapping identity");
+        when(admin.examineTopicRouteInfo("orders")).thenReturn(null);
+        assertThatThrownBy(this::inspect).hasMessageContaining("route or broker registry is unavailable");
+        assertThatThrownBy(() -> service.inspect("instance-a", " ")).hasMessageContaining("Topic is required");
+    }
+
+    @Test
+    void interruptionStopsFurtherSamplingAndRestoresThreadFlag() throws Exception {
+        doThrow(new InterruptedException()).when(admin).examineTopicConfig("master:10911", "orders");
+        try {
+            assertThatThrownBy(this::inspect).hasMessageContaining("inspection was interrupted");
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+            verify(admin, never()).examineTopicConfig("registered-b:10911", "orders");
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void readOnlyHttpContractSerializesLongValuesAsStrings() throws Exception {
+        var mvc = MockMvcBuilders.standaloneSetup(new StaticTopicMappingController(service)).build();
+        mvc.perform(get("/api/static-topic-mappings").param("instanceId", "instance-a").param("topic", "orders"))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.data.nodes[0].local.epoch").value("9007199254740993"))
+                .andExpect(jsonPath("$.data.nodes[0].local.queues[0].segments[1].physicalEndExclusive").value("-1"));
+        verify(admin, never()).createStaticTopic(anyString(), anyString(), org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyBoolean());
+    }
+}

--- a/web/src/api/staticTopicMapping.test.ts
+++ b/web/src/api/staticTopicMapping.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import { beforeEach, expect, it, vi } from 'vitest';
+import client from './client';
+import { inspectStaticTopicMapping } from './staticTopicMapping';
+vi.mock('./client', () => ({ default: { get: vi.fn(), post: vi.fn() } }));
+beforeEach(() => vi.clearAllMocks());
+it('reads mappings with the exact topic, instance and cancellation signal', async () => {
+  const payload = { nodes: [{ local: { epoch: '9007199254740993' } }] };
+  vi.mocked(client.get).mockResolvedValue({ data: { data: payload } });
+  const params = { instanceId: 'instance-a', topic: 'orders' };
+  const signal = new AbortController().signal;
+  expect(await inspectStaticTopicMapping(params, signal)).toEqual(payload);
+  expect(client.get).toHaveBeenCalledWith('/static-topic-mappings', { params, signal });
+  expect(client.post).not.toHaveBeenCalled();
+});
+it('propagates an unavailable route without replacing it with an empty mapping', async () => {
+  vi.mocked(client.get).mockRejectedValue(new Error('route unavailable'));
+  await expect(inspectStaticTopicMapping({ instanceId: 'a', topic: 'orders' })).rejects.toThrow(
+    'route unavailable',
+  );
+});

--- a/web/src/api/staticTopicMapping.ts
+++ b/web/src/api/staticTopicMapping.ts
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import client from './client';
+export interface StaticMappingTarget {
+  instanceId: string;
+  topic: string;
+}
+export interface MappingSegment {
+  generation: number;
+  brokerName: string;
+  physicalQueueId: number;
+  logicalStart: string;
+  physicalStart: string;
+  physicalEndExclusive: string;
+}
+export interface QueueHistory {
+  logicalQueueId: number;
+  lastMappedBroker: string;
+  segments: MappingSegment[];
+}
+export interface MappingNode {
+  brokerName: string;
+  address: string | null;
+  status: 'MAPPING' | 'NO_MAPPING' | 'UNAVAILABLE';
+  error: string | null;
+  advertised: {
+    epoch: string;
+    scope: string;
+    totalQueues: number;
+    currentQueues: { logicalQueueId: number; physicalQueueId: number }[];
+  } | null;
+  local: {
+    epoch: string;
+    scope: string;
+    totalQueues: number;
+    dirty: boolean;
+    queues: QueueHistory[];
+  } | null;
+}
+export interface StaticMappingSnapshot {
+  topic: string;
+  startedAt: string;
+  finishedAt: string;
+  partial: boolean;
+  nodes: MappingNode[];
+}
+export async function inspectStaticTopicMapping(params: StaticMappingTarget, signal?: AbortSignal) {
+  const response = await client.get<{ data: StaticMappingSnapshot }>('/static-topic-mappings', {
+    params,
+    signal,
+  });
+  return response.data.data;
+}

--- a/web/src/components/StaticTopicMappingDialog.tsx
+++ b/web/src/components/StaticTopicMappingDialog.tsx
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import { useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Card,
+  Descriptions,
+  Empty,
+  Modal,
+  Space,
+  Table,
+  Tag,
+  Typography,
+} from 'antd';
+import {
+  inspectStaticTopicMapping,
+  type MappingNode,
+  type MappingSegment,
+  type StaticMappingSnapshot,
+  type StaticMappingTarget,
+} from '../api/staticTopicMapping';
+
+function NodeMapping({ node }: { node: MappingNode }) {
+  const advertised = node.advertised;
+  const local = node.local;
+  const changed =
+    advertised &&
+    local &&
+    (advertised.epoch !== local.epoch ||
+      advertised.scope !== local.scope ||
+      advertised.totalQueues !== local.totalQueues);
+  return (
+    <Card
+      size="small"
+      title={
+        <Space>
+          <Typography.Text>{node.brokerName}</Typography.Text>
+          <Tag color={node.status === 'UNAVAILABLE' ? 'orange' : 'blue'}>{node.status}</Tag>
+        </Space>
+      }
+    >
+      <Space direction="vertical" style={{ width: '100%' }}>
+        <Typography.Text code>{node.address || 'No registered master'}</Typography.Text>
+        {node.error && <Alert type="warning" message={node.error} />}
+        {node.status === 'NO_MAPPING' && (
+          <Alert
+            type="info"
+            message="This broker returned no local static mapping"
+            description="This may be an ordinary topic or a changing route. It does not prove that every broker has no mapping."
+          />
+        )}
+        {changed && (
+          <Alert
+            type="warning"
+            message="Route and local mapping metadata differ"
+            description="These are separate samples. Re-read and inspect migration state before drawing a consistency conclusion."
+          />
+        )}
+        <Descriptions
+          bordered
+          size="small"
+          column={1}
+          items={[
+            {
+              key: 'route',
+              label: 'Route epoch / scope / total logical queues',
+              children: advertised
+                ? `${advertised.epoch} / ${advertised.scope} / ${advertised.totalQueues}`
+                : 'No advertised mapping',
+            },
+            {
+              key: 'local',
+              label: 'Local epoch / scope / total logical queues',
+              children: local
+                ? `${local.epoch} / ${local.scope} / ${local.totalQueues}`
+                : 'Unavailable',
+            },
+            {
+              key: 'dirty',
+              label: 'Local dirty flag',
+              children: local ? String(local.dirty) : 'Unavailable',
+            },
+          ]}
+        />
+        {advertised && (
+          <>
+            <Typography.Text strong>Advertised current queue IDs</Typography.Text>
+            {advertised.currentQueues.length ? (
+              <Space wrap>
+                {advertised.currentQueues.map((queue) => (
+                  <Tag key={queue.logicalQueueId}>
+                    Logical {queue.logicalQueueId} → physical {queue.physicalQueueId}
+                  </Tag>
+                ))}
+              </Space>
+            ) : (
+              <Typography.Text type="secondary">
+                No current queue IDs advertised by this broker.
+              </Typography.Text>
+            )}
+          </>
+        )}
+        {local && local.queues.length === 0 && (
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No hosted queue history" />
+        )}
+        {local?.queues.map((queue) => (
+          <section key={queue.logicalQueueId} style={{ width: '100%' }}>
+            <Typography.Title level={5}>Logical queue {queue.logicalQueueId}</Typography.Title>
+            <Typography.Paragraph type="secondary">
+              Last mapped broker in this local history: {queue.lastMappedBroker}
+            </Typography.Paragraph>
+            <Table<MappingSegment>
+              size="small"
+              dataSource={queue.segments}
+              rowKey="generation"
+              pagination={false}
+              scroll={{ x: 730 }}
+              columns={[
+                { title: 'Generation', dataIndex: 'generation', width: 100 },
+                { title: 'Broker', dataIndex: 'brokerName', width: 140 },
+                { title: 'Physical queue', dataIndex: 'physicalQueueId', width: 120 },
+                {
+                  title: 'Logical start',
+                  dataIndex: 'logicalStart',
+                  render: (value) => <code>{value === '-1' ? '-1 (undecided)' : value}</code>,
+                },
+                {
+                  title: 'Physical start',
+                  dataIndex: 'physicalStart',
+                  render: (value) => <code>{value}</code>,
+                },
+                {
+                  title: 'Physical end (exclusive)',
+                  dataIndex: 'physicalEndExclusive',
+                  render: (value) => <code>{value === '-1' ? '-1 (open)' : value}</code>,
+                },
+              ]}
+            />
+          </section>
+        ))}
+      </Space>
+    </Card>
+  );
+}
+
+export default function StaticTopicMappingDialog({
+  target,
+  onClose,
+}: {
+  target: StaticMappingTarget;
+  onClose: () => void;
+}) {
+  const [snapshot, setSnapshot] = useState<StaticMappingSnapshot>();
+  const [error, setError] = useState<string>();
+  const [busy, setBusy] = useState(false);
+  const busyRef = useRef(false);
+  const active = useRef(true);
+  const abort = useRef<AbortController>();
+  useEffect(() => {
+    active.current = true;
+    return () => {
+      active.current = false;
+      abort.current?.abort();
+    };
+  }, []);
+  const read = async () => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setBusy(true);
+    setError(undefined);
+    setSnapshot(undefined);
+    abort.current = new AbortController();
+    try {
+      const value = await inspectStaticTopicMapping(target, abort.current.signal);
+      if (active.current) setSnapshot(value);
+    } catch (failure) {
+      if (active.current)
+        setError(failure instanceof Error ? failure.message : 'Mapping inspection failed');
+    } finally {
+      if (active.current) {
+        busyRef.current = false;
+        setBusy(false);
+      }
+    }
+  };
+  return (
+    <Modal
+      open
+      title={`Static queue mapping · ${target.topic}`}
+      width={1000}
+      style={{ top: 24 }}
+      onCancel={onClose}
+      footer={
+        <Space>
+          <Button onClick={onClose}>Close</Button>
+          <Button type="primary" loading={busy} disabled={busy} onClick={() => void read()}>
+            Read mappings
+          </Button>
+        </Space>
+      }
+    >
+      <Space
+        direction="vertical"
+        size="middle"
+        style={{ width: '100%', maxHeight: 'calc(100vh - 210px)', overflowY: 'auto' }}
+      >
+        <Alert
+          showIcon
+          type="info"
+          message="Read-only route and broker mapping samples"
+          description="Reads registered masters for brokers named by the current route and mapping advertisements. Historical brokers absent from the route are not queried. Samples are not atomic and do not prove cluster-wide ownership."
+        />
+        <Typography.Paragraph type="secondary">
+          Segments remain in the broker's original order. Offsets are queue offsets, not CommitLog
+          positions. For a decided segment: logical offset = logical start + physical offset −
+          physical start. The end is exclusive; -1 marks an undecided logical start or open physical
+          end. This view does not measure retained messages or migrate queues.
+        </Typography.Paragraph>
+        {error && <Alert type="error" message={error} />}
+        {snapshot && (
+          <>
+            <Typography.Text type="secondary">
+              Sample interval: {snapshot.startedAt} — {snapshot.finishedAt}
+            </Typography.Text>
+            {snapshot.partial && (
+              <Alert
+                type="warning"
+                message="Some broker mappings are unavailable"
+                description="Successful samples remain visible. Missing data must not be interpreted as no mapping."
+              />
+            )}
+            {snapshot.nodes.map((node) => (
+              <NodeMapping key={node.brokerName} node={node} />
+            ))}
+          </>
+        )}
+      </Space>
+    </Modal>
+  );
+}

--- a/web/src/components/__tests__/StaticTopicMappingDialog.test.tsx
+++ b/web/src/components/__tests__/StaticTopicMappingDialog.test.tsx
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { ConfigProvider } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import StaticTopicMappingDialog from '../StaticTopicMappingDialog';
+import {
+  inspectStaticTopicMapping,
+  type StaticMappingSnapshot,
+} from '../../api/staticTopicMapping';
+
+vi.mock('../../api/staticTopicMapping', () => ({ inspectStaticTopicMapping: vi.fn() }));
+const target = { instanceId: 'instance-a', topic: 'orders' };
+const sample: StaticMappingSnapshot = {
+  topic: 'orders',
+  startedAt: '2026-09-08T00:00:00Z',
+  finishedAt: '2026-09-08T00:00:01Z',
+  partial: false,
+  nodes: [
+    {
+      brokerName: 'broker-a',
+      address: 'master:10911',
+      status: 'MAPPING',
+      error: null,
+      advertised: {
+        epoch: '9007199254740993',
+        scope: '__global__',
+        totalQueues: 2,
+        currentQueues: [{ logicalQueueId: 0, physicalQueueId: 3 }],
+      },
+      local: {
+        epoch: '9007199254740993',
+        scope: '__global__',
+        totalQueues: 2,
+        dirty: false,
+        queues: [
+          {
+            logicalQueueId: 0,
+            lastMappedBroker: 'broker-a',
+            segments: [
+              {
+                generation: 0,
+                brokerName: 'old-broker',
+                physicalQueueId: 1,
+                logicalStart: '0',
+                physicalStart: '0',
+                physicalEndExclusive: '9007199254740993',
+              },
+              {
+                generation: 1,
+                brokerName: 'broker-a',
+                physicalQueueId: 3,
+                logicalStart: '-1',
+                physicalStart: '0',
+                physicalEndExclusive: '-1',
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+};
+const open = (onClose = vi.fn()) =>
+  render(
+    <ConfigProvider theme={{ token: { motion: false } }}>
+      <StaticTopicMappingDialog target={target} onClose={onClose} />
+    </ConfigProvider>,
+  );
+const read = () => fireEvent.click(screen.getByRole('button', { name: /Read mappings/ }));
+describe('Static topic mapping inspection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    vi.mocked(inspectStaticTopicMapping).mockResolvedValue(sample);
+  });
+  it('reads only on request and preserves large values and undecided boundaries', async () => {
+    open();
+    expect(inspectStaticTopicMapping).not.toHaveBeenCalled();
+    read();
+    await screen.findByText('9007199254740993');
+    expect(screen.getByText('-1 (undecided)')).toBeInTheDocument();
+    expect(screen.getByText('-1 (open)')).toBeInTheDocument();
+    expect(screen.getByText('Logical 0 → physical 3')).toBeInTheDocument();
+    expect(inspectStaticTopicMapping).toHaveBeenCalledWith(target, expect.any(AbortSignal));
+    expect(screen.queryByText(/metadata differ/)).not.toBeInTheDocument();
+  });
+  it('warns about route and local epoch differences without declaring either authoritative', async () => {
+    vi.mocked(inspectStaticTopicMapping).mockResolvedValue({
+      ...sample,
+      nodes: [
+        {
+          ...sample.nodes[0],
+          local: { ...sample.nodes[0].local!, epoch: '9007199254740994', dirty: true },
+        },
+      ],
+    });
+    open();
+    read();
+    await screen.findByText('Route and local mapping metadata differ');
+    expect(screen.getByText('9007199254740994 / __global__ / 2')).toBeInTheDocument();
+    expect(screen.getByText('true')).toBeInTheDocument();
+  });
+  it('retains successful segments when another broker cannot be read', async () => {
+    vi.mocked(inspectStaticTopicMapping).mockResolvedValue({
+      ...sample,
+      partial: true,
+      nodes: [
+        ...sample.nodes,
+        {
+          brokerName: 'broker-b',
+          address: null,
+          status: 'UNAVAILABLE',
+          error: 'No registered master address',
+          advertised: null,
+          local: null,
+        },
+      ],
+    });
+    open();
+    read();
+    await screen.findByText('Some broker mappings are unavailable');
+    expect(screen.getByText('old-broker')).toBeInTheDocument();
+    expect(screen.getByText('No registered master address')).toBeInTheDocument();
+  });
+  it('separates no local mapping from an empty hosted mapping', async () => {
+    vi.mocked(inspectStaticTopicMapping).mockResolvedValue({
+      ...sample,
+      nodes: [
+        { ...sample.nodes[0], local: { ...sample.nodes[0].local!, queues: [] } },
+        {
+          brokerName: 'broker-b',
+          address: 'b:10911',
+          status: 'NO_MAPPING',
+          error: null,
+          advertised: null,
+          local: null,
+        },
+      ],
+    });
+    open();
+    read();
+    await screen.findByText('No hosted queue history');
+    expect(screen.getByText('This broker returned no local static mapping')).toBeInTheDocument();
+  });
+  it('drops an old sample before a refresh that fails', async () => {
+    open();
+    read();
+    await screen.findByText('old-broker');
+    vi.mocked(inspectStaticTopicMapping).mockRejectedValue(new Error('route unavailable'));
+    read();
+    await screen.findByText('route unavailable');
+    expect(screen.queryByText('old-broker')).not.toBeInTheDocument();
+  });
+  it('prevents overlapping reads and discards late responses after unmount', async () => {
+    let resolve!: (value: StaticMappingSnapshot) => void;
+    vi.mocked(inspectStaticTopicMapping).mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    const view = open();
+    read();
+    read();
+    expect(inspectStaticTopicMapping).toHaveBeenCalledTimes(1);
+    const signal = vi.mocked(inspectStaticTopicMapping).mock.calls[0][1];
+    view.unmount();
+    expect(signal?.aborted).toBe(true);
+    await act(async () => resolve(sample));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -77,7 +77,10 @@ import {
   sendTopicMessage,
 } from '../../services/topicService';
 import { useInstanceFilter } from '../../hooks/useInstanceFilter';
-import type { Instance } from '../../api/instance';
+import { supportsApacheRuntime, type Instance } from '../../api/instance';
+import { isMockMode } from '../../services/dataMode';
+import StaticTopicMappingDialog from '../../components/StaticTopicMappingDialog';
+import type { StaticMappingTarget } from '../../api/staticTopicMapping';
 import {
   parseCsvTable,
   RESOURCE_NAME_MAX_LENGTH,
@@ -350,6 +353,7 @@ const TopicPage = () => {
   const hasSelectedInstance = Boolean(selectedInstanceId);
 
   // ─── State ─────────────────────────────────────────────────────
+  const [mappingTarget, setMappingTarget] = useState<StaticMappingTarget>();
   const [topics, setTopics] = useState<Topic[]>([]);
   const [totalTopics, setTotalTopics] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -738,7 +742,7 @@ const TopicPage = () => {
     {
       title: '操作',
       key: 'action',
-      width: 200,
+      width: 310,
       render: (_: unknown, record: Topic) => (
         <Flex gap={6} onClick={(e) => e.stopPropagation()}>
           <Button
@@ -749,6 +753,19 @@ const TopicPage = () => {
           >
             详情
           </Button>
+          {selectedInstanceId &&
+            selectedInstance &&
+            supportsApacheRuntime(selectedInstance) &&
+            !isMockMode() && (
+              <Button
+                size="small"
+                onClick={() =>
+                  setMappingTarget({ instanceId: selectedInstanceId, topic: record.name })
+                }
+              >
+                Static mapping
+              </Button>
+            )}
           {!isCloudInstance && (
             <Button
               size="small"
@@ -1452,6 +1469,7 @@ const TopicPage = () => {
             value={selectedInstanceId || undefined}
             onChange={(value) => {
               resetTablePage();
+              setMappingTarget(undefined);
               selectInstance(value);
             }}
             options={instanceOptions}
@@ -2030,6 +2048,13 @@ const TopicPage = () => {
           </>
         )}
       </Modal>
+      {mappingTarget && mappingTarget.instanceId === selectedInstanceId && (
+        <StaticTopicMappingDialog
+          key={`${mappingTarget.instanceId}/${mappingTarget.topic}`}
+          target={mappingTarget}
+          onClose={() => setMappingTarget(undefined)}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
静态 Topic 迁移后，同一逻辑队列可以跨多个 Broker 的历史物理队列分段。现有路由视图只有分布、数量和权限，无法解释这些映射。本 PR 增加 Topic 列表的 Static mapping 入口及只读诊断接口。

## 改动说明

服务取当前路由 Broker 与映射广播名称的并集，只访问所选实例已登记主节点，通过 SDK examineTopicConfig 获取完整 TopicConfigAndQueueMapping。界面并排展示 NameServer 广播版本/范围/当前队列 ID 与 Broker 本地版本/dirty 标记/历史分段；版本、范围或总逻辑队列数不同明确提示采样差异。

历史分段保留 Broker 原顺序和原始代数，64 位 epoch 与位点全程为字符串。-1 的逻辑起点、开放物理末尾明确标注，不伪造保留消息范围。NO_MAPPING 与响应不可用严格区分，部分失败保留其它节点结果；缺少主节点不回退副本，不按历史分段里的任意地址发请求。关闭和实例切换中止等待，刷新先清旧样本，无自动轮询或修复。

协议依据：[MQClientAPIImpl.getTopicConfig](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java#L3274) 使用 lo=true；[TopicQueueMappingDetail](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/statictopic/TopicQueueMappingDetail.java) 定义 hostedQueues 与当前 ID 广播，[LogicQueueMappingItem](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/statictopic/LogicQueueMappingItem.java) 定义物理末尾排除语义及偏移换算。没有创建、迁移或修改静态 Topic 的写操作。

## 原提交验证记录

本地后端 61、前端 30 项测试通过；服务 79/79 行、60/68 分支覆盖。Checkstyle、TypeScript/Vite 构建、后端打包通过，ESLint 0 错误、10 条现有告警。浏览器使用本地 GET 拦截验证真实 Topic 入口、版本差异、超大位点和部分失败，最终无控制台错误；未修改真实 Broker。

## 兼容性与回滚

无新增依赖或数据库迁移，撤销提交可移除入口和接口。读取是分时采样，不证明全集群所有权；历史但已不在路由中的 Broker 不额外查询。真实静态 Topic 迁移、并发选主、性能、压力、容量和混沌测试未执行。上游已有全量测试失败和依赖审计缺口继续披露。提交含 [skip ci]，未执行远端工作流。核验日期：2026-09-08。
