### PR TITLE
[Studio] feat: add Ops NameServer configuration preflight

### DIFF
--- a/web/src/pages/studio/Ops.tsx
+++ b/web/src/pages/studio/Ops.tsx
@@ -15,19 +15,25 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   App,
   Button,
+  Card,
+  Descriptions,
+  Flex,
   Input,
   Popconfirm,
   Select,
   Space,
   Switch,
+  Table,
+  Tag,
   Tooltip,
   Typography,
 } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
 import { FloppyDisk, Plus, Trash } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
 import useAuthStore from '../../stores/authStore';
@@ -39,6 +45,213 @@ import {
   updateNameSvrAddr,
   updateUseTLS,
 } from '../../api/ops';
+import {
+  analyzeOpsNameServerPreflight,
+  type NameServerAddressDiagnostic,
+  type OpsNameServerPreflight,
+  type OpsNameServerReadiness,
+  type OpsNameServerSeverity,
+} from '../../utils/opsNameServerPreflight';
+import { tableScrollX } from '../../utils/table';
+
+const { Text } = Typography;
+
+const readinessAlertType: Record<OpsNameServerReadiness, 'success' | 'warning' | 'error'> = {
+  ready: 'success',
+  warning: 'warning',
+  blocked: 'error',
+};
+
+const severityColor: Record<OpsNameServerSeverity, string> = {
+  critical: 'red',
+  warning: 'orange',
+  info: 'blue',
+};
+
+const candidateStatusColor: Record<OpsNameServerPreflight['newAddress']['status'], string> = {
+  empty: 'default',
+  ready: 'green',
+  invalid: 'red',
+  duplicate: 'orange',
+};
+
+const candidateStatusText: Record<OpsNameServerPreflight['newAddress']['status'], string> = {
+  empty: '未输入',
+  ready: '可新增',
+  invalid: '格式错误',
+  duplicate: '已存在',
+};
+
+const statusText = (address: NameServerAddressDiagnostic) => {
+  if (!address.valid) return '格式错误';
+  if (address.duplicate) return '重复';
+  return '有效';
+};
+
+const OpsNameServerPreflightPanel = ({ preflight }: { preflight: OpsNameServerPreflight }) => {
+  const columns: ColumnsType<NameServerAddressDiagnostic> = [
+    {
+      title: 'NameServer 地址',
+      dataIndex: 'raw',
+      key: 'raw',
+      width: 260,
+      ellipsis: true,
+      render: (value: string) => <Text code>{value || '-'}</Text>,
+    },
+    {
+      title: 'Endpoint',
+      dataIndex: 'endpoints',
+      key: 'endpoints',
+      width: 260,
+      render: (endpoints: NameServerAddressDiagnostic['endpoints']) =>
+        endpoints.length === 0 ? (
+          <Text type="secondary">-</Text>
+        ) : (
+          <Space size={[0, 4]} wrap>
+            {endpoints.map((endpoint) => (
+              <Tag
+                key={`${endpoint.raw}-${endpoint.normalized}`}
+                color={endpoint.valid ? 'blue' : 'red'}
+              >
+                {endpoint.valid ? endpoint.normalized : endpoint.raw || '-'}
+              </Tag>
+            ))}
+          </Space>
+        ),
+    },
+    {
+      title: '角色',
+      key: 'role',
+      width: 160,
+      render: (_: unknown, address) => (
+        <Space size={[0, 4]} wrap>
+          {address.current && <Tag color="green">当前使用</Tag>}
+          {address.selected && <Tag color="purple">已选择</Tag>}
+          {!address.current && !address.selected && <Text type="secondary">-</Text>}
+        </Space>
+      ),
+    },
+    {
+      title: '状态',
+      key: 'status',
+      width: 120,
+      render: (_: unknown, address) => (
+        <Tag color={!address.valid ? 'red' : address.duplicate ? 'orange' : 'green'}>
+          {statusText(address)}
+        </Tag>
+      ),
+    },
+    {
+      title: '说明',
+      dataIndex: 'issueText',
+      key: 'issueText',
+      render: (issues: string[]) =>
+        issues.length === 0 ? (
+          <Text type="secondary">-</Text>
+        ) : (
+          <Space direction="vertical" size={2}>
+            {issues.map((issue) => (
+              <Text key={issue} type="secondary" style={{ fontSize: 14 }}>
+                {issue}
+              </Text>
+            ))}
+          </Space>
+        ),
+    },
+  ];
+
+  return (
+    <Card
+      size="small"
+      title="NameServer 配置预检"
+      style={{ marginBottom: 24 }}
+      styles={{ body: { padding: 16 } }}
+    >
+      <Space direction="vertical" size={16} style={{ width: '100%' }}>
+        <Alert
+          showIcon
+          type={readinessAlertType[preflight.readiness]}
+          message={preflight.statusText}
+          description={preflight.statusDescription}
+        />
+
+        <Descriptions size="small" bordered column={{ xs: 1, sm: 2, md: 4 }}>
+          <Descriptions.Item label="地址数">
+            {preflight.stats.configuredAddresses}
+          </Descriptions.Item>
+          <Descriptions.Item label="有效地址">{preflight.stats.validAddresses}</Descriptions.Item>
+          <Descriptions.Item label="有效 endpoint">
+            {preflight.stats.validEndpointCount}/{preflight.stats.endpointCount}
+          </Descriptions.Item>
+          <Descriptions.Item label="待新增地址">
+            <Tag color={candidateStatusColor[preflight.newAddress.status]}>
+              {candidateStatusText[preflight.newAddress.status]}
+            </Tag>
+          </Descriptions.Item>
+          <Descriptions.Item label="重复地址">
+            {preflight.stats.duplicateAddresses}
+          </Descriptions.Item>
+          <Descriptions.Item label="无效地址">{preflight.stats.invalidAddresses}</Descriptions.Item>
+          <Descriptions.Item label="当前地址在列表内">
+            <Tag color={preflight.currentAddressKnown ? 'green' : 'red'}>
+              {preflight.currentAddressKnown ? '是' : '否'}
+            </Tag>
+          </Descriptions.Item>
+          <Descriptions.Item label="选中地址可更新">
+            <Tag color={preflight.selectedAddressValid ? 'green' : 'red'}>
+              {preflight.selectedAddressValid ? '是' : '否'}
+            </Tag>
+          </Descriptions.Item>
+        </Descriptions>
+
+        {preflight.issues.length > 0 && (
+          <Flex gap={8} wrap>
+            {preflight.issues.map((issue) => (
+              <Tooltip key={issue.id} title={issue.description}>
+                <Tag color={severityColor[issue.severity]}>{issue.title}</Tag>
+              </Tooltip>
+            ))}
+          </Flex>
+        )}
+
+        {preflight.pendingChanges.length > 0 && (
+          <div style={{ border: '1px solid #f0f0f0', borderRadius: 8, padding: 12 }}>
+            <Text strong style={{ display: 'block', marginBottom: 8 }}>
+              待确认变更
+            </Text>
+            <Space direction="vertical" size={8} style={{ width: '100%' }}>
+              {preflight.pendingChanges.map((change) => (
+                <Flex key={change.id} justify="space-between" gap={12} wrap>
+                  <Space>
+                    <Tag color={severityColor[change.severity]}>{change.title}</Tag>
+                    <Text>{change.description}</Text>
+                  </Space>
+                </Flex>
+              ))}
+            </Space>
+          </div>
+        )}
+
+        <Table
+          columns={columns}
+          dataSource={preflight.addresses}
+          rowKey="key"
+          pagination={false}
+          size="small"
+          scroll={{ x: tableScrollX(columns) }}
+        />
+
+        <Space direction="vertical" size={4}>
+          {preflight.recommendations.map((recommendation) => (
+            <Text key={recommendation} type="secondary" style={{ fontSize: 14 }}>
+              {recommendation}
+            </Text>
+          ))}
+        </Space>
+      </Space>
+    </Card>
+  );
+};
 
 const OpsPage: React.FC = () => {
   const { t } = useLang();
@@ -62,8 +275,39 @@ const OpsPage: React.FC = () => {
   const [configurationAvailable, setConfigurationAvailable] = useState(false);
   const [unavailableReason, setUnavailableReason] = useState('');
   const writeOperationEnabled = configurationAvailable && (!userId || admin === true);
+  const nameServerPreflight = useMemo(
+    () =>
+      analyzeOpsNameServerPreflight({
+        namesrvAddrList,
+        currentNamesrv,
+        selectedNamesrv,
+        newNamesrvAddr,
+        configurationAvailable,
+        unavailableReason,
+        canWrite: writeOperationEnabled,
+        useVIPChannel,
+        useTLS,
+      }),
+    [
+      configurationAvailable,
+      currentNamesrv,
+      namesrvAddrList,
+      newNamesrvAddr,
+      selectedNamesrv,
+      unavailableReason,
+      useTLS,
+      useVIPChannel,
+      writeOperationEnabled,
+    ],
+  );
+  const newAddressBlocked =
+    Boolean(newNamesrvAddr.trim()) && nameServerPreflight.newAddress.status !== 'ready';
+  const updateNameServerDisabled = namesrvUpdating || !nameServerPreflight.selectedAddressValid;
   const deleteNameServerDisabled =
-    !selectedNamesrv || selectedNamesrv === currentNamesrv || namesrvAddrList.length <= 1;
+    !selectedNamesrv ||
+    selectedNamesrv === currentNamesrv ||
+    namesrvAddrList.length <= 1 ||
+    !nameServerPreflight.selectedAddressValid;
 
   useEffect(() => {
     let cancelled = false;
@@ -98,6 +342,10 @@ const OpsPage: React.FC = () => {
     if (namesrvMutationInFlight.current) return;
     if (!selectedNamesrv) {
       message.warning(t('ops.selectNamesrv'));
+      return;
+    }
+    if (!nameServerPreflight.selectedAddressValid) {
+      message.warning('请选择列表中格式有效的 NameServer 地址');
       return;
     }
     namesrvMutationInFlight.current = true;
@@ -136,6 +384,10 @@ const OpsPage: React.FC = () => {
     const addr = newNamesrvAddr.trim();
     if (!addr) {
       message.warning(t('ops.inputNamesrvAddr'));
+      return;
+    }
+    if (nameServerPreflight.newAddress.status !== 'ready') {
+      message.warning(nameServerPreflight.newAddress.message);
       return;
     }
     namesrvMutationInFlight.current = true;
@@ -218,7 +470,7 @@ const OpsPage: React.FC = () => {
               icon={<FloppyDisk size={16} />}
               onClick={handleUpdateNameSvrAddr}
               loading={namesrvUpdating}
-              disabled={namesrvUpdating}
+              disabled={updateNameServerDisabled}
             >
               {t('common.update')}
             </Button>
@@ -250,19 +502,23 @@ const OpsPage: React.FC = () => {
                 onChange={(e) => setNewNamesrvAddr(e.target.value)}
                 disabled={namesrvUpdating}
               />
-              <Button
-                type="primary"
-                icon={<Plus size={16} />}
-                onClick={handleAddNameSvrAddr}
-                loading={namesrvUpdating}
-                disabled={namesrvUpdating}
-              >
-                {t('common.add')}
-              </Button>
+              <Tooltip title={newAddressBlocked ? nameServerPreflight.newAddress.message : ''}>
+                <Button
+                  type="primary"
+                  icon={<Plus size={16} />}
+                  onClick={handleAddNameSvrAddr}
+                  loading={namesrvUpdating}
+                  disabled={namesrvUpdating || newAddressBlocked}
+                >
+                  {t('common.add')}
+                </Button>
+              </Tooltip>
             </Space.Compact>
           )}
         </Space>
       </div>
+
+      <OpsNameServerPreflightPanel preflight={nameServerPreflight} />
 
       {/* VIP Channel */}
       <div style={{ marginBottom: 24 }}>

--- a/web/src/pages/studio/__tests__/Ops.test.tsx
+++ b/web/src/pages/studio/__tests__/Ops.test.tsx
@@ -22,7 +22,12 @@ import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
 import OpsPage from '../Ops';
-import { addNameSvrAddr, deleteNameSvrAddr, queryOpsHomePage, updateIsVIPChannel } from '../../../api/ops';
+import {
+  addNameSvrAddr,
+  deleteNameSvrAddr,
+  queryOpsHomePage,
+  updateIsVIPChannel,
+} from '../../../api/ops';
 import useAuthStore from '../../../stores/authStore';
 
 vi.mock('../../../api/ops', () => ({
@@ -80,9 +85,66 @@ describe('OpsPage', () => {
       expect(queryOpsHomePage).toHaveBeenCalledTimes(1);
     });
 
-    expect(await screen.findByText('127.0.0.1:9876')).toBeInTheDocument();
+    expect((await screen.findAllByText('127.0.0.1:9876')).length).toBeGreaterThan(0);
     expect(screen.getAllByRole('switch')[0]).toBeChecked();
     expect(screen.getAllByRole('switch')[1]).not.toBeChecked();
+  });
+
+  it('renders NameServer configuration preflight details', async () => {
+    renderWithProviders(<OpsPage />);
+
+    expect(await screen.findByText('NameServer 配置预检')).toBeInTheDocument();
+    expect(await screen.findByText('配置预检通过')).toBeInTheDocument();
+    expect(screen.getByText('待确认变更')).toBeInTheDocument();
+    expect(screen.getByText('VIP 通道已启用')).toBeInTheDocument();
+    expect(screen.getByText('当前 NameServer 配置可直接更新')).toBeInTheDocument();
+  });
+
+  it('surfaces pending NameServer switches and additions before saving', async () => {
+    const user = userEvent.setup();
+    const { container } = renderWithProviders(<OpsPage />);
+
+    await screen.findAllByText('127.0.0.1:9876');
+    fireEvent.mouseDown(container.querySelector('.ant-select-selector') as Element);
+    fireEvent.click(
+      await screen.findByText('127.0.0.2:9876', {
+        selector: '.ant-select-item-option-content',
+      }),
+    );
+    await user.type(await screen.findByPlaceholderText('NamesrvAddr'), '127.0.0.3:9876');
+
+    expect(screen.getByText('待切换当前 NameServer')).toBeInTheDocument();
+    expect(screen.getByText('127.0.0.1:9876 -> 127.0.0.2:9876')).toBeInTheDocument();
+    expect(screen.getByText('待新增 NameServer')).toBeInTheDocument();
+    expect(screen.getAllByText('127.0.0.3:9876').length).toBeGreaterThan(0);
+  });
+
+  it('blocks duplicate NameServer additions on the client side', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<OpsPage />);
+
+    await user.type(await screen.findByPlaceholderText('NamesrvAddr'), '127.0.0.1:9876');
+    const addButton = screen.getByRole('button', { name: /新增|添加/ });
+
+    expect(addButton).toBeDisabled();
+    fireEvent.click(addButton);
+    expect(addNameSvrAddr).not.toHaveBeenCalled();
+    expect(screen.getByText('待新增地址已存在')).toBeInTheDocument();
+  });
+
+  it('shows a blocked preflight when the current NameServer is missing from the list', async () => {
+    vi.mocked(queryOpsHomePage).mockResolvedValue({
+      namesvrAddrList: ['127.0.0.2:9876'],
+      configurationAvailable: true,
+      useVIPChannel: false,
+      useTLS: false,
+      currentNamesrv: '127.0.0.1:9876',
+    });
+    renderWithProviders(<OpsPage />);
+
+    expect(await screen.findByText('需要先处理阻断项')).toBeInTheDocument();
+    expect(screen.getByText('当前使用地址不在候选列表中')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: '更新' })[0]).toBeDisabled();
   });
 
   it('prevents overlapping NameServer mutations', async () => {

--- a/web/src/utils/opsNameServerPreflight.test.ts
+++ b/web/src/utils/opsNameServerPreflight.test.ts
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  analyzeOpsNameServerPreflight,
+  parseNameServerAddress,
+  parseNameServerEndpoint,
+} from './opsNameServerPreflight';
+
+describe('parseNameServerEndpoint', () => {
+  it('normalizes host and port based NameServer endpoints', () => {
+    expect(parseNameServerEndpoint(' NameSrv-A.EXAMPLE.com:9876 ')).toMatchObject({
+      normalized: 'namesrv-a.example.com:9876',
+      host: 'namesrv-a.example.com',
+      port: 9876,
+      valid: true,
+    });
+  });
+
+  it.each([
+    ['https://namesrv.example.com:9876', 'NameServer 地址不应包含协议前缀'],
+    ['namesrv.example.com', 'NameServer 地址格式应为 host:port'],
+    ['namesrv.example.com:70000', 'NameServer 端口必须在 1-65535 之间'],
+    ['name srv.example.com:9876', 'NameServer host 只能包含域名、IP 或 localhost'],
+    ['2001:db8::1:9876', 'NameServer 地址格式应为 host:port'],
+  ])('rejects invalid endpoint %s', (value, reason) => {
+    expect(parseNameServerEndpoint(value)).toMatchObject({
+      valid: false,
+      reason,
+    });
+  });
+});
+
+describe('parseNameServerAddress', () => {
+  it('parses a semicolon or comma separated endpoint chain', () => {
+    expect(parseNameServerAddress('namesrv-a:9876; namesrv-b:9876,localhost:9876')).toMatchObject({
+      normalized: 'namesrv-a:9876;namesrv-b:9876;localhost:9876',
+      valid: true,
+    });
+  });
+
+  it('marks repeated endpoints inside the same address as invalid', () => {
+    const result = parseNameServerAddress('namesrv-a:9876;namesrv-a:9876');
+
+    expect(result.valid).toBe(false);
+    expect(result.issueText).toContain('同一个地址串内包含重复 endpoint: namesrv-a:9876');
+  });
+});
+
+describe('analyzeOpsNameServerPreflight', () => {
+  const baseInput = {
+    namesrvAddrList: ['namesrv-a:9876', 'namesrv-b:9876'],
+    currentNamesrv: 'namesrv-a:9876',
+    selectedNamesrv: 'namesrv-a:9876',
+    newNamesrvAddr: '',
+    configurationAvailable: true,
+    canWrite: true,
+    useVIPChannel: false,
+    useTLS: false,
+  };
+
+  it('passes healthy NameServer settings without issues', () => {
+    const result = analyzeOpsNameServerPreflight(baseInput);
+
+    expect(result.readiness).toBe('ready');
+    expect(result.issues).toEqual([]);
+    expect(result.stats).toMatchObject({
+      configuredAddresses: 2,
+      validAddresses: 2,
+      invalidAddresses: 0,
+      duplicateAddresses: 0,
+      endpointCount: 2,
+      validEndpointCount: 2,
+    });
+    expect(result.currentAddressKnown).toBe(true);
+    expect(result.selectedAddressValid).toBe(true);
+  });
+
+  it('reports invalid and duplicated saved addresses', () => {
+    const result = analyzeOpsNameServerPreflight({
+      ...baseInput,
+      namesrvAddrList: ['namesrv-a:9876', 'namesrv-a:9876', 'bad-address'],
+    });
+
+    expect(result.readiness).toBe('warning');
+    expect(result.stats.duplicateAddresses).toBe(1);
+    expect(result.stats.invalidAddresses).toBe(1);
+    expect(result.issues.map((issue) => issue.id)).toEqual(
+      expect.arrayContaining(['duplicate-addresses', 'invalid-addresses']),
+    );
+  });
+
+  it('blocks updates when the current address is missing from the configured list', () => {
+    const result = analyzeOpsNameServerPreflight({
+      ...baseInput,
+      namesrvAddrList: ['namesrv-b:9876'],
+      currentNamesrv: 'namesrv-a:9876',
+      selectedNamesrv: 'namesrv-b:9876',
+    });
+
+    expect(result.readiness).toBe('blocked');
+    expect(result.currentAddressKnown).toBe(false);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        id: 'current-missing',
+        severity: 'critical',
+      }),
+    );
+  });
+
+  it('summarizes a valid pending switch and add operation', () => {
+    const result = analyzeOpsNameServerPreflight({
+      ...baseInput,
+      selectedNamesrv: 'namesrv-b:9876',
+      newNamesrvAddr: 'namesrv-c:9876',
+      useTLS: true,
+      useVIPChannel: true,
+    });
+
+    expect(result.newAddress).toMatchObject({
+      normalized: 'namesrv-c:9876',
+      status: 'ready',
+    });
+    expect(result.pendingChanges.map((change) => change.id)).toEqual([
+      'switch-nameserver',
+      'add-nameserver',
+      'tls-enabled',
+      'vip-enabled',
+    ]);
+  });
+
+  it('rejects a pending duplicate add before it reaches the API', () => {
+    const result = analyzeOpsNameServerPreflight({
+      ...baseInput,
+      newNamesrvAddr: ' NameSrv-A:9876 ',
+    });
+
+    expect(result.newAddress).toMatchObject({
+      normalized: 'namesrv-a:9876',
+      status: 'duplicate',
+    });
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        id: 'new-address-duplicate',
+        severity: 'warning',
+      }),
+    );
+  });
+
+  it('marks unavailable runtime configuration as blocked and read-only as advisory', () => {
+    const result = analyzeOpsNameServerPreflight({
+      ...baseInput,
+      configurationAvailable: false,
+      unavailableReason: 'configuration disabled',
+      canWrite: false,
+    });
+
+    expect(result.readiness).toBe('blocked');
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        id: 'configuration-unavailable',
+        description: 'configuration disabled',
+      }),
+    );
+    expect(result.recommendations).toContain('当前账号只读，预检结果仅供排查参考');
+  });
+});

--- a/web/src/utils/opsNameServerPreflight.ts
+++ b/web/src/utils/opsNameServerPreflight.ts
@@ -1,0 +1,479 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type OpsNameServerReadiness = 'ready' | 'warning' | 'blocked';
+export type OpsNameServerSeverity = 'critical' | 'warning' | 'info';
+
+export interface NameServerEndpointDiagnostic {
+  raw: string;
+  normalized: string;
+  host: string;
+  port: number | null;
+  valid: boolean;
+  reason?: string;
+}
+
+export interface NameServerAddressDiagnostic {
+  key: string;
+  raw: string;
+  normalized: string;
+  endpoints: NameServerEndpointDiagnostic[];
+  valid: boolean;
+  duplicate: boolean;
+  current: boolean;
+  selected: boolean;
+  issueText: string[];
+}
+
+export interface OpsNameServerIssue {
+  id: string;
+  severity: OpsNameServerSeverity;
+  title: string;
+  description: string;
+}
+
+export interface OpsNameServerPendingChange {
+  id: string;
+  severity: OpsNameServerSeverity;
+  title: string;
+  description: string;
+}
+
+export interface OpsNameServerCandidate {
+  raw: string;
+  normalized: string;
+  status: 'empty' | 'ready' | 'invalid' | 'duplicate';
+  message: string;
+  endpoints: NameServerEndpointDiagnostic[];
+}
+
+export interface OpsNameServerPreflightInput {
+  namesrvAddrList: string[];
+  currentNamesrv: string;
+  selectedNamesrv: string;
+  newNamesrvAddr: string;
+  configurationAvailable: boolean;
+  unavailableReason?: string;
+  canWrite: boolean;
+  useVIPChannel: boolean;
+  useTLS: boolean;
+}
+
+export interface OpsNameServerPreflight {
+  readiness: OpsNameServerReadiness;
+  statusText: string;
+  statusDescription: string;
+  addresses: NameServerAddressDiagnostic[];
+  issues: OpsNameServerIssue[];
+  pendingChanges: OpsNameServerPendingChange[];
+  recommendations: string[];
+  newAddress: OpsNameServerCandidate;
+  stats: {
+    configuredAddresses: number;
+    validAddresses: number;
+    invalidAddresses: number;
+    duplicateAddresses: number;
+    endpointCount: number;
+    validEndpointCount: number;
+  };
+  selectedAddressValid: boolean;
+  currentAddressKnown: boolean;
+}
+
+const HOST_PATTERN = /^[a-zA-Z0-9.-]+$/;
+const IPV4_PATTERN = /^(25[0-5]|2[0-4]\d|1?\d?\d)(\.(25[0-5]|2[0-4]\d|1?\d?\d)){3}$/;
+
+const trimAddress = (value: string | null | undefined) => (value ?? '').trim();
+
+const parsePort = (value: string): number | null => {
+  if (!/^\d+$/.test(value)) return null;
+  const port = Number(value);
+  return port >= 1 && port <= 65535 ? port : null;
+};
+
+const normalizeHost = (host: string) => host.trim().toLowerCase();
+
+const isHostnameLike = (host: string) => {
+  if (!host || /\s/.test(host)) return false;
+  if (host === 'localhost') return true;
+  if (IPV4_PATTERN.test(host)) return true;
+  if (!HOST_PATTERN.test(host)) return false;
+  return !host.startsWith('.') && !host.endsWith('.') && !host.includes('..');
+};
+
+const parseBracketedEndpoint = (raw: string): NameServerEndpointDiagnostic | null => {
+  const match = /^\[([^\]]+)]:(\d+)$/.exec(raw);
+  if (!match) return null;
+  const host = normalizeHost(match[1]);
+  const port = parsePort(match[2]);
+  const normalized = port == null ? raw : `[${host}]:${port}`;
+  return {
+    raw,
+    normalized,
+    host,
+    port,
+    valid: Boolean(host && port != null),
+    reason: host && port != null ? undefined : 'IPv6 地址必须包含有效端口',
+  };
+};
+
+export function parseNameServerEndpoint(rawEndpoint: string): NameServerEndpointDiagnostic {
+  const raw = rawEndpoint.trim();
+  if (!raw) {
+    return {
+      raw,
+      normalized: raw,
+      host: '',
+      port: null,
+      valid: false,
+      reason: '地址为空',
+    };
+  }
+  if (raw.includes('://')) {
+    return {
+      raw,
+      normalized: raw,
+      host: raw,
+      port: null,
+      valid: false,
+      reason: 'NameServer 地址不应包含协议前缀',
+    };
+  }
+
+  const bracketed = parseBracketedEndpoint(raw);
+  if (bracketed) return bracketed;
+  if (raw.startsWith('[') || raw.includes(']')) {
+    return {
+      raw,
+      normalized: raw,
+      host: raw,
+      port: null,
+      valid: false,
+      reason: 'IPv6 地址格式应为 [host]:port',
+    };
+  }
+
+  const firstColon = raw.indexOf(':');
+  const lastColon = raw.lastIndexOf(':');
+  if (firstColon <= 0 || firstColon !== lastColon || lastColon === raw.length - 1) {
+    return {
+      raw,
+      normalized: raw,
+      host: raw,
+      port: null,
+      valid: false,
+      reason: 'NameServer 地址格式应为 host:port',
+    };
+  }
+
+  const host = normalizeHost(raw.slice(0, lastColon));
+  const port = parsePort(raw.slice(lastColon + 1));
+  const normalized = port == null ? raw : `${host}:${port}`;
+  if (!isHostnameLike(host)) {
+    return {
+      raw,
+      normalized,
+      host,
+      port,
+      valid: false,
+      reason: 'NameServer host 只能包含域名、IP 或 localhost',
+    };
+  }
+  if (port == null) {
+    return {
+      raw,
+      normalized,
+      host,
+      port: null,
+      valid: false,
+      reason: 'NameServer 端口必须在 1-65535 之间',
+    };
+  }
+
+  return { raw, normalized, host, port, valid: true };
+}
+
+export function parseNameServerAddress(
+  rawAddress: string,
+): Omit<NameServerAddressDiagnostic, 'key' | 'duplicate' | 'current' | 'selected'> {
+  const raw = trimAddress(rawAddress);
+  const parts = raw ? raw.split(/[;,]/).map((part) => part.trim()) : [];
+  const endpoints = parts.length > 0 ? parts.map(parseNameServerEndpoint) : [];
+  const valid = endpoints.length > 0 && endpoints.every((endpoint) => endpoint.valid);
+  const normalized = valid ? endpoints.map((endpoint) => endpoint.normalized).join(';') : raw;
+  const endpointCounts = endpoints.reduce((counts, endpoint) => {
+    if (endpoint.valid) counts.set(endpoint.normalized, (counts.get(endpoint.normalized) ?? 0) + 1);
+    return counts;
+  }, new Map<string, number>());
+  const repeatedEndpoints = endpoints
+    .filter((endpoint) => endpoint.valid && (endpointCounts.get(endpoint.normalized) ?? 0) > 1)
+    .map((endpoint) => endpoint.normalized);
+  const issueText = [
+    ...endpoints.filter((endpoint) => !endpoint.valid).map((endpoint) => endpoint.reason ?? ''),
+    ...(repeatedEndpoints.length > 0
+      ? [`同一个地址串内包含重复 endpoint: ${[...new Set(repeatedEndpoints)].join(', ')}`]
+      : []),
+  ].filter(Boolean);
+
+  return {
+    raw,
+    normalized,
+    endpoints,
+    valid: valid && repeatedEndpoints.length === 0,
+    issueText,
+  };
+}
+
+const buildCandidate = (
+  rawAddress: string,
+  existingNormalized: Set<string>,
+): OpsNameServerCandidate => {
+  const raw = trimAddress(rawAddress);
+  if (!raw) {
+    return {
+      raw,
+      normalized: '',
+      status: 'empty',
+      message: '输入新的 NameServer 地址后会在这里预检',
+      endpoints: [],
+    };
+  }
+  const parsed = parseNameServerAddress(raw);
+  if (!parsed.valid) {
+    return {
+      raw,
+      normalized: parsed.normalized,
+      status: 'invalid',
+      message: parsed.issueText[0] ?? 'NameServer 地址格式无效',
+      endpoints: parsed.endpoints,
+    };
+  }
+  if (existingNormalized.has(parsed.normalized)) {
+    return {
+      raw,
+      normalized: parsed.normalized,
+      status: 'duplicate',
+      message: '该 NameServer 地址已存在，无需重复添加',
+      endpoints: parsed.endpoints,
+    };
+  }
+  return {
+    raw,
+    normalized: parsed.normalized,
+    status: 'ready',
+    message: `将新增 ${parsed.endpoints.length} 个 endpoint`,
+    endpoints: parsed.endpoints,
+  };
+};
+
+const unique = <T>(items: T[]) => [...new Set(items)];
+
+export function analyzeOpsNameServerPreflight(
+  input: OpsNameServerPreflightInput,
+): OpsNameServerPreflight {
+  const parsedAddresses = input.namesrvAddrList.map((address, index) => ({
+    ...parseNameServerAddress(address),
+    key: `${index}:${address}`,
+    duplicate: false,
+    current: false,
+    selected: false,
+  }));
+  const validNormalizedCounts = parsedAddresses.reduce((counts, address) => {
+    if (address.valid) {
+      counts.set(address.normalized, (counts.get(address.normalized) ?? 0) + 1);
+    }
+    return counts;
+  }, new Map<string, number>());
+  const existingNormalized = new Set(validNormalizedCounts.keys());
+  const current = parseNameServerAddress(input.currentNamesrv);
+  const selected = parseNameServerAddress(input.selectedNamesrv);
+  const currentAddressKnown = Boolean(
+    current.valid && parsedAddresses.some((address) => address.normalized === current.normalized),
+  );
+  const selectedAddressValid = Boolean(
+    selected.valid && existingNormalized.has(selected.normalized),
+  );
+  const addresses = parsedAddresses.map((address) => ({
+    ...address,
+    duplicate: address.valid && (validNormalizedCounts.get(address.normalized) ?? 0) > 1,
+    current: current.valid && address.normalized === current.normalized,
+    selected: selected.valid && address.normalized === selected.normalized,
+  }));
+  const newAddress = buildCandidate(input.newNamesrvAddr, existingNormalized);
+  const invalidAddresses = addresses.filter((address) => !address.valid);
+  const duplicateAddresses = addresses.filter((address) => address.duplicate);
+  const validAddresses = addresses.filter((address) => address.valid);
+  const issues: OpsNameServerIssue[] = [];
+
+  if (!input.configurationAvailable) {
+    issues.push({
+      id: 'configuration-unavailable',
+      severity: 'critical',
+      title: '运行时配置不可写',
+      description: input.unavailableReason || '当前环境无法读取或更新 Ops 配置',
+    });
+  }
+  if (addresses.length === 0) {
+    issues.push({
+      id: 'empty-list',
+      severity: 'critical',
+      title: 'NameServer 地址列表为空',
+      description: '至少保留一个可连接的 NameServer 地址，避免客户端无法发现 Broker',
+    });
+  }
+  if (invalidAddresses.length > 0) {
+    issues.push({
+      id: 'invalid-addresses',
+      severity: 'warning',
+      title: '存在格式无效的 NameServer 地址',
+      description: invalidAddresses.map((address) => address.raw || '(empty)').join(', '),
+    });
+  }
+  if (duplicateAddresses.length > 0) {
+    issues.push({
+      id: 'duplicate-addresses',
+      severity: 'warning',
+      title: '存在重复 NameServer 地址',
+      description: unique(duplicateAddresses.map((address) => address.normalized)).join(', '),
+    });
+  }
+  if (current.raw && !currentAddressKnown) {
+    issues.push({
+      id: 'current-missing',
+      severity: 'critical',
+      title: '当前使用地址不在候选列表中',
+      description: `当前地址 ${input.currentNamesrv} 不在已配置列表内，更新前应先补齐或切换`,
+    });
+  }
+  if (input.selectedNamesrv && !selectedAddressValid) {
+    issues.push({
+      id: 'selected-invalid',
+      severity: 'critical',
+      title: '选中的 NameServer 地址不可用',
+      description: '请选择列表中格式有效的 NameServer 地址后再更新',
+    });
+  }
+  if (newAddress.status === 'invalid') {
+    issues.push({
+      id: 'new-address-invalid',
+      severity: 'warning',
+      title: '待新增地址格式无效',
+      description: newAddress.message,
+    });
+  }
+  if (newAddress.status === 'duplicate') {
+    issues.push({
+      id: 'new-address-duplicate',
+      severity: 'warning',
+      title: '待新增地址已存在',
+      description: newAddress.normalized,
+    });
+  }
+
+  const pendingChanges: OpsNameServerPendingChange[] = [];
+  if (
+    selectedAddressValid &&
+    current.valid &&
+    selected.normalized &&
+    selected.normalized !== current.normalized
+  ) {
+    pendingChanges.push({
+      id: 'switch-nameserver',
+      severity: 'info',
+      title: '待切换当前 NameServer',
+      description: `${current.normalized} -> ${selected.normalized}`,
+    });
+  }
+  if (newAddress.status === 'ready') {
+    pendingChanges.push({
+      id: 'add-nameserver',
+      severity: 'info',
+      title: '待新增 NameServer',
+      description: newAddress.normalized,
+    });
+  }
+  if (input.useTLS) {
+    pendingChanges.push({
+      id: 'tls-enabled',
+      severity: 'info',
+      title: 'TLS 已启用',
+      description: '请确认客户端、Broker 与 NameServer 端口均支持 TLS 握手',
+    });
+  }
+  if (input.useVIPChannel) {
+    pendingChanges.push({
+      id: 'vip-enabled',
+      severity: 'info',
+      title: 'VIP 通道已启用',
+      description: '请确认 Broker VIP 端口与防火墙策略已放通',
+    });
+  }
+
+  const hasCritical = issues.some((issue) => issue.severity === 'critical');
+  const hasWarning = issues.some((issue) => issue.severity === 'warning');
+  const readiness: OpsNameServerReadiness = hasCritical
+    ? 'blocked'
+    : hasWarning
+      ? 'warning'
+      : 'ready';
+  const recommendations = [
+    ...(invalidAddresses.length > 0 ? ['修正或删除格式无效的 NameServer 地址'] : []),
+    ...(duplicateAddresses.length > 0 ? ['删除重复地址，避免切换时误判可用性'] : []),
+    ...(!currentAddressKnown && current.raw
+      ? ['先把当前地址补回列表，或切换到列表中的有效地址']
+      : []),
+    ...(newAddress.status === 'ready' ? ['新增前确认该 endpoint 已在防火墙和 DNS 中可达'] : []),
+    ...(!input.canWrite ? ['当前账号只读，预检结果仅供排查参考'] : []),
+  ];
+  if (recommendations.length === 0) {
+    recommendations.push('当前 NameServer 配置可直接更新');
+  }
+
+  return {
+    readiness,
+    statusText:
+      readiness === 'blocked'
+        ? '需要先处理阻断项'
+        : readiness === 'warning'
+          ? '建议先处理风险项'
+          : '配置预检通过',
+    statusDescription:
+      readiness === 'blocked'
+        ? '存在会影响 Ops 写入或 NameServer 切换的阻断问题'
+        : readiness === 'warning'
+          ? '配置可继续操作，但建议先清理重复或格式问题'
+          : '当前地址列表、选中地址和待新增地址均未发现阻断风险',
+    addresses,
+    issues,
+    pendingChanges,
+    recommendations,
+    newAddress,
+    stats: {
+      configuredAddresses: addresses.length,
+      validAddresses: validAddresses.length,
+      invalidAddresses: invalidAddresses.length,
+      duplicateAddresses: unique(duplicateAddresses.map((address) => address.normalized)).length,
+      endpointCount: addresses.reduce((sum, address) => sum + address.endpoints.length, 0),
+      validEndpointCount: addresses.reduce(
+        (sum, address) => sum + address.endpoints.filter((endpoint) => endpoint.valid).length,
+        0,
+      ),
+    },
+    selectedAddressValid,
+    currentAddressKnown,
+  };
+}


### PR DESCRIPTION
## What is the purpose of the change

Add a client-side preflight view on the Studio Ops page so operators can verify NameServer settings before updating runtime configuration. The panel validates saved NameServer address chains, highlights invalid or duplicated endpoints, confirms whether the current and selected NameServer are usable, and previews pending NameServer, TLS, and VIP channel changes.

It also blocks obviously invalid or duplicate NameServer additions before sending them to the API while keeping backend validation as the final authority.

## Brief changelog

- Added NameServer endpoint/address parsing and Ops preflight analysis helpers.
- Added an Ops page preflight panel with summary, issues, pending changes, recommendations, and address diagnostics.
- Blocked invalid or duplicate NameServer additions on the client side.
- Added unit and page tests for parsing, readiness, pending changes, unavailable/read-only state, and duplicate-add blocking.

## Verifying this change

- `npm run test -- src/utils/opsNameServerPreflight.test.ts src/pages/studio/__tests__/Ops.test.tsx`
- `git diff --check`
- `npm run lint -- src/pages/studio/Ops.tsx src/pages/studio/__tests__/Ops.test.tsx src/utils/opsNameServerPreflight.ts src/utils/opsNameServerPreflight.test.ts`
- `npm run build`