### PR TITLE
fix(consumer): filter groups by subscription mode on the server

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupController.java
@@ -56,9 +56,11 @@ public class ConsumerGroupController {
             @RequestParam(required = false) String instanceId,
             @RequestParam(required = false) String clusterId,
             @RequestParam(required = false) String search,
+            @RequestParam(required = false) String subscriptionMode,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "20") int pageSize) {
-        return Result.ok(metadataService.listConsumerGroupsPage(instanceId, clusterId, search, page, pageSize));
+        return Result.ok(metadataService.listConsumerGroupsPage(instanceId, clusterId, search,
+                subscriptionMode, page, pageSize));
     }
 
     @GetMapping("/{name}")

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
@@ -211,15 +211,15 @@ public class MetadataService {
     }
 
     public PageResult<ConsumerGroupVO> listConsumerGroupsPage(String instanceId, String clusterId, String search,
-                                                              int page, int pageSize) {
+                                                              String subscriptionMode, int page, int pageSize) {
         validatePagination(page, pageSize);
         instanceId = normalizeInstanceId(instanceId);
         if (!StringUtils.hasText(instanceId) && StringUtils.hasText(clusterId)) {
             return metadataProvider.listConsumerGroupsPage(normalizeFilter(clusterId),
-                    normalizeFilter(search), page, pageSize);
+                    normalizeFilter(search), subscriptionMode, page, pageSize);
         }
         return resolve(instanceId).listConsumerGroupsPage(instanceId, normalizeFilter(search),
-                page, pageSize);
+                subscriptionMode, page, pageSize);
     }
 
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/ConsumerGroupListToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/ConsumerGroupListToolHandler.java
@@ -45,7 +45,8 @@ public class ConsumerGroupListToolHandler implements ToolHandler {
         String clusterId = (String) input.get("cluster");
         String search = (String) input.get("search");
         PageResult<ConsumerGroupVO> page = metadataService.listConsumerGroupsPage(
-                clusterId, null, search, ToolListPagination.page(input), ToolListPagination.pageSize(input));
+                null, clusterId, search, null,
+                ToolListPagination.page(input), ToolListPagination.pageSize(input));
         return ToolListPagination.pagedResult(page, page.getItems().stream()
                 .map(ConsumerGroupListToolHandler::safeProjection)
                 .toList());

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
@@ -101,6 +101,27 @@ public interface InstanceProvider {
         return PageResult.of(groups.subList(from, to), total, page, pageSize);
     }
 
+    /**
+     * Paged group list filtered by subscription mode. Providers that cannot push the filter
+     * into their source keep the in-memory default; the mode is matched against the VO's
+     * textual subscription mode ("Push"/"Pop") so the visible rows and the total agree.
+     */
+    default PageResult<ConsumerGroupVO> listConsumerGroupsPage(String instanceId, String search,
+            String subscriptionMode, int page, int pageSize) {
+        List<ConsumerGroupVO> groups = listConsumerGroups(instanceId, search);
+        if (subscriptionMode != null && !subscriptionMode.isBlank() && !"ALL".equals(subscriptionMode)) {
+            groups = groups.stream()
+                    .filter(group -> subscriptionMode.equals(
+                            group.getSubscriptionMode() == null ? null : group.getSubscriptionMode().name()))
+                    .toList();
+        }
+        int total = groups.size();
+        long offset = Pagination.pageOffset(page, pageSize);
+        int from = (int) Math.min(offset, total);
+        int to = from + (int) Math.min(pageSize, total - from);
+        return PageResult.of(groups.subList(from, to), total, page, pageSize);
+    }
+
     ConsumerGroupVO createConsumerGroup(String instanceId, ConsumerGroupVO group);
 
     void deleteConsumerGroup(String instanceId, String groupName);

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
@@ -130,6 +130,13 @@ public class ApacheInstanceProvider implements InstanceProvider {
     }
 
     @Override
+    public PageResult<ConsumerGroupVO> listConsumerGroupsPage(String instanceId, String search,
+            String subscriptionMode, int page, int pageSize) {
+        return metadataProvider.listConsumerGroupsPage(instanceId, null, search, subscriptionMode,
+                page, pageSize);
+    }
+
+    @Override
     public ConsumerGroupVO createConsumerGroup(String instanceId, ConsumerGroupVO group) {
         return adminClient.createConsumerGroup(group);
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/MetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/MetadataProvider.java
@@ -71,6 +71,16 @@ public interface MetadataProvider {
         return listConsumerGroupsPage(clusterId, search, page, pageSize);
     }
 
+    /**
+     * Paged group list filtered by subscription mode. Cloud providers keep the in-memory
+     * default; the Apache provider pushes the filter into the database query so counts stay
+     * consistent with the filtered rows.
+     */
+    default PageResult<ConsumerGroupVO> listConsumerGroupsPage(String instanceId, String clusterId,
+            String search, String subscriptionMode, int page, int pageSize) {
+        return listConsumerGroupsPage(clusterId, search, page, pageSize);
+    }
+
     List<BrokerRouteVO> getTopicRoutes(String instanceId, String name);
     List<TopicConsumerVO> getTopicConsumers(String instanceId, String name);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -239,11 +239,15 @@ public class RocketMQMetadataProvider implements MetadataProvider {
 
     @Override
     public PageResult<ConsumerGroupVO> listConsumerGroupsPage(String instanceId, String clusterId,
-            String search, int page, int pageSize) {
+            String search, String subscriptionMode, int page, int pageSize) {
         LambdaQueryWrapper<RmqGroup> query = new LambdaQueryWrapper<RmqGroup>()
                 .eq(instanceId != null, RmqGroup::getInstanceId, normalizeMetadataScope(instanceId))
                 .eq(StringUtils.hasText(clusterId), RmqGroup::getClusterId, clusterId)
                 .like(StringUtils.hasText(search), RmqGroup::getName, search)
+                // messageModel stores the subscription mode ("Push"/"Pop"), the same column
+                // toConsumerGroupVO reads; filter server-side so total matches the rows.
+                .eq(StringUtils.hasText(subscriptionMode) && !"ALL".equals(subscriptionMode),
+                        RmqGroup::getMessageModel, subscriptionMode)
                 .orderByAsc(RmqGroup::getName, RmqGroup::getId);
         Page<RmqGroup> result = groupMapper.selectPage(new Page<>(page, pageSize), query);
         List<ConsumerGroupVO> groups = result.getRecords().stream()

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupControllerTest.java
@@ -82,7 +82,7 @@ class ConsumerGroupControllerTest {
     @Test
     void listConsumerGroupsPageShouldPassSelectedInstanceFiltersAndPaging() throws Exception {
         PageResult<ConsumerGroupVO> page = PageResult.of(List.of(), 3, 2, 20);
-        when(metadataService.listConsumerGroupsPage("instance-a", "cluster-a", "orders", 2, 20))
+        when(metadataService.listConsumerGroupsPage("instance-a", "cluster-a", "orders", null, 2, 20))
                 .thenReturn(page);
 
         mockMvc.perform(get("/api/groups/page")
@@ -96,7 +96,22 @@ class ConsumerGroupControllerTest {
                 .andExpect(jsonPath("$.data.page").value(2))
                 .andExpect(jsonPath("$.data.size").value(20));
 
-        verify(metadataService).listConsumerGroupsPage("instance-a", "cluster-a", "orders", 2, 20);
+        verify(metadataService).listConsumerGroupsPage("instance-a", "cluster-a", "orders", null, 2, 20);
+    }
+
+    @Test
+    void listConsumerGroupsPageShouldPassSubscriptionModeFilterThrough() throws Exception {
+        PageResult<ConsumerGroupVO> page = PageResult.of(List.of(), 1, 1, 20);
+        when(metadataService.listConsumerGroupsPage("instance-a", null, null, "Pop", 1, 20))
+                .thenReturn(page);
+
+        mockMvc.perform(get("/api/groups/page")
+                        .param("instanceId", "instance-a")
+                        .param("subscriptionMode", "Pop"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.total").value(1));
+
+        verify(metadataService).listConsumerGroupsPage("instance-a", null, null, "Pop", 1, 20);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/MetadataServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/MetadataServiceTest.java
@@ -446,44 +446,59 @@ class MetadataServiceTest {
     void listConsumerGroupsPageShouldPaginateFromOneBasedIndexes() {
         ConsumerGroupVO third = new ConsumerGroupVO();
         third.setName("cg-c");
-        when(apacheProvider.listConsumerGroupsPage("instance-a", "order", 2, 2))
+        when(apacheProvider.listConsumerGroupsPage("instance-a", "order", null, 2, 2))
                 .thenReturn(PageResult.of(List.of(third), 3, 2, 2));
 
         PageResult<ConsumerGroupVO> result =
-                metadataService.listConsumerGroupsPage("instance-a", null, "order", 2, 2);
+                metadataService.listConsumerGroupsPage("instance-a", null, "order", null, 2, 2);
 
         assertThat(result.getItems()).containsExactly(third);
         assertThat(result.getTotal()).isEqualTo(3);
         assertThat(result.getPage()).isEqualTo(2);
         assertThat(result.getSize()).isEqualTo(2);
-        verify(apacheProvider).listConsumerGroupsPage("instance-a", "order", 2, 2);
+        verify(apacheProvider).listConsumerGroupsPage("instance-a", "order", null, 2, 2);
         verify(apacheProvider, org.mockito.Mockito.never()).listConsumerGroups("instance-a", "order");
     }
 
     @Test
+    void listConsumerGroupsPageShouldPassSubscriptionModeToTheProvider() {
+        ConsumerGroupVO popGroup = new ConsumerGroupVO();
+        popGroup.setName("cg-pop");
+        when(apacheProvider.listConsumerGroupsPage("instance-a", null, "Pop", 1, 20))
+                .thenReturn(PageResult.of(List.of(popGroup), 1, 1, 20));
+
+        PageResult<ConsumerGroupVO> result =
+                metadataService.listConsumerGroupsPage("instance-a", null, null, "Pop", 1, 20);
+
+        assertThat(result.getItems()).containsExactly(popGroup);
+        assertThat(result.getTotal()).isEqualTo(1);
+        verify(apacheProvider).listConsumerGroupsPage("instance-a", null, "Pop", 1, 20);
+    }
+
+    @Test
     void listConsumerGroupsPageShouldReturnEmptyItemsWhenPageStartsPastFilteredTotal() {
-        when(metadataProvider.listConsumerGroupsPage("cluster-1", "order", 2, 1))
+        when(metadataProvider.listConsumerGroupsPage("cluster-1", "order", null, 2, 1))
                 .thenReturn(PageResult.empty(2, 1));
 
         PageResult<ConsumerGroupVO> result =
-                metadataService.listConsumerGroupsPage(null, "cluster-1", "order", 2, 1);
+                metadataService.listConsumerGroupsPage(null, "cluster-1", "order", null, 2, 1);
 
         assertThat(result.getItems()).isEmpty();
         assertThat(result.getTotal()).isZero();
         assertThat(result.getPage()).isEqualTo(2);
         assertThat(result.getSize()).isEqualTo(1);
-        verify(metadataProvider).listConsumerGroupsPage("cluster-1", "order", 2, 1);
+        verify(metadataProvider).listConsumerGroupsPage("cluster-1", "order", null, 2, 1);
     }
 
     @Test
     void listConsumerGroupsPageShouldRejectInvalidPaginationBounds() {
-        assertThatThrownBy(() -> metadataService.listConsumerGroupsPage(null, "cluster-1", null, 0, 20))
+        assertThatThrownBy(() -> metadataService.listConsumerGroupsPage(null, "cluster-1", null, null, 0, 20))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("page must be greater than zero");
-        assertThatThrownBy(() -> metadataService.listConsumerGroupsPage(null, "cluster-1", null, 1, 0))
+        assertThatThrownBy(() -> metadataService.listConsumerGroupsPage(null, "cluster-1", null, null, 1, 0))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("pageSize must be between 1 and 100");
-        assertThatThrownBy(() -> metadataService.listConsumerGroupsPage(null, "cluster-1", null, 1, 101))
+        assertThatThrownBy(() -> metadataService.listConsumerGroupsPage(null, "cluster-1", null, null, 1, 101))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("pageSize must be between 1 and 100");
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
@@ -432,7 +432,7 @@ class ToolGatewayServiceTest {
         when(clusterService.getCluster("cluster-v5")).thenReturn(cluster(ClusterType.V5_PROXY_CLUSTER));
         ConsumerGroupVO group = consumerGroup();
         group.setDelaySeconds(30);
-        when(metadataService.listConsumerGroupsPage("cluster-v5", null, "order", 2, 20))
+        when(metadataService.listConsumerGroupsPage(null, "cluster-v5", "order", null, 2, 20))
                 .thenReturn(PageResult.of(List.of(group), 101, 2, 20));
 
         Object output = gateway.execute("rmq.group.list", Map.of(

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
@@ -218,7 +218,7 @@ class RocketMQMetadataProviderTest {
         RocketMQMetadataProvider provider = newProvider();
 
         PageResult<ConsumerGroupVO> result = provider.listConsumerGroupsPage(
-                "instance-a", "cluster-1", "group", 2, 1);
+                "instance-a", "cluster-1", "group", null, 2, 1);
 
         assertThat(result.getItems()).hasSize(1);
         assertThat(result.getItems().get(0).getName()).isEqualTo("group-b");
@@ -234,6 +234,21 @@ class RocketMQMetadataProviderTest {
                 .contains("instance_id", "cluster_id", "ORDER BY name ASC,id ASC");
         verify(groupMapper, never()).selectList(any());
         verify(runtimeAdminClientResolver, times(2)).execute(eq("instance-a"), any());
+    }
+
+    @Test
+    void listConsumerGroupsPageShouldPushSubscriptionModeFilterIntoTheDatabaseQuery() {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqGroup.class);
+        when(groupMapper.selectPage(any(Page.class), any(LambdaQueryWrapper.class))).thenReturn(new Page<>(1, 20, 0));
+        RocketMQMetadataProvider provider = newProvider();
+
+        provider.listConsumerGroupsPage("instance-a", null, "group", "Pop", 1, 20);
+
+        org.mockito.ArgumentCaptor<LambdaQueryWrapper<RmqGroup>> captor =
+                org.mockito.ArgumentCaptor.forClass(LambdaQueryWrapper.class);
+        verify(groupMapper).selectPage(any(Page.class), captor.capture());
+        assertThat(captor.getValue().getSqlSegment()).contains("message_model");
+        assertThat(captor.getValue().getParamNameValuePairs().values()).contains("Pop");
     }
 
     @Test

--- a/web/src/api/metadata.ts
+++ b/web/src/api/metadata.ts
@@ -171,6 +171,7 @@ export interface ConsumerGroupQuery {
   instanceId?: string;
   clusterId?: string;
   search?: string;
+  subscriptionMode?: string;
 }
 
 export interface ConsumerGroupPageQuery extends ConsumerGroupQuery {

--- a/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
+++ b/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
@@ -294,6 +294,34 @@ describe('Consumer page', () => {
     });
   });
 
+  it('passes the subscription mode filter to the server query and resets the page', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ConsumerPage />);
+
+    expect(await screen.findByText('remote-cg')).toBeInTheDocument();
+    expect(consumerService.listConsumerGroupPage).toHaveBeenCalledWith({
+      instanceId: 'instance-1',
+      page: 1,
+      pageSize: 20,
+      search: undefined,
+    });
+
+    const modeSelect = screen
+      .getAllByRole('combobox')
+      .find((element) => element.closest('.ant-select')?.textContent?.includes('全部模式'));
+    expect(modeSelect).toBeTruthy();
+    await user.click(modeSelect as HTMLElement);
+    await user.click(
+      await screen.findByText('Pop', { selector: '.ant-select-item-option-content' }),
+    );
+
+    await waitFor(() =>
+      expect(consumerService.listConsumerGroupPage).toHaveBeenLastCalledWith(
+        expect.objectContaining({ subscriptionMode: 'Pop', page: 1 }),
+      ),
+    );
+  });
+
   afterEach(() => {
     cleanup();
     Modal.destroyAll();

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -151,16 +151,6 @@ const formatDelay = (totalSeconds: number): string => {
   return parts.length > 0 ? parts.join('') : '0秒';
 };
 
-const visibleConsumerGroups = (groups: ConsumerGroup[], modeFilter: string): ConsumerGroup[] => {
-  let data = groups;
-
-  if (modeFilter !== 'ALL') {
-    data = data.filter((group) => group.subscriptionMode === modeFilter);
-  }
-
-  return data;
-};
-
 const normalizedConsistency = (value?: string | null): string => value?.trim().toLowerCase() ?? '';
 
 const isConsistentValue = (value?: string | null): boolean =>
@@ -349,6 +339,7 @@ const ConsumerPageContent = ({
         const result = await listConsumerGroupPage({
           instanceId: selectedInstanceId,
           search: search.trim() || undefined,
+          subscriptionMode: modeFilter !== 'ALL' ? modeFilter : undefined,
           page: pageToLoad,
           pageSize: pageSizeToLoad,
         });
@@ -367,7 +358,7 @@ const ConsumerPageContent = ({
         if (requestId === groupRequestIdRef.current) setLoading(false);
       }
     },
-    [t, selectedInstanceId, search],
+    [t, selectedInstanceId, search, modeFilter],
   );
 
   const reloadConsumerGroupPageAfterDelete = useCallback(async () => {
@@ -465,10 +456,8 @@ const ConsumerPageContent = ({
     return () => window.clearInterval(interval);
   }, [modalOpen, selectedGroupName, selectedInstanceId, loadProgress]);
 
-  /* ─── Filtered & sorted data ─── */
-  const filtered = useMemo(() => {
-    return visibleConsumerGroups(groups, modeFilter);
-  }, [groups, modeFilter]);
+  /* ─── Table data (server-filtered & server-paginated) ─── */
+  const filtered = groups;
 
   const handleExport = async () => {
     setExporting(true);
@@ -1437,7 +1426,10 @@ const ConsumerPageContent = ({
           />
           <Select
             value={modeFilter}
-            onChange={setModeFilter}
+            onChange={(mode) => {
+              setModeFilter(mode);
+              setPage(1);
+            }}
             style={{ width: 140 }}
             options={[
               { value: 'ALL', label: '全部模式' },


### PR DESCRIPTION
Fixes #4171.

## Problem / Evidence

The Consumer Groups page applies the subscription-mode select client-side only: `visibleConsumerGroups` (`web/src/pages/instance/consumer.tsx`, base `0a596661`, lines 154-162) filters the rows of the **current server page**, while `loadConsumerGroupPage` (343-371) never sends the mode and the paginator shows the unfiltered `totalGroups`. The same view's export already filters server-side (`/api/groups/export` → `MetadataService.exportConsumerGroups` lines 436-438), so the list and the export disagree.

New regression test `passes the subscription mode filter to the server query and resets the page` fails on base: after selecting "Pop", the last `listConsumerGroupPage` call does not include `subscriptionMode: 'Pop'` (`- "subscriptionMode": "Pop"` missing from the received call).

## Root cause / Fix

Root cause: the mode filter was implemented as a client-side slice over server-paginated data.

Fix:
- **Backend**: `/api/groups/page` accepts an optional `subscriptionMode` request parameter and threads it through `MetadataService.listConsumerGroupsPage` → provider chain. `RocketMQMetadataProvider` pushes the filter into the database query via the `rmq_group.message_model` column (the same column `toConsumerGroupVO` reads), so `total` matches the filtered rows. Cloud providers keep a default in-memory implementation (filter on `getSubscriptionMode().name()` then paginate) since their remote APIs have no such filter; `ConsumerGroupListToolHandler` (AI tool) passes `null` explicitly, preserving its behavior.
- **Frontend**: `listConsumerGroupPage` sends `subscriptionMode`; the client-side slice filter is removed; changing the mode resets the page to 1 (same as the search box).

## Priority & scoring

- Impact 30/40 (the filter lies on a core list page whenever the filtered set spans pages; list/export inconsistency) + breadth 14/20 (all server-paginated consumer group lists, any instance with ≥ 2 pages) + reproducibility 18/20 (deterministic API-call regression + DB query assertion) + maintainability value 14/20 (restores the list/export contract symmetry) = **PRIORITY 76** ≥ 70.
- Signature-threading with in-file precedent (export path) and red→green regressions on both ends → **FIX_CONFIDENCE 85** ≥ 80.

## Tests

- Red (frontend): `npx vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx` on base with only the test added → 1 failed (`subscriptionMode: 'Pop'` not sent).
- Green (frontend): same command after the fix → `Tests 32 passed (32)`.
- Backend module: `mvn -o test -Dtest='RocketMQMetadataProviderTest,MetadataServiceTest,ConsumerGroupControllerTest,ToolGatewayServiceTest'` → `Tests run: 132, Failures: 0, Errors: 0` (new: DB-query filter assertion, service passthrough, controller param passthrough).
- Full web suite after the fix: `npx vitest run` → `Test Files 115 passed (115)`, `Tests 945 passed (945)` (an earlier run had 1 failure in `ConsumerPage > shows group health diagnostics`, which passes in isolation and in this full re-run — the documented load-flaky test).
- `npx tsc --noEmit` clean; eslint clean on the changed web files; `npm run build` → `✓ built in 12.18s`.

## Risk

Low-moderate. The `/groups/page` endpoint gains an **optional** parameter — existing callers (including the AI tool, which passes null) are unaffected; cloud providers get a default that filters in memory over the already-fetched list (same data their unfiltered path returns). The Apache DB filter uses the exact `message_model` values ("Push"/"Pop") that `toConsumerGroupVO` maps. One behavioral change is intended: the table now shows only server-filtered rows and the total reflects the filter.
