### PR TITLE
[ISSUE #4157] fix(alert): bound native aggregation windows

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.alert;
 
+import org.apache.rocketmq.studio.cluster.metrics.AlertingProperties;
 import org.apache.rocketmq.studio.cluster.metrics.MetricProfileService;
 import org.apache.rocketmq.studio.cluster.metrics.SemanticMetric;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -38,6 +39,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
@@ -61,6 +63,7 @@ public class AlertService {
     private final AlertRuleAssetService alertRuleAssetService;
     private final OperationAuditService operationAuditService;
     private final MetricProfileService metricProfileService;
+    private final AlertingProperties alertingProperties;
 
 
     public List<AlertRuleVO> listRules() {
@@ -169,6 +172,7 @@ public class AlertService {
         }
         rule.setName(rule.getName().trim());
         NativeAlertRulePolicy.validate(rule);
+        validateAggregationWindow(rule);
         rejectDuplicateSemanticRule(rule, null);
         log.info("Creating alert rule: {}", rule.getName());
         AlertRuleVO saved = saveNewRule(rule);
@@ -199,6 +203,7 @@ public class AlertService {
         log.info("Updating alert rule: {}", id);
         validateRuleId(id);
         NativeAlertRulePolicy.validate(rule);
+        validateAggregationWindow(rule);
         rejectDuplicateSemanticRule(rule, id);
         if (!replaceRuleWithoutDuplicate(rule)) {
             throw ruleNotFound(id);
@@ -223,6 +228,20 @@ public class AlertService {
 
     private AlertDomain resolveDomain(AlertRuleVO rule) {
         return rule.getDomain() == null ? AlertDomain.BUSINESS : rule.getDomain();
+    }
+
+    private void validateAggregationWindow(AlertRuleVO rule) {
+        if (!NativeAlertRulePolicy.isNativeMetric(rule.getMetric()) || rule.getWindowSeconds() <= 0) {
+            return;
+        }
+        Duration retention = Duration.parse(alertingProperties.getSnapshotRetention());
+        if (retention.isZero() || retention.isNegative()) {
+            return;
+        }
+        if (Duration.ofSeconds(rule.getWindowSeconds()).compareTo(retention) > 0) {
+            throw new BusinessException(400, "Native alert windowSeconds must not exceed snapshot retention "
+                    + retention);
+        }
     }
 
     private void rejectDuplicateSemanticRule(AlertRuleVO rule, Long excludedId) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleSnapshotRetentionTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleSnapshotRetentionTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.cluster.metrics.AlertingProperties;
+import org.apache.rocketmq.studio.cluster.metrics.MetricProfileService;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AlertRuleSnapshotRetentionTest {
+
+    @Test
+    void rejectsCreateWhenNativeAggregationWindowExceedsSnapshotRetention() {
+        AlertRepository repository = mock(AlertRepository.class);
+        when(repository.insertRule(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        AlertService service = alertService("PT24H", repository);
+
+        assertThatThrownBy(() -> service.createRule(nativeRule(null, 86_401)))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("snapshot retention")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+
+        verify(repository, never()).insertRule(any());
+    }
+
+    @Test
+    void rejectsUpdateWhenNativeAggregationWindowExceedsSnapshotRetention() {
+        AlertRepository repository = mock(AlertRepository.class);
+        when(repository.replaceRule(any())).thenReturn(true);
+        AlertService service = alertService("PT24H", repository);
+
+        assertThatThrownBy(() -> service.updateRule(nativeRule(1L, 86_401)))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("snapshot retention")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+
+        verify(repository, never()).replaceRule(any());
+    }
+
+    @Test
+    void acceptsNativeAggregationWindowEqualToSnapshotRetention() {
+        AlertRepository repository = acceptingRepository();
+        AlertService service = alertService("PT1H", repository);
+
+        assertThatCode(() -> service.createRule(nativeRule(null, 3_600))).doesNotThrowAnyException();
+
+        verify(repository).insertRule(any());
+    }
+
+    @Test
+    void acceptsSingleSampleNativeRuleWithPositiveSnapshotRetention() {
+        AlertRepository repository = acceptingRepository();
+        AlertService service = alertService("PT1H", repository);
+
+        assertThatCode(() -> service.createRule(nativeRule(null, 0))).doesNotThrowAnyException();
+
+        verify(repository).insertRule(any());
+    }
+
+    @Test
+    void leavesNonNativePrometheusRuleIndependentOfSnapshotRetention() {
+        AlertRepository repository = acceptingRepository();
+        AlertRuleVO rule = nativeRule(null, 7_200);
+        rule.setMetric("rocketmq_consumer_lag_messages");
+        rule.setInstanceId(null);
+        rule.setConsumerGroup(null);
+        AlertService service = alertService("PT1H", repository);
+
+        assertThatCode(() -> service.createRule(rule)).doesNotThrowAnyException();
+
+        verify(repository).insertRule(rule);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"PT0S", "-PT1H"})
+    void acceptsNativeAggregationWindowWhenSnapshotCleanupIsDisabled(String retention) {
+        AlertRepository repository = acceptingRepository();
+        AlertService service = alertService(retention, repository);
+
+        assertThatCode(() -> service.createRule(nativeRule(null, 172_800))).doesNotThrowAnyException();
+
+        verify(repository).insertRule(any());
+    }
+
+    private static AlertRuleVO nativeRule(Long id, int windowSeconds) {
+        return AlertRuleVO.builder()
+                .id(id)
+                .domain(AlertDomain.BUSINESS)
+                .name("Consumer lag average")
+                .metric("consumer.lag.total")
+                .operator(">")
+                .threshold(1000)
+                .duration("5m")
+                .aggregation("AVG")
+                .windowSeconds(windowSeconds)
+                .instanceId("instance-a")
+                .consumerGroup("group-a")
+                .build();
+    }
+
+    private static AlertRepository acceptingRepository() {
+        AlertRepository repository = mock(AlertRepository.class);
+        when(repository.insertRule(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        return repository;
+    }
+
+    private static AlertService alertService(String retention, AlertRepository repository) {
+        AlertingProperties properties = new AlertingProperties();
+        properties.setSnapshotRetention(retention);
+        return new AlertService(repository, mock(AlertStateRepository.class), new AlertRuleAssetService(),
+                mock(OperationAuditService.class), mock(MetricProfileService.class), properties);
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceDefaultRulesTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceDefaultRulesTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.cluster.metrics.MetricProfileService;
+import org.apache.rocketmq.studio.cluster.metrics.AlertingProperties;
 import org.apache.rocketmq.studio.cluster.metrics.PrometheusProperties;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -42,7 +43,7 @@ class AlertServiceDefaultRulesTest {
 
         AlertService service = new AlertService(repository, Mockito.mock(AlertStateRepository.class),
                 new AlertRuleAssetService(), Mockito.mock(OperationAuditService.class),
-                new MetricProfileService(new PrometheusProperties()));
+                new MetricProfileService(new PrometheusProperties()), new AlertingProperties());
         String yaml = service.exportPrometheusRulesYaml();
 
         int ruleCount = countRules(yaml);
@@ -56,7 +57,7 @@ class AlertServiceDefaultRulesTest {
 
         AlertService service = new AlertService(repository, Mockito.mock(AlertStateRepository.class),
                 new AlertRuleAssetService(), Mockito.mock(OperationAuditService.class),
-                new MetricProfileService(new PrometheusProperties()));
+                new MetricProfileService(new PrometheusProperties()), new AlertingProperties());
         String yaml = service.exportPrometheusRulesYaml();
 
         assertTrue(yaml.contains("rocketmq-broker.rules"));

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -24,6 +24,7 @@ import org.apache.rocketmq.studio.common.domain.enums.AlertLevel;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.cluster.metrics.MetricProfileService;
+import org.apache.rocketmq.studio.cluster.metrics.AlertingProperties;
 import org.apache.rocketmq.studio.cluster.metrics.PrometheusProperties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,7 +67,8 @@ class AlertServiceTest {
     @org.junit.jupiter.api.BeforeEach
     void setUpTest() {
         alertService = new AlertService(alertRepository, alertStateRepository, new AlertRuleAssetService(),
-                operationAuditService, new MetricProfileService(new PrometheusProperties()));
+                operationAuditService, new MetricProfileService(new PrometheusProperties()),
+                new AlertingProperties());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- inject the existing alerting retention configuration into `AlertService`
- reject native alert aggregation windows longer than a positive snapshot retention
- apply the check before repository mutation on both create and update paths
- preserve equal-boundary, single-sample, non-native Prometheus, and cleanup-disabled behavior

## Scope

The validation applies only to Studio-native metrics with `windowSeconds > 0`. A zero or negative snapshot retention retains the current cleanup-disabled semantics and does not impose a cap. Import already delegates to the same create path. Snapshot collection, cleanup, aggregation math, and existing-rule migration are unchanged.

## TDD evidence

Before implementation, the create and update regressions completed repository writes without rejecting a 24-hour-plus-one-second window under the default 24-hour retention. After the minimal Service validation, both reject with business code 400 before persistence.

## Verification

- `mvn -B -ntp -f server/pom.xml -Dtest=AlertRuleSnapshotRetentionTest,AlertServiceTest,AlertServiceDefaultRulesTest,NativeAlertRulePolicyTest,AlertRuleTransferServiceTest,AlertRuleControllerTest,ClusterAlertRuleControllerTest test` — 129 tests passed
- `mvn -B -ntp -f server/pom.xml -Dtest=StudioApplicationTest test` — 2 tests passed
- `mvn -B -ntp -f server/pom.xml -DskipTests package`
- Checkstyle — 0 violations
- `git diff --check`

Closes #4157