### PR TITLE
fix(ai): tolerate alert rules without a metric in the rule list tool

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/AlertRuleListToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/AlertRuleListToolHandler.java
@@ -54,7 +54,9 @@ public class AlertRuleListToolHandler implements ToolHandler {
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("id", rule.getId());
         result.put("name", require(rule.getName(), "name"));
-        result.put("metric", require(rule.getMetric(), "metric"));
+        // NativeAlertRulePolicy deliberately accepts rules without a metric, so the
+        // projection degrades to blank instead of failing the whole listing.
+        result.put("metric", blankIfNull(rule.getMetric()));
         result.put("operator", blankIfNull(rule.getOperator()));
         result.put("threshold", rule.getThreshold());
         result.put("thresholdUnit", blankIfNull(rule.getThresholdUnit()));

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
@@ -498,6 +498,26 @@ class ToolGatewayServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void executesAlertRuleListWhenARuleHasNoMetric() {
+        when(alertService.listRules(null, null, 1, 20)).thenReturn(PageResult.of(
+                List.of(
+                        alertRule(1L, "High Lag", "rocketmq_consumer_lag_messages", true),
+                        alertRule(2L, "Manual rule", null, false)),
+                2, 1, 20));
+
+        Object output = gateway.execute("rmq.alert.rule.list", Map.of("cluster", "cluster-v5"));
+
+        Map<String, Object> result = (Map<String, Object>) output;
+        List<Map<String, Object>> items = (List<Map<String, Object>>) result.get("items");
+        assertThat(items).hasSize(2);
+        assertThat(items.get(0)).containsEntry("metric", "rocketmq_consumer_lag_messages");
+        assertThat(items.get(1))
+                .containsEntry("name", "Manual rule")
+                .containsEntry("metric", "");
+    }
+
+    @Test
     void rejectsAlertRuleListWithoutAClusterBeforeHandlerRuns() {
         assertThatThrownBy(() -> gateway.execute("rmq.alert.rule.list", Map.of()))
                 .isInstanceOf(BusinessException.class)


### PR DESCRIPTION
## Motivation

One alert rule without a metric makes `rmq.alert.rule.list` fail for the **entire** listing:

```
IllegalStateException: Alert rule metric is unavailable
```

A blank metric is a legal stored state, creatable through the public REST API:

- `AlertRuleRequestDTO.metric` has no `@NotBlank` (only `name` is validated);
- `AlertService.createRule`/`updateRule` only require the name;
- `NativeAlertRulePolicy.validate` **deliberately returns early** when the metric is blank — blank-metric rules pass validation by design;
- the DB column is nullable (`metric VARCHAR(128)`), and `MybatisPlusAlertRepository` copies it straight into the VO.

The YAML transfer import is the only creation path that validates the metric (`AlertRuleTransferService` → `metricCatalogService.validate`), so REST-created rules can lack one. `AlertRuleListToolHandler.safeProjection` then projects every row with `require(rule.getMetric(), "metric")`, and the first such row kills the whole tool call — the AI can no longer list alert rules at all.

## Modification

Degrade the metric to blank via the handler's existing `blankIfNull` helper — exactly how `operator`, `thresholdUnit`, `duration` and `description` are already projected. The output schema (`rmq-tools.yaml`) types `metric` as a plain `string` with no `minLength`, so an empty string is a valid value for AI consumers.

## Verification

Fail-before (handler change stashed, test kept):

```
[ERROR] Tests run: 33, Errors: 1
ToolGatewayServiceTest.executesAlertRuleListWhenARuleHasNoMetric »
IllegalStateException: Alert rule metric is unavailable
```

Pass-after (fix applied):

```
ToolGatewayServiceTest  Tests run: 33, Failures: 0, Errors: 0
```

New test `executesAlertRuleListWhenARuleHasNoMetric` lists a mixed page (one rule with a metric, one without) and asserts the call succeeds, the metric-less row is present with `metric: ""`, and other rows are unaffected.