### PR TITLE
feat(cluster): export k8s certificate inventory

### DIFF
--- a/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
@@ -192,4 +192,42 @@ describe('K8sCertsPage', () => {
     await waitFor(() => expect(deleteK8sCert).toHaveBeenCalledWith(1));
     await waitFor(() => expect(screen.queryByText('rocketmq-prod-tls')).not.toBeInTheDocument());
   });
+
+  it('exports the filtered certificate inventory without PEM content', async () => {
+    const createObjectURL = vi.fn(() => 'blob:cert-export');
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', { writable: true, value: createObjectURL });
+    Object.defineProperty(URL, 'revokeObjectURL', { writable: true, value: revokeObjectURL });
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    let exportedBlob: Blob | undefined;
+    vi.mocked(URL.createObjectURL).mockImplementation((blob) => {
+      exportedBlob = blob as Blob;
+      return 'blob:cert-export';
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText('rocketmq-prod-tls');
+
+    await user.click(screen.getByRole('button', { name: /导出/ }));
+
+    await waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(1));
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:cert-export');
+
+    expect(exportedBlob).toBeDefined();
+    const csv = await exportedBlob!.text();
+    expect(csv).toContain('"K8s ID"');
+    expect(csv).toContain('"rocketmq-prod-tls"');
+    expect(csv).toContain('"rocketmq-staging-tls"');
+    expect(csv).toContain('"broker.prod.example.com"');
+    expect(csv).toContain('"365"');
+    expect(csv).toContain('metadata-only-tls');
+    expect(csv).not.toContain('certPem');
+    expect(csv).not.toContain('keyPem');
+    expect(
+      document.querySelector('a[download^="rocketmq-k8s-certificates-"]'),
+    ).not.toBeInTheDocument();
+    clickSpy.mockRestore();
+  });
 });

--- a/web/src/pages/cluster/certs.tsx
+++ b/web/src/pages/cluster/certs.tsx
@@ -31,7 +31,7 @@ import {
   Popconfirm,
   message,
 } from 'antd';
-import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
+import { PlusOutlined, DeleteOutlined, DownloadOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import PageHeader from '../../components/PageHeader';
 import InfoBanner from '../../components/InfoBanner';
@@ -39,6 +39,7 @@ import type { K8sCertInfo } from '../../api/cluster';
 import { listK8sCerts, createK8sCert, deleteK8sCert } from '../../services/clusterService';
 import { formatDateTime } from '../../utils/format';
 import { tableScrollX } from '../../utils/table';
+import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 
 const { Text } = Typography;
 
@@ -53,6 +54,32 @@ interface CreateCertFormValues {
   keyPem?: string;
 }
 
+interface K8sCertExportRow {
+  id: number;
+  k8sId: string;
+  cluster: string;
+  type: string | null;
+  issuer: string | null;
+  notBefore: string | null;
+  notAfter: string | null;
+  daysRemaining: number;
+  status: string | null;
+  san: string;
+}
+
+const K8S_CERT_EXPORT_COLUMNS: CsvColumn<K8sCertExportRow>[] = [
+  { header: 'ID', value: (row) => row.id },
+  { header: 'K8s ID', value: (row) => row.k8sId },
+  { header: 'Cluster', value: (row) => row.cluster },
+  { header: 'Type', value: (row) => row.type ?? '' },
+  { header: 'Issuer', value: (row) => row.issuer ?? '' },
+  { header: 'Not Before', value: (row) => row.notBefore ?? '' },
+  { header: 'Not After', value: (row) => row.notAfter ?? '' },
+  { header: 'Days Remaining', value: (row) => row.daysRemaining },
+  { header: 'Status', value: (row) => row.status ?? '' },
+  { header: 'SANs', value: (row) => row.san },
+];
+
 const K8sCertsPage = () => {
   const [certs, setCerts] = useState<K8sCertInfo[]>([]);
   const [loading, setLoading] = useState(true);
@@ -61,6 +88,7 @@ const K8sCertsPage = () => {
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [creating, setCreating] = useState(false);
   const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [exporting, setExporting] = useState(false);
   const [createForm] = Form.useForm<CreateCertFormValues>();
 
   useEffect(() => {
@@ -128,6 +156,33 @@ const K8sCertsPage = () => {
       message.error(getErrorMessage(error));
     } finally {
       setDeletingId(null);
+    }
+  };
+
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      const rows: K8sCertExportRow[] = filteredCerts.map((cert) => ({
+        id: cert.id,
+        k8sId: cert.k8sId,
+        cluster: cert.cluster,
+        type: cert.type,
+        issuer: cert.issuer,
+        notBefore: cert.notBefore,
+        notAfter: cert.notAfter,
+        daysRemaining: cert.daysRemaining,
+        status: cert.status,
+        san: (cert.san ?? []).join(';'),
+      }));
+      downloadCsv(
+        `rocketmq-k8s-certificates-${new Date().toISOString().slice(0, 10)}.csv`,
+        buildCsv(K8S_CERT_EXPORT_COLUMNS, rows),
+      );
+      message.success(`已导出 ${rows.length} 个证书`);
+    } catch {
+      message.error('导出证书列表失败，请稍后重试');
+    } finally {
+      setExporting(false);
     }
   };
 
@@ -277,9 +332,19 @@ const K8sCertsPage = () => {
             ]}
           />
         </Space>
-        <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>
-          新增证书
-        </Button>
+        <Space>
+          <Button
+            icon={<DownloadOutlined />}
+            loading={exporting}
+            disabled={filteredCerts.length === 0}
+            onClick={() => void handleExport()}
+          >
+            导出
+          </Button>
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>
+            新增证书
+          </Button>
+        </Space>
       </Flex>
       <Card styles={{ body: { padding: 0 } }}>
         <Table


### PR DESCRIPTION
## What is the purpose of the change

The K8s certificate page tracks certificate expiry — issuer, validity window, days remaining, and status — but the inventory cannot be exported. Operators preparing a security review, compliance audit, or certificate renewal plan currently have to copy certificate rows manually.

Certificate expiry reporting is a routine compliance requirement: auditors and security teams ask for "all certificates and their expiry dates" as a standard deliverable.

This change adds CSV export to the certificate page, exporting the inventory matching the current search/type filter. Details: #4155

## Brief changelog

**What it does**

- Adds an Export button to the certificate toolbar.
- Exports the inventory matching the **current search/type filter**, not just the visible page.
- Exports the audit-relevant fields: ID, k8s ID, cluster, type, issuer, notBefore, notAfter, days remaining, status, and SANs.
- Does **not** export certificate PEM content or private key PEM — those are secrets and must not appear in exports.
- Uses the shared `buildCsv`/`downloadCsv` helpers, so cells are quoted and spreadsheet formula injection is prevented.
- Shows a loading state while the export runs and surfaces errors.

**Deliberately no backend change**

The existing list endpoint already returns the complete inventory with all audit-relevant fields, so the export reuses it instead of adding a duplicate server-side export endpoint.

**Tests**

- `K8sCertsPage.test.tsx`: regression coverage that the export button downloads a CSV containing all filtered certificates with their expiry metadata, and that PEM fields are absent from the output.

## Verifying this change

- `npm test -- K8sCertsPage.test.tsx --run` in `web` — 8 tests passed
- `npm run lint -- --quiet` in `web` — 0 errors
- `npm run build` in `web` — passed (Vite)
- `git diff --check` — passed

The GitHub Actions status is not being described as green here; the checks above are local validation on this branch.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change. This PR addresses only #4155.
- [x] The pull request title follows the change type and scope.
- [x] This description covers what the PR does, how, and why.
- [x] A regression test verifies the export downloads a CSV with the expected fields and without PEM content.
- [x] Frontend tests, lint, and build were run locally on this branch.
- [ ] Apache Individual Contributor License Agreement (not required for this change size).

