### PR TITLE
fix(cluster): discard superseded broker config preview responses

### DIFF
--- a/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
@@ -23,6 +23,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   BrokerConfigDiffResult,
+  ClusterConfigPreviewResult,
   ClusterInfo,
   ClusterProbeResult,
   NameServerConfigDiffResult,
@@ -720,6 +721,75 @@ describe('Cluster page', () => {
     });
 
     expect(dialog).toHaveClass('ant-zoom-leave');
+  });
+
+  it('discards a superseded broker config preview response', async () => {
+    const stalePreview = deferred<ClusterConfigPreviewResult>();
+    const latestPreview = deferred<ClusterConfigPreviewResult>();
+    clusterServiceMocks.previewClusterConfig
+      .mockReturnValueOnce(stalePreview.promise)
+      .mockReturnValueOnce(latestPreview.promise);
+    renderWithProviders(<ClusterPage />);
+
+    const openConfigModal = async (queueNums: string) => {
+      const brokerRow = await screen.findByRole('row', { name: /10\.101\.2\.11:10911/ });
+      fireEvent.click(within(brokerRow).getByRole('button', { name: /^配\s*置$/ }));
+      const dialog = await screen.findByRole('dialog', { name: /配置 - rocketmq-prod/ });
+      const user = userEvent.setup();
+      const writeQueuesInput = within(dialog).getByLabelText('写队列数');
+      await user.clear(writeQueuesInput);
+      await user.type(writeQueuesInput, queueNums);
+      await waitFor(() =>
+        expect(within(dialog).getByRole('button', { name: /预\s*览/ })).toBeEnabled(),
+      );
+      fireEvent.click(within(dialog).getByRole('button', { name: /预\s*览/ }));
+      return dialog;
+    };
+
+    const staleDialog = await openConfigModal('16');
+    await waitFor(() => expect(clusterServiceMocks.previewClusterConfig).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(within(staleDialog).getByRole('button', { name: /^Cancel$/ }));
+    await waitFor(() => expect(staleDialog).toHaveClass('ant-zoom-leave'));
+
+    const latestDialog = await openConfigModal('24');
+    await waitFor(() => expect(clusterServiceMocks.previewClusterConfig).toHaveBeenCalledTimes(2));
+
+    const buildPreview = (queueNums: string): ClusterConfigPreviewResult => {
+      const cluster = buildCluster();
+      return {
+        cluster,
+        currentConfig: cluster.config,
+        proposedConfig: { ...cluster.config, writeQueueNums: Number(queueNums) },
+        targetBrokers: [{ name: 'rocketmq-prod-0', address: '10.101.2.11:10911' }],
+        brokerProperties: { defaultTopicQueueNums: queueNums },
+        changes: [
+          {
+            field: 'writeQueueNums',
+            currentValue: '8',
+            proposedValue: queueNums,
+            brokerProperty: 'defaultTopicQueueNums',
+          },
+        ],
+        changed: true,
+      };
+    };
+
+    await act(async () => {
+      latestPreview.resolve(buildPreview('24'));
+      await latestPreview.promise;
+    });
+    await waitFor(() =>
+      expect(within(latestDialog).getByText('defaultTopicQueueNums=24')).toBeInTheDocument(),
+    );
+
+    await act(async () => {
+      stalePreview.resolve(buildPreview('16'));
+      await stalePreview.promise;
+    });
+
+    expect(within(latestDialog).getByText('defaultTopicQueueNums=24')).toBeInTheDocument();
+    expect(within(latestDialog).queryByText('defaultTopicQueueNums=16')).not.toBeInTheDocument();
   });
 
   it('keeps the requested broker config diff when a slower response finishes last', async () => {

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -172,6 +172,7 @@ const ClusterPage = () => {
   const nsConfigDiffRequestRef = useRef(0);
   const brokerConfigDiffRequestRef = useRef(0);
   const connectionTestRequestRef = useRef(0);
+  const configPreviewRequestRef = useRef(0);
 
   const loadRegistryClusters = useCallback(async () => {
     const requestId = ++registryClustersRequestRef.current;
@@ -613,6 +614,7 @@ const ClusterPage = () => {
   const handleConfigOpen = (cluster: ClusterInfo) => {
     const cfg: ClusterConfig = cluster.config ?? ({} as ClusterConfig);
     setSelectedCluster(cluster);
+    configPreviewRequestRef.current += 1;
     setConfigPreview(null);
     setConfigPreviewLoading(false);
     setConfigSubmitting(false);
@@ -653,16 +655,21 @@ const ClusterPage = () => {
     const request = buildConfigUpdateRequest(values);
     if (!request) return;
 
+    const requestId = ++configPreviewRequestRef.current;
     setConfigPreviewLoading(true);
     try {
       const preview = await previewClusterConfig(request);
+      if (requestId !== configPreviewRequestRef.current) return;
       setConfigPreview(preview);
       message.success(t('cluster.configPreviewGenerated'));
     } catch {
+      if (requestId !== configPreviewRequestRef.current) return;
       setConfigPreview(null);
       message.error(t('cluster.configPreviewFailed'));
     } finally {
-      setConfigPreviewLoading(false);
+      if (requestId === configPreviewRequestRef.current) {
+        setConfigPreviewLoading(false);
+      }
     }
   };
 
@@ -1308,6 +1315,7 @@ const ClusterPage = () => {
             title={t('cluster.configTitle', { name: selectedCluster.name })}
             open={configModalOpen}
             onCancel={() => {
+              configPreviewRequestRef.current += 1;
               setConfigModalOpen(false);
               setConfigPreview(null);
             }}
@@ -1324,7 +1332,14 @@ const ClusterPage = () => {
                 {t('cluster.configPreview')}
               </Button>
             </Space>
-            <Form form={configForm} layout="vertical" onValuesChange={() => setConfigPreview(null)}>
+            <Form
+              form={configForm}
+              layout="vertical"
+              onValuesChange={() => {
+                configPreviewRequestRef.current += 1;
+                setConfigPreview(null);
+              }}
+            >
               <Form.Item label={t('cluster.flushDiskType')} name="flushDiskType">
                 <Radio.Group>
                   <Radio value="SYNC_FLUSH">{t('cluster.syncFlush')}</Radio>


### PR DESCRIPTION
Fixes #4165.

## Problem / Evidence

On the Cluster page (Broker 管理), the broker config preview panel renders whichever `previewClusterConfig` response arrives last. `handleConfigPreview` (`web/src/pages/cluster/index.tsx`, base `0a596661`, lines 648-669) awaits the request and then unconditionally commits the result — no request-generation guard — while every comparable async path in the same file (`nsConfigDiffRequestRef`, `brokerConfigDiffRequestRef`, `connectionTestRequestRef`, registry lists) is guarded.

Reproduction: open 配置 for a broker → change a value → 预览 (response A slow) → Cancel → reopen 配置 → change values → 预览 (response B arrives) → slow response A resolves last → the panel shows A's diff while the form holds different values, and A's success toast fires while B's loading state is left stuck.

A new regression test (`discards a superseded broker config preview response`) fails on the unmodified base: after the stale response resolves, `getByText('defaultTopicQueueNums=24')` fails because the panel was overwritten with the stale preview's `defaultTopicQueueNums=16`.

## Root cause / Fix

Root cause: the preview async handler lacks the request-generation guard used by its sibling flows.

Fix: add `configPreviewRequestRef`; bump it at the start of `handleConfigPreview`, and only commit state/toast/loading when the generation is still current. Invalidate the generation when the config dialog opens (`handleConfigOpen`), when it closes (`onCancel`), and when a form value changes (`onValuesChange`, which already cleared the panel). Mirrors the twin guard pattern from the #3292 fix.

## Priority & scoring

- Impact 30/40 (misleading safety-check panel before a cluster-wide broker config apply) + breadth 13/20 (single dialog, but the same file's identical races were each accepted as bugs) + reproducibility 18/20 (deterministic deferred-promise regression) + maintainability value 14/20 (completes the file's guard pattern) = **PRIORITY 75** ≥ 70.
- Mechanical pattern port with a red→green regression → **FIX_CONFIDENCE 95** ≥ 80.

## Tests

- Red: `npx vitest run src/pages/cluster/__tests__/ClusterPage.test.tsx -t "discards a superseded broker config preview response"` on base → `Tests 1 failed | 25 skipped` (`Unable to find an element with the text: defaultTopicQueueNums=24` — stale preview overwrote the latest one).
- Green: same command after the fix → `Tests 1 passed`.
- Module suite: `npx vitest run src/pages/cluster/__tests__/ClusterPage.test.tsx` → `Test Files 1 passed (1)`, `Tests 26 passed (26)` (25 pre-existing + 1 new).
- Full web suite: `npx vitest run` → 945 tests; first run `2 failed | 943 passed` (AclPage ×1, ConsumerPage ×2 — none of these files is touched by this change); reruns of those two files in isolation with the fix applied → `Tests 54 passed (54)`. This matches the documented load-flakiness of those files under full-suite parallelism (see verification comment for the base-branch stash check).
- `npx tsc --noEmit` clean; `npx eslint` on both changed files clean; `npm run build` succeeds (`✓ built in 9.81s`).

## Risk

Low. The change only adds a generation guard around an existing async handler and bumps the generation at three existing invalidation points; no API, data, or visual changes. The one behavioral difference is intended: responses from superseded preview requests no longer write state or toast. The submit path (`handleConfigSubmit`) is intentionally untouched — its result is guarded by `confirmLoading` and revalidates on the server.
