### PR TITLE
[studio] fix(message): resolve registered broker hostnames for offset ID queries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/BrokerTopologyGuards.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/BrokerTopologyGuards.java
@@ -16,8 +16,10 @@
  */
 package org.apache.rocketmq.studio.provider.apache;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -67,12 +69,41 @@ public final class BrokerTopologyGuards {
         if (!StringUtils.hasText(brokerAddr)) {
             return null;
         }
-        if (knownBrokerEndpoints(admin).contains(brokerAddr)) {
+        Set<String> endpoints = knownBrokerEndpoints(admin);
+        if (endpoints.contains(brokerAddr)) {
             return brokerAddr;
+        }
+        InetSocketAddress address = (InetSocketAddress) messageId.getAddress();
+        for (String endpoint : endpoints) {
+            if (matchesBrokerEndpoint(endpoint, address)) {
+                // Keep the decoded IP for remoting instead of resolving the hostname again.
+                return brokerAddr;
+            }
         }
         log.warn("Rejecting decoded broker address {} for msgId={} because it is not a known broker endpoint"
                 + " for the selected instance", brokerAddr, msgId);
         return null;
+    }
+
+    private static boolean matchesBrokerEndpoint(String endpoint, InetSocketAddress address) {
+        int separator = endpoint.lastIndexOf(':');
+        if (separator <= 0) {
+            return false;
+        }
+        try {
+            if (Integer.parseInt(endpoint.substring(separator + 1)) != address.getPort()) {
+                return false;
+            }
+            // Only resolve hosts advertised by the selected instance's broker topology.
+            for (InetAddress resolved : InetAddress.getAllByName(endpoint.substring(0, separator))) {
+                if (resolved.equals(address.getAddress())) {
+                    return true;
+                }
+            }
+        } catch (NumberFormatException | UnknownHostException e) {
+            log.debug("Could not resolve registered broker endpoint {}: {}", endpoint, e.getMessage());
+        }
+        return false;
     }
 
     static String decodedBrokerAddr(MessageId messageId) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/BrokerTopologyGuardsHostnameTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/BrokerTopologyGuardsHostnameTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.apache;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import org.apache.rocketmq.common.message.MessageDecoder;
+import org.apache.rocketmq.common.message.MessageId;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class BrokerTopologyGuardsHostnameTest {
+
+    @Test
+    void acceptsRegisteredHostnameAndKeepsDecodedIpForRemoting() throws Exception {
+        MQAdminExt admin = adminWithEndpoints(" localhost:10911 ");
+        String msgId = MessageDecoder.createMessageId(new InetSocketAddress("127.0.0.1", 10911), 123L);
+
+        assertThat(BrokerTopologyGuards.isWithinKnownBrokerTopology(admin, msgId)).isTrue();
+        assertThat(BrokerTopologyGuards.validatedBrokerAddr(admin, msgId, MessageDecoder.decodeMessageId(msgId)))
+                .isEqualTo("127.0.0.1:10911");
+    }
+
+    @Test
+    void matchesAnyAddressResolvedFromRegisteredHostname() throws Exception {
+        MQAdminExt admin = adminWithEndpoints("broker.test:10911");
+        MessageId messageId = messageId("192.0.2.2", 10911);
+        InetAddress first = InetAddress.getByName("192.0.2.1");
+        InetAddress second = InetAddress.getByName("192.0.2.2");
+
+        try (MockedStatic<InetAddress> addresses = mockStatic(InetAddress.class)) {
+            addresses.when(() -> InetAddress.getAllByName("broker.test"))
+                    .thenReturn(new InetAddress[]{first, second});
+
+            assertThat(BrokerTopologyGuards.validatedBrokerAddr(admin, "offset-id", messageId))
+                    .isEqualTo("192.0.2.2:10911");
+            addresses.verify(() -> InetAddress.getAllByName("broker.test"));
+            addresses.verifyNoMoreInteractions();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"192.0.2.2", "2001:db8::2"})
+    void rejectsAddressNotResolvedFromRegisteredHostname(String ip) throws Exception {
+        MQAdminExt admin = adminWithEndpoints("broker.test:10911");
+        MessageId messageId = messageId(ip, 10911);
+        InetAddress registeredAddress = InetAddress.getByName("192.0.2.1");
+
+        try (MockedStatic<InetAddress> addresses = mockStatic(InetAddress.class)) {
+            addresses.when(() -> InetAddress.getAllByName("broker.test"))
+                    .thenReturn(new InetAddress[]{registeredAddress});
+
+            assertThat(BrokerTopologyGuards.validatedBrokerAddr(admin, "offset-id", messageId)).isNull();
+            addresses.verify(() -> InetAddress.getAllByName("broker.test"));
+            addresses.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    void rejectsUnresolvableRegisteredHostname() throws Exception {
+        MQAdminExt admin = adminWithEndpoints("missing.test:10911");
+        MessageId messageId = messageId("127.0.0.1", 10911);
+
+        try (MockedStatic<InetAddress> addresses = mockStatic(InetAddress.class)) {
+            addresses.when(() -> InetAddress.getAllByName("missing.test"))
+                    .thenThrow(new UnknownHostException("missing.test"));
+
+            assertThat(BrokerTopologyGuards.validatedBrokerAddr(admin, "offset-id", messageId)).isNull();
+            addresses.verify(() -> InetAddress.getAllByName("missing.test"));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"broker-a.test", "broker-b.test"})
+    void unresolvableEndpointDoesNotHideMatchingRegisteredHostname(String matchingHost) throws Exception {
+        MQAdminExt admin = adminWithEndpoints("broker-a.test:10911", "broker-b.test:10911");
+        String missingHost = matchingHost.equals("broker-a.test") ? "broker-b.test" : "broker-a.test";
+        MessageId messageId = messageId("192.0.2.1", 10911);
+        InetAddress registeredAddress = InetAddress.getByName("192.0.2.1");
+
+        try (MockedStatic<InetAddress> addresses = mockStatic(InetAddress.class)) {
+            addresses.when(() -> InetAddress.getAllByName(missingHost))
+                    .thenThrow(new UnknownHostException(missingHost));
+            addresses.when(() -> InetAddress.getAllByName(matchingHost))
+                    .thenReturn(new InetAddress[]{registeredAddress});
+
+            assertThat(BrokerTopologyGuards.validatedBrokerAddr(admin, "offset-id", messageId))
+                    .isEqualTo("192.0.2.1:10911");
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"[2001:db8::1]:10911", "2001:db8::1:10911", "[2001:DB8:0:0:0:0:0:1]:10911"})
+    void acceptsEquivalentIpv6Representations(String endpoint) throws Exception {
+        MQAdminExt admin = adminWithEndpoints(endpoint);
+        String msgId = MessageDecoder.createMessageId(new InetSocketAddress("2001:db8::1", 10911), 123L);
+
+        assertThat(BrokerTopologyGuards.isWithinKnownBrokerTopology(admin, msgId)).isTrue();
+        assertThat(BrokerTopologyGuards.validatedBrokerAddr(admin, msgId, MessageDecoder.decodeMessageId(msgId)))
+                .isEqualTo("2001:db8:0:0:0:0:0:1:10911");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "broker.test:10912", "broker.test", ":10911", "broker.test:",
+        "broker.test:invalid", "broker.test:65536", "broker.test:-1"
+    })
+    void rejectsMismatchedOrMalformedPortWithoutResolvingHosts(String endpoint) throws Exception {
+        MQAdminExt admin = adminWithEndpoints(endpoint);
+        MessageId messageId = messageId("127.0.0.1", 10911);
+
+        try (MockedStatic<InetAddress> addresses = mockStatic(InetAddress.class)) {
+            assertThat(BrokerTopologyGuards.validatedBrokerAddr(admin, "offset-id", messageId)).isNull();
+            addresses.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    void exactIpMatchDoesNotRequireDnsForOtherRegisteredBrokers() throws Exception {
+        MQAdminExt admin = adminWithEndpoints("missing.test:10911", "192.0.2.1:10911");
+        MessageId messageId = messageId("192.0.2.1", 10911);
+
+        try (MockedStatic<InetAddress> addresses = mockStatic(InetAddress.class)) {
+            assertThat(BrokerTopologyGuards.validatedBrokerAddr(admin, "offset-id", messageId))
+                    .isEqualTo("192.0.2.1:10911");
+            addresses.verifyNoInteractions();
+        }
+    }
+
+    private static MessageId messageId(String ip, int port) {
+        return new MessageId(new InetSocketAddress(ip, port), 123L);
+    }
+
+    private static MQAdminExt adminWithEndpoints(String... endpoints) throws Exception {
+        MQAdminExt admin = mock(MQAdminExt.class);
+        ClusterInfo clusterInfo = new ClusterInfo();
+        HashMap<String, BrokerData> brokers = new HashMap<>();
+        for (int i = 0; i < endpoints.length; i++) {
+            BrokerData broker = new BrokerData();
+            HashMap<Long, String> addresses = new HashMap<>();
+            addresses.put(0L, endpoints[i]);
+            broker.setBrokerAddrs(addresses);
+            brokers.put("broker-" + i, broker);
+        }
+        clusterInfo.setBrokerAddrTable(brokers);
+        when(admin.examineBrokerClusterInfo()).thenReturn(clusterInfo);
+        return admin;
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -247,6 +247,36 @@ class RocketMQMessageProviderTest {
     }
 
     @Test
+    void queryByMsgIdAcceptsRegisteredBrokerHostname() throws Exception {
+        String msgId = MessageDecoder.createMessageId(new InetSocketAddress("127.0.0.1", 10911), 12345L);
+        MessageExt message = new MessageExt();
+        message.setMsgId(msgId);
+        message.setTopic("TopicA");
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithBrokerAddresses("localhost:10911"));
+        when(adminExt.viewMessage("TopicA", msgId)).thenReturn(message);
+
+        assertThat(provider.queryMessages("instance-a", "TopicA", msgId, null, null, null, null))
+                .singleElement().extracting(MessageRecordVO::getMsgId).isEqualTo(msgId);
+        verify(adminExt).viewMessage("TopicA", msgId);
+    }
+
+    @Test
+    void queryByMsgIdUsesDecodedIpForHostnameBrokerFallback() throws Exception {
+        String msgId = MessageDecoder.createMessageId(new InetSocketAddress("127.0.0.1", 10911), 12345L);
+        MQClientAPIImpl clientApi = mockOffsetLookupClient();
+        MessageExt message = new MessageExt();
+        message.setMsgId(msgId);
+        message.setTopic("TopicA");
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithBrokerAddresses("localhost:10911"));
+        when(adminExt.viewMessage("TopicA", msgId)).thenThrow(new IllegalStateException("primary lookup failed"));
+        when(clientApi.viewMessage("127.0.0.1:10911", "TopicA", 12345L, 3000L)).thenReturn(message);
+
+        assertThat(provider.queryMessages("instance-a", "TopicA", msgId, null, null, null, null))
+                .singleElement().extracting(MessageRecordVO::getMsgId).isEqualTo(msgId);
+        verify(clientApi).viewMessage("127.0.0.1:10911", "TopicA", 12345L, 3000L);
+    }
+
+    @Test
     void queryByMsgIdIgnoresUnrelatedTimeBounds() throws Exception {
         MessageExt message = new MessageExt();
         message.setMsgId("msg-1");


### PR DESCRIPTION
修复 Broker 使用主机名注册时，按物理消息 ID 查询返回空结果的问题。解析已登记且端口匹配的 Broker 主机名，按 IP 判断地址是否属于所选实例，并继续使用消息 ID 内嵌 IP 查询。

新增主查询、回退查询及地址校验回归测试，保留未知地址拒绝和纯 IP 快速路径。

验证：95 个相关后端测试及 Checkstyle 通过；真实 Broker 和原页面中，同一物理 ID 的查询结果由 0 条恢复为 1 条。

Fixes #4181
