### PR TITLE
fix(message): preserve Unicode property characters

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/MessagePropertyDisplay.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/MessagePropertyDisplay.java
@@ -25,10 +25,11 @@ import java.util.Map;
 
 /**
  * Shared rendering limits for message property maps, used by the message explorer and the DLQ
- * drawer so both apply the same {@value #MAX_PROPERTIES}-entry / {@value #MAX_PROPERTY_VALUE_CHARS}-char
- * caps instead of duplicating the logic. {@link #userProperties} additionally drops the broker-set
- * system keys ({@link MessageConst#STRING_HASH_SET}) so a view labelled "user properties" is not
- * crowded out by system entries once the cap and alphabetical ordering are applied.
+ * drawer so both apply the same {@value #MAX_PROPERTIES}-entry /
+ * {@value #MAX_PROPERTY_VALUE_CHARS}-code-point caps instead of duplicating the logic.
+ * {@link #userProperties} additionally drops the broker-set system keys
+ * ({@link MessageConst#STRING_HASH_SET}) so a view labelled "user properties" is not crowded out
+ * by system entries once the cap and alphabetical ordering are applied.
  */
 public final class MessagePropertyDisplay {
 
@@ -65,16 +66,22 @@ public final class MessagePropertyDisplay {
         return limited;
     }
 
-    /** True when any value exceeds {@link #MAX_PROPERTY_VALUE_CHARS} and would be abbreviated. */
+    /** True when any value exceeds {@link #MAX_PROPERTY_VALUE_CHARS} Unicode code points. */
     public static boolean hasOversizedProperty(Map<String, String> properties) {
         return properties != null && properties.values().stream()
-                .anyMatch(value -> value != null && value.length() > MAX_PROPERTY_VALUE_CHARS);
+                .anyMatch(value -> value != null
+                        && value.codePointCount(0, value.length()) > MAX_PROPERTY_VALUE_CHARS);
     }
 
     private static String abbreviate(String value) {
-        if (value == null || value.length() <= MAX_PROPERTY_VALUE_CHARS) {
+        if (value == null) {
             return value;
         }
-        return value.substring(0, MAX_PROPERTY_VALUE_CHARS) + "...";
+        int codePointCount = value.codePointCount(0, value.length());
+        if (codePointCount <= MAX_PROPERTY_VALUE_CHARS) {
+            return value;
+        }
+        int endIndex = value.offsetByCodePoints(0, MAX_PROPERTY_VALUE_CHARS);
+        return value.substring(0, endIndex) + "...";
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/MessagePropertyDisplayTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/MessagePropertyDisplayTest.java
@@ -59,9 +59,31 @@ class MessagePropertyDisplayTest {
     }
 
     @Test
+    void limitPropertiesShouldNotSplitSupplementaryUnicodeCharactersTest() {
+        String emoji = "\uD83D\uDE80";
+        String value = "x".repeat(1023) + emoji + "tail";
+
+        Map<String, String> limited = MessagePropertyDisplay.limitProperties(Map.of("mixed", value));
+
+        assertThat(limited.get("mixed")).isEqualTo("x".repeat(1023) + emoji + "...");
+    }
+
+    @Test
     void hasOversizedPropertyShouldDetectLongValuesTest() {
         assertThat(MessagePropertyDisplay.hasOversizedProperty(Map.of("big", "x".repeat(1500)))).isTrue();
         assertThat(MessagePropertyDisplay.hasOversizedProperty(Map.of("k", "short"))).isFalse();
         assertThat(MessagePropertyDisplay.hasOversizedProperty(null)).isFalse();
+    }
+
+    @Test
+    void propertyLimitShouldCountUnicodeCodePointsTest() {
+        String emoji = "\uD83D\uDE80";
+        String exact = emoji.repeat(MessagePropertyDisplay.MAX_PROPERTY_VALUE_CHARS);
+        String oversized = exact + emoji;
+
+        assertThat(MessagePropertyDisplay.hasOversizedProperty(Map.of("exact", exact))).isFalse();
+        assertThat(MessagePropertyDisplay.limitProperties(Map.of("exact", exact)).get("exact"))
+                .isEqualTo(exact);
+        assertThat(MessagePropertyDisplay.hasOversizedProperty(Map.of("oversized", oversized))).isTrue();
     }
 }


### PR DESCRIPTION
Fixes #4167.

## Problem

`MessagePropertyDisplay` capped property values with UTF-16 `String.length()` and `substring(0, 1024)`. A supplementary Unicode character uses a surrogate pair, so a truncation boundary between the two code units produced an unpaired surrogate. The same utility feeds both regular message details and DLQ property output.

The UTF-16 length check also treated each supplementary character as two displayed characters: a value containing exactly 1024 emoji was incorrectly marked oversized and truncated.

## Changes

- Count the property value limit in Unicode code points.
- Compute the truncation index with `offsetByCodePoints`, preserving complete surrogate pairs.
- Use the same code-point rule in `hasOversizedProperty` so the value and truncation metadata cannot disagree.
- Keep the existing 1024-character limit and `...` suffix unchanged for ASCII/BMP text.

## TDD evidence

Before implementation, the new regressions showed both failures:

- 1023 ASCII characters followed by an emoji were cut into an isolated high surrogate;
- exactly 1024 emoji were incorrectly reported as oversized.

After the fix:

```text
mvn -B test -Dtest='MessagePropertyDisplayTest,RocketMQMessageProviderTest,RocketMQDLQProviderTest'
Tests run: 82, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
Checkstyle violations: 0
```

Tests were run with Java 21.

## Compatibility

No REST contract, persistence, dependency, or frontend changes. ASCII and BMP property values retain their existing behavior; supplementary Unicode values now use user-visible code-point counting and remain well formed after truncation.
