### PR TITLE
fix(ai): accept unavailable topology counts in the dashboard summary tool

### DIFF
--- a/server/src/main/resources/tool-catalog/rmq-tools.yaml
+++ b/server/src/main/resources/tool-catalog/rmq-tools.yaml
@@ -126,7 +126,9 @@ tools:
             brokers:
               type: integer
             proxies:
-              type: integer
+              type:
+                - integer
+                - 'null'
             topics:
               type: integer
             groups:
@@ -164,9 +166,13 @@ tools:
             totalBrokers:
               type: integer
             totalProxies:
-              type: integer
+              type:
+                - integer
+                - 'null'
             totalNameServers:
-              type: integer
+              type:
+                - integer
+                - 'null'
             totalTopics:
               type: integer
             totalConsumerGroups:

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
@@ -340,6 +340,51 @@ class ToolGatewayServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void executesDashboardSummaryWhenTopologyCountsAreUnavailable() {
+        when(dashboardService.getDashboard()).thenReturn(DashboardDataVO.builder()
+                .stats(DashboardStatsVO.builder()
+                        .totalClusters(1)
+                        .healthyClusters(1)
+                        .totalBrokers(2)
+                        .totalTopics(3)
+                        .totalConsumerGroups(4)
+                        .totalMessagesToday(500L)
+                        .messagesPerSecond(6L)
+                        .tpsIn(7L)
+                        .tpsOut(8L)
+                        .build())
+                .clusters(List.of(ClusterOverviewVO.builder()
+                        .id("cluster-v5")
+                        .name("test")
+                        .type(ClusterType.V5_PROXY_CLUSTER)
+                        .status(ClusterStatus.healthy)
+                        .brokers(2)
+                        .topics(3)
+                        .groups(4)
+                        .tpsIn(7)
+                        .tpsOut(8)
+                        .version("5.3.1")
+                        .throughput(List.of())
+                        .build()))
+                .build());
+
+        Object output = gateway.execute(
+                "rmq.dashboard.summary", Map.of("cluster", "cluster-v5"));
+
+        Map<String, Object> result = (Map<String, Object>) output;
+        Map<String, Object> cluster = (Map<String, Object>) result.get("cluster");
+        assertThat(cluster).containsKey("proxies");
+        assertThat(cluster.get("proxies")).isNull();
+        Map<String, Object> stats = (Map<String, Object>) result.get("stats");
+        assertThat(stats).containsKey("totalProxies");
+        assertThat(stats.get("totalProxies")).isNull();
+        assertThat(stats).containsKey("totalNameServers");
+        assertThat(stats.get("totalNameServers")).isNull();
+        assertThat(stats).containsEntry("totalBrokers", 2);
+    }
+
+    @Test
     void rejectsDashboardSummaryWithoutRequiredClusterBeforeHandlerRuns() {
         assertThatThrownBy(() -> gateway.execute("rmq.dashboard.summary", Map.of()))
                 .isInstanceOf(BusinessException.class)


### PR DESCRIPTION
## Motivation

`rmq.dashboard.summary` fails with `IllegalStateException` on every real V5 or multi-instance deployment.

The tool's output schema (from #642) declares `cluster.proxies`, `stats.totalProxies` and `stats.totalNameServers` as required plain integers. But #2419 (`e9f5df9a`, "preserve unavailable dashboard topology counts") deliberately made those counts nullable on the provider side, and the handler was never updated:

- `RocketMQDashboardProvider.collectDashboardData` sets `.proxies(V4_DIRECT ? 0 : null)` for every V5 proxy cluster and `.totalProxies(V4_DIRECT ? 0 : null)` in stats;
- `unavailableInstanceCluster` does the same for unreachable instances;
- `aggregateInstances` sets `.totalProxies(null)` **unconditionally** — so any deployment with registered Apache instances hits it;
- `unavailableTopologyDashboard` sets both `totalProxies` and `totalNameServers` to null.

`DashboardSummaryToolHandler` passes the values straight through and `ToolGatewayService.validateOutput` rejects the result:

```
IllegalStateException: Tool output validation failed for rmq.dashboard.summary:
[/cluster/proxies: null found, integer expected,
 /stats/totalNameServers: null found, integer expected,
 /stats/totalProxies: null found, integer expected]
```

The existing gateway test masked this by stubbing `.proxies(1)`/`.totalProxies(1)`, so the production wiring was never exercised.

## Modification

Allow `null` for the three topology-count fields in `tool-catalog/rmq-tools.yaml` using the same type-list convention the nameserver config diff tool already uses (`type: [string, 'null']`). This keeps #2419's semantics — null means "unknown/unavailable", not zero — for AI consumers, and requires no handler change since the handler already passes the counts through.

## Verification

Fail-before (schema change stashed, test kept):

```
[ERROR] Tests run: 33, Errors: 1
ToolGatewayServiceTest.executesDashboardSummaryWhenTopologyCountsAreUnavailable »
IllegalStateException: Tool output validation failed for rmq.dashboard.summary:
[/cluster/proxies: null found, integer expected, /stats/totalNameServers: null found,
 integer expected, /stats/totalProxies: null found, integer expected]
```

This is exactly the failure every V5/multi-instance deployment hits in production.

Pass-after (fix applied):

```
ToolGatewayServiceTest  Tests run: 33, Failures: 0, Errors: 0
ToolCatalogTest         Tests run: 6,  Failures: 0, Errors: 0
```

New test `executesDashboardSummaryWhenTopologyCountsAreUnavailable` drives the full gateway (schema validation included) with a V5 proxy cluster whose proxy counts are unavailable, and asserts the tool succeeds with `proxies`/`totalProxies`/`totalNameServers` present as null.