### PR TITLE
fix(acl): preserve Tencent role when deleting rule

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentAclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentAclService.java
@@ -102,6 +102,10 @@ public class TencentAclService {
                 if (role == null || !StringUtils.hasText(role.getRoleName())) {
                     continue;
                 }
+                if (!Boolean.TRUE.equals(role.getPermRead())
+                        && !Boolean.TRUE.equals(role.getPermWrite())) {
+                    continue;
+                }
                 if (requestedPrincipal != null
                         && !requestedPrincipal.equals(role.getRoleName())) {
                     continue;
@@ -242,11 +246,13 @@ public class TencentAclService {
     public void deleteRule(String instanceId, String principal) {
         Context context = resolve(instanceId);
         String roleName = requireRoleName(principal, "ACL principal");
-        DeleteRoleRequest request = new DeleteRoleRequest();
+        ModifyRoleRequest request = new ModifyRoleRequest();
         request.setInstanceId(context.cloudInstanceId());
         request.setRole(roleName);
+        request.setPermRead(false);
+        request.setPermWrite(false);
         clientFactory.call(context.credentialId(), context.regionId(),
-                client -> client.DeleteRole(request));
+                client -> client.ModifyRole(request));
     }
 
     private static String requireRulePrincipal(AclRuleVO rule) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentAclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentAclServiceTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.provider.tencent;
 
 import com.tencentcloudapi.trocket.v20230308.TrocketClient;
+import com.tencentcloudapi.trocket.v20230308.models.DeleteRoleRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeRoleListRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeRoleListResponse;
 import com.tencentcloudapi.trocket.v20230308.models.ModifyRoleRequest;
@@ -43,6 +44,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -142,6 +144,20 @@ class TencentAclServiceTest {
     }
 
     @Test
+    void listRulesShouldSkipRolesWithoutReadOrWritePermissionTest() throws Exception {
+        RoleItem permissionless = role("disabled-role");
+        permissionless.setPermRead(false);
+        RoleItem readable = role("reader-role");
+        DescribeRoleListResponse response = new DescribeRoleListResponse();
+        response.setData(new RoleItem[]{permissionless, readable});
+        when(client.DescribeRoleList(any())).thenReturn(response);
+
+        assertThat(service.listRules(INSTANCE_ID, null))
+                .extracting(AclRuleVO::getPrincipal)
+                .containsExactly("reader-role");
+    }
+
+    @Test
     void updateUserShouldFindRolePastLegacyTenThousandTencentRoleCapTest() throws Exception {
         when(client.DescribeRoleList(any())).thenAnswer(invocation -> {
             DescribeRoleListRequest request = invocation.getArgument(0);
@@ -237,6 +253,32 @@ class TencentAclServiceTest {
         assertThat(request.getPermRead()).isTrue();
         assertThat(request.getPermWrite()).isTrue();
         assertThat(created.getActions()).containsExactly("PUB", "SUB");
+    }
+
+    @Test
+    void deleteRuleShouldDisablePermissionsWithoutDeletingRoleTest() throws Exception {
+        service.deleteRule(INSTANCE_ID, "  reader-role  ");
+
+        ArgumentCaptor<ModifyRoleRequest> requestCaptor = ArgumentCaptor.forClass(ModifyRoleRequest.class);
+        verify(client).ModifyRole(requestCaptor.capture());
+        ModifyRoleRequest request = requestCaptor.getValue();
+        assertThat(request.getInstanceId()).isEqualTo(CLOUD_INSTANCE_ID);
+        assertThat(request.getRole()).isEqualTo("reader-role");
+        assertThat(request.getPermRead()).isFalse();
+        assertThat(request.getPermWrite()).isFalse();
+        verify(client, never()).DeleteRole(any());
+    }
+
+    @Test
+    void deleteUserShouldDeleteRoleTest() throws Exception {
+        service.deleteUser(INSTANCE_ID, "  reader-role  ");
+
+        ArgumentCaptor<DeleteRoleRequest> requestCaptor = ArgumentCaptor.forClass(DeleteRoleRequest.class);
+        verify(client).DeleteRole(requestCaptor.capture());
+        DeleteRoleRequest request = requestCaptor.getValue();
+        assertThat(request.getInstanceId()).isEqualTo(CLOUD_INSTANCE_ID);
+        assertThat(request.getRole()).isEqualTo("reader-role");
+        verify(client, never()).ModifyRole(any());
     }
 
     @Test


### PR DESCRIPTION
Fixes #4161.

## Problem

Studio maps each Tencent Cloud RocketMQ role to both an ACL user and a cluster-wide ACL rule. The two resources have separate delete actions, but the rule deletion path called Tencent Cloud `DeleteRole`, exactly like user deletion. Deleting a rule therefore also removed the role account and its access credentials.

Roles with both `PermRead` and `PermWrite` disabled were also returned as ACL rules with an empty action list.

## Changes

- Change `TencentAclService.deleteRule` to call `ModifyRole` with `PermRead=false` and `PermWrite=false`.
- Exclude permissionless roles from `listRules`, while leaving them visible in the ACL user list.
- Keep explicit ACL user deletion on `DeleteRole`.
- Add regression coverage for all three behavior boundaries.

## Testing

The two new behavior tests failed against the base commit:

- rule deletion invoked `DeleteRole` instead of `ModifyRole`;
- the rule list included a role with neither permission.

After the fix:

```text
mvn -B test -Dtest='TencentAclServiceTest,AclServiceTest'
Tests run: 79, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
Checkstyle violations: 0
```

Tests were run with Java 21.

## Compatibility

This is limited to the Tencent ACL provider. It does not change REST contracts, persistence, frontend code, or other vendors. Existing Tencent role accounts remain intact when their mapped rule is deleted; the separate user deletion action remains destructive by design.
