### PR TITLE
fix(alert): interpret lastTriggered as UTC like the system alerts page

### DIFF
--- a/web/src/pages/ops/__tests__/AlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/AlertsPage.test.tsx
@@ -22,7 +22,7 @@ import { App } from 'antd';
 import type { AlertRule, NativeAlertMetricInfo, PageResult } from '../../../api/ops';
 import { LangProvider } from '../../../i18n/LangContext';
 import { LANGUAGE_STORAGE_KEY } from '../../../i18n/languagePreference';
-import { formatDateTime } from '../../../utils/format';
+import { formatUtcDateTime } from '../../../utils/format';
 import AlertsPage, { formatThresholdCondition, supportsUnavailableOperator } from '../alerts';
 import { listInstances } from '../../../services/instanceService';
 import {
@@ -217,8 +217,19 @@ describe('AlertsPage', () => {
 
     renderPage();
 
-    expect(await screen.findByText(formatDateTime(lastTriggered))).toBeInTheDocument();
+    expect(await screen.findByText(formatUtcDateTime(lastTriggered))).toBeInTheDocument();
     expect(screen.queryByText(lastTriggered)).not.toBeInTheDocument();
+  });
+
+  it('interprets the last triggered timestamp as UTC, not the browser zone', async () => {
+    const lastTriggered = '2026-08-23T23:30:00';
+    vi.mocked(listAlertRulesPage).mockResolvedValue(
+      pageResult([{ ...cloneRule(alertRules[0]), lastTriggered }]),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText(formatUtcDateTime(lastTriggered))).toBeInTheDocument();
   });
 
   it('allows the unavailable operator only for availability metrics', () => {

--- a/web/src/pages/ops/alerts.tsx
+++ b/web/src/pages/ops/alerts.tsx
@@ -65,7 +65,7 @@ import {
 } from '../../services/opsService';
 import { attachThresholdUnit, normalizeDuration, normalizeMetric } from './alertRulePayload';
 import { tableScrollX } from '../../utils/table';
-import { formatDateTime } from '../../utils/format';
+import { formatUtcDateTime } from '../../utils/format';
 import { listInstances } from '../../services/instanceService';
 import type { Instance } from '../../api/instance';
 import { downloadBlob } from '../../utils/download';
@@ -696,7 +696,9 @@ const AlertsPage = ({ domain = 'CLUSTER' }: AlertsPageProps) => {
       sorter: (a, b) => (a.lastTriggered ?? '').localeCompare(b.lastTriggered ?? ''),
       render: (_, record) =>
         record.lastTriggered ? (
-          formatDateTime(record.lastTriggered)
+          // The backend stamps lastTriggered with ZoneOffset.UTC without an offset suffix;
+          // parse it as UTC so the column matches the system alerts page in any browser TZ.
+          formatUtcDateTime(record.lastTriggered)
         ) : (
           <span style={{ color: '#999' }}>{t('alerts.neverTriggered')}</span>
         ),


### PR DESCRIPTION
Fixes #4174.

## Problem / Evidence

On `/ops/alerts` (and `/ops/business-alerts`) the **最近触发时间** column renders `lastTriggered` with `formatDateTime`, which parses offset-less ISO strings as **browser-local** time. The backend stamps this value as UTC without a suffix:

- `NativeAlertProcessor.java:143` — `LocalDateTime eventTime = LocalDateTime.ofInstant(collectedAt, ZoneOffset.UTC);`
- `NativeAlertProcessor.java:165` → `markRuleTriggered(rule.getId(), eventTime.toString())` → `2026-08-23T23:30:00` in `rmq_alert_rule.last_triggered` (`NativeAlertEvaluationService.java:92` same).

So a rule that fired at 23:30 UTC displays "23:30" in every timezone; a UTC+8 browser shows a trigger time up to 8 hours in the future. The header counter `近24小时触发` (`alerts.tsx:406-408`, `new Date(r.lastTriggered).getTime() > dayAgo`) mixes the same naive parse with an epoch `dayAgo`, shifting the 24h window.

The sibling system alerts page already established the correct contract for these offset-less UTC values: `systemAlerts.tsx` renders `alert.time` / `alert.acknowledgedAt` via `formatUtcDateTime`, whose doc comment states the exact failure mode ("Alert APIs serialize UTC LocalDateTime values without an offset, so normal Date parsing would incorrectly treat them as browser-local timestamps").

## Root cause / Fix

`alerts.tsx` used the local-time formatter for an offset-less UTC timestamp. Switch the column to `formatUtcDateTime` (one-line change plus comment). The "24h triggered" filter already compares against `Date.now()`; once the value is interpreted as UTC it is consistent with epoch math, and existing null-sort semantics are untouched.

## Priority & scoring

PRIORITY = 84 (影响 34: wrong wall-clock time on every non-UTC browser on a core ops page + skewed 24h counter; 波及范围 16: both alert domains, every viewer east of UTC; 可复现性 20: any fired rule renders wrong in a non-UTC browser; 维护价值 14: aligns the page with the existing documented UTC contract). FIX_CONFIDENCE = 92 (single formatter swap with in-repo precedent and TZ-independent tests).

## Tests

Red (before fix, `fix/alerts-last-triggered-utc` @ abef8546^, branch `rocketmq-studio` @ 0a596661):

```
npx vitest run src/pages/ops/__tests__/AlertsPage.test.tsx
 ❯ src/pages/ops/__tests__/AlertsPage.test.tsx (24 tests | 2 failed)
   × formats the last triggered timestamp instead of rendering the raw ISO value
   × interprets the last triggered timestamp as UTC, not the browser zone
```

Green (after fix):

```
npx vitest run src/pages/ops/__tests__/AlertsPage.test.tsx
 Test Files  1 passed (1)
      Tests  24 passed (24)
```

The existing "formats the last triggered timestamp" test asserted `formatDateTime(...)` (the local-time renderer) — i.e. it pinned the buggy behavior; it now expects `formatUtcDateTime(...)`. The new second test uses `2026-08-23T23:30:00`, where the local-time parse and the UTC parse differ by more than a date boundary in the reference TZ.

Full web suite (`npx vitest run`): **945 tests, 944 passed, 1 failed** — `ConsumerPage > shows group health diagnostics from subscriptions, progress and clients` (unrelated file). Verified flaky-under-load both ways: pristine `rocketmq-studio` isolated run passes, isolated run with this change applied also passes (31 tests file-level, target test green).

`tsc --noEmit` clean; `eslint` on both changed files: 0 errors (5 warnings, all pre-existing at the same positions); `npm run build` ✓ (8.25s).

## Risk

Low. Display-only change on one column; no API/payload change. In a UTC-configured browser the rendered string additionally gains a timezone suffix (e.g. ` UTC`), consistent with the system alerts page. The `localeCompare` sorter and null handling are unchanged.
