### PR TITLE
[Studio] feat: add metrics profile and query tools for AI gateway

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MetricProfileListToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MetricProfileListToolHandler.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai.tool;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.cluster.metrics.MetricProfileService;
+import org.apache.rocketmq.studio.cluster.metrics.MetricProfileVO;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class MetricProfileListToolHandler implements ToolHandler {
+
+    private static final String NAME = "rmq.metrics.profile.list";
+
+    private final MetricProfileService metricProfileService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public Object execute(Map<String, Object> input) {
+        return metricProfileService.listProfiles().stream()
+                .map(MetricProfileListToolHandler::profileProjection)
+                .toList();
+    }
+
+    private static Map<String, Object> profileProjection(MetricProfileVO profile) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("id", require(profile.getId(), "profile id"));
+        result.put("name", require(profile.getName(), "profile name"));
+        result.put("description", blankIfNull(profile.getDescription()));
+        result.put("metrics", metrics(profile.getMetrics()));
+        return result;
+    }
+
+    private static List<Map<String, Object>> metrics(List<MetricProfileVO.MetricMappingVO> metrics) {
+        if (metrics == null) {
+            return List.of();
+        }
+        return metrics.stream()
+                .map(MetricProfileListToolHandler::metricProjection)
+                .toList();
+    }
+
+    private static Map<String, Object> metricProjection(MetricProfileVO.MetricMappingVO metric) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("semanticMetric", require(metric.getSemanticMetric(), "semantic metric"));
+        result.put("name", require(metric.getName(), "metric name"));
+        result.put("unit", blankIfNull(metric.getUnit()));
+        result.put("prometheusMetric", require(metric.getPrometheusMetric(), "prometheus metric"));
+        result.put("promql", require(metric.getPromql(), "promql"));
+        result.put("labels", metric.getLabels() == null ? List.of() : List.copyOf(metric.getLabels()));
+        return result;
+    }
+
+    private static String require(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException("Metric " + field + " is unavailable");
+        }
+        return value;
+    }
+
+    private static String blankIfNull(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MetricsQueryToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MetricsQueryToolHandler.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai.tool;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.cluster.metrics.MetricDataVO;
+import org.apache.rocketmq.studio.cluster.metrics.MetricQueryDTO;
+import org.apache.rocketmq.studio.cluster.metrics.MetricsService;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class MetricsQueryToolHandler implements ToolHandler {
+
+    private static final String NAME = "rmq.metrics.query";
+
+    private final MetricsService metricsService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public Object execute(Map<String, Object> input) {
+        MetricQueryDTO query = MetricQueryDTO.builder()
+                .metric(trimToNull(input.get("metric")))
+                .profileId(trimToNull(input.get("profileId")))
+                .semanticMetric(trimToNull(input.get("semanticMetric")))
+                .start(requiredLong(input.get("start"), "start"))
+                .end(requiredLong(input.get("end"), "end"))
+                .step(requiredString(input.get("step"), "step"))
+                .build();
+        return resultProjection(metricsService.query(query));
+    }
+
+    private static Map<String, Object> resultProjection(MetricDataVO data) {
+        if (data == null) {
+            throw new IllegalStateException("Metric query result is unavailable");
+        }
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("resultType", blankIfNull(data.getResultType()));
+        result.put("series", series(data.getSeries()));
+        result.put("warnings", data.getWarnings() == null ? List.of() : List.copyOf(data.getWarnings()));
+        return result;
+    }
+
+    private static List<Map<String, Object>> series(List<MetricDataVO.MetricSeriesVO> series) {
+        if (series == null) {
+            return List.of();
+        }
+        return series.stream()
+                .map(MetricsQueryToolHandler::seriesProjection)
+                .toList();
+    }
+
+    private static Map<String, Object> seriesProjection(MetricDataVO.MetricSeriesVO series) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("labels", series.getLabels() == null ? Map.of() : Map.copyOf(series.getLabels()));
+        result.put("values", samples(series.getValues()));
+        result.put("histograms", histogramSamples(series.getHistograms()));
+        return result;
+    }
+
+    private static List<Map<String, Object>> samples(List<MetricDataVO.MetricSampleVO> samples) {
+        if (samples == null) {
+            return List.of();
+        }
+        return samples.stream()
+                .map(MetricsQueryToolHandler::sampleProjection)
+                .toList();
+    }
+
+    private static Map<String, Object> sampleProjection(MetricDataVO.MetricSampleVO sample) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("timestamp", sample.getTimestamp());
+        result.put("value", blankIfNull(sample.getValue()));
+        return result;
+    }
+
+    private static List<Map<String, Object>> histogramSamples(
+            List<MetricDataVO.MetricHistogramSampleVO> samples) {
+        if (samples == null) {
+            return List.of();
+        }
+        return samples.stream()
+                .map(MetricsQueryToolHandler::histogramSampleProjection)
+                .toList();
+    }
+
+    private static Map<String, Object> histogramSampleProjection(
+            MetricDataVO.MetricHistogramSampleVO sample) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("timestamp", sample.getTimestamp());
+        JsonNode histogram = sample.getHistogram();
+        result.put("histogram", histogram == null ? Map.of() : histogram);
+        return result;
+    }
+
+    private static String requiredString(Object value, String field) {
+        String text = trimToNull(value);
+        if (text == null) {
+            throw new BusinessException(400, "Metric query " + field + " is required");
+        }
+        return text;
+    }
+
+    private static String trimToNull(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String text = value.toString().trim();
+        return text.isEmpty() ? null : text;
+    }
+
+    private static long requiredLong(Object value, String field) {
+        if (value == null) {
+            throw new BusinessException(400, "Metric query " + field + " is required");
+        }
+        if (value instanceof BigInteger bigInteger) {
+            try {
+                return bigInteger.longValueExact();
+            } catch (ArithmeticException ex) {
+                throw new BusinessException(400, "Metric query " + field + " must fit in a 64-bit integer");
+            }
+        }
+        if (value instanceof Number number) {
+            if (number instanceof Double || number instanceof Float) {
+                double doubleValue = number.doubleValue();
+                if (!Double.isFinite(doubleValue)
+                        || doubleValue > Long.MAX_VALUE
+                        || doubleValue < Long.MIN_VALUE
+                        || doubleValue % 1 != 0) {
+                    throw new BusinessException(400, "Metric query " + field + " must be an integer");
+                }
+            }
+            return number.longValue();
+        }
+        try {
+            return Long.parseLong(value.toString().trim());
+        } catch (NumberFormatException ex) {
+            throw new BusinessException(400, "Metric query " + field + " must be an integer");
+        }
+    }
+
+    private static String blankIfNull(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/server/src/main/resources/tool-catalog/rmq-tools.yaml
+++ b/server/src/main/resources/tool-catalog/rmq-tools.yaml
@@ -181,6 +181,182 @@ tools:
               type: integer
     viewHint: object
     deprecated: false
+  - name: rmq.metrics.profile.list
+    cli:
+      resource: metrics-profile
+      verb: list
+    description: List RocketMQ metric profiles and semantic PromQL mappings.
+    riskLevel: L1
+    permission: metrics:read
+    requiredCapabilities: []
+    inputSchema:
+      type: object
+      required:
+        - cluster
+      additionalProperties: false
+      properties:
+        cluster:
+          type: string
+          minLength: 1
+    outputSchema:
+      type: array
+      items:
+        type: object
+        required:
+          - id
+          - name
+          - description
+          - metrics
+        additionalProperties: false
+        properties:
+          id:
+            type: string
+          name:
+            type: string
+          description:
+            type: string
+          metrics:
+            type: array
+            items:
+              type: object
+              required:
+                - semanticMetric
+                - name
+                - unit
+                - prometheusMetric
+                - promql
+                - labels
+              additionalProperties: false
+              properties:
+                semanticMetric:
+                  type: string
+                name:
+                  type: string
+                unit:
+                  type: string
+                prometheusMetric:
+                  type: string
+                promql:
+                  type: string
+                labels:
+                  type: array
+                  items:
+                    type: string
+    viewHint: object
+    deprecated: false
+  - name: rmq.metrics.query
+    cli:
+      resource: metrics
+      verb: query
+    description: Query Prometheus range metrics through the configured RocketMQ Studio metrics source.
+    riskLevel: L1
+    permission: metrics:read
+    requiredCapabilities: []
+    inputSchema:
+      type: object
+      required:
+        - cluster
+        - start
+        - end
+        - step
+      oneOf:
+        - required:
+            - metric
+          not:
+            anyOf:
+              - required:
+                  - profileId
+              - required:
+                  - semanticMetric
+        - required:
+            - profileId
+            - semanticMetric
+          not:
+            required:
+              - metric
+      additionalProperties: false
+      properties:
+        cluster:
+          type: string
+          minLength: 1
+        metric:
+          type: string
+          minLength: 1
+          maxLength: 4096
+        profileId:
+          type: string
+          minLength: 1
+          maxLength: 128
+        semanticMetric:
+          type: string
+          minLength: 1
+          maxLength: 128
+        start:
+          type: integer
+          minimum: 1
+        end:
+          type: integer
+          minimum: 1
+        step:
+          type: string
+          minLength: 1
+          maxLength: 32
+    outputSchema:
+      type: object
+      required:
+        - resultType
+        - series
+        - warnings
+      additionalProperties: false
+      properties:
+        resultType:
+          type: string
+        series:
+          type: array
+          items:
+            type: object
+            required:
+              - labels
+              - values
+              - histograms
+            additionalProperties: false
+            properties:
+              labels:
+                type: object
+                additionalProperties:
+                  type: string
+              values:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - timestamp
+                    - value
+                  additionalProperties: false
+                  properties:
+                    timestamp:
+                      type: number
+                    value:
+                      type: string
+              histograms:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - timestamp
+                    - histogram
+                  additionalProperties: false
+                  properties:
+                    timestamp:
+                      type: number
+                    histogram:
+                      type: object
+        warnings:
+          type: array
+          items:
+            type: string
+    viewHint: object
+    deprecated: false
   - name: rmq.topic.list
     cli:
       resource: topic

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MetricProfileListToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MetricProfileListToolHandlerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai.tool;
+
+import org.apache.rocketmq.studio.cluster.metrics.MetricProfileService;
+import org.apache.rocketmq.studio.cluster.metrics.MetricProfileVO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MetricProfileListToolHandlerTest {
+
+    @Mock
+    private MetricProfileService metricProfileService;
+
+    @InjectMocks
+    private MetricProfileListToolHandler handler;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void executeShouldDelegateToMetricProfileServiceAndProjectProfiles() {
+        when(metricProfileService.listProfiles()).thenReturn(List.of(profile()));
+
+        Object result = handler.execute(Map.of("cluster", "cluster-v5"));
+
+        assertThat(result).isInstanceOf(List.class);
+        List<Map<String, Object>> profiles = (List<Map<String, Object>>) result;
+        assertThat(profiles).hasSize(1);
+        Map<String, Object> profile = profiles.get(0);
+        assertThat(profile).containsEntry("id", "rocketmq5-native");
+        assertThat(profile).containsEntry("name", "RocketMQ 5.x Native");
+        assertThat(profile).containsEntry("description", "native metrics");
+
+        List<Map<String, Object>> metrics = (List<Map<String, Object>>) profile.get("metrics");
+        assertThat(metrics).hasSize(1);
+        assertThat(metrics.get(0)).containsAllEntriesOf(Map.of(
+                "semanticMetric", "message_in_tps",
+                "name", "Message In TPS",
+                "unit", "messages/s",
+                "prometheusMetric", "rocketmq_messages_in_total",
+                "promql", "sum(rate(rocketmq_messages_in_total[1m])) by (cluster, node_id)"));
+        assertThat(metrics.get(0)).containsEntry("labels", List.of("cluster", "node_id"));
+        verify(metricProfileService).listProfiles();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void executeShouldReturnEmptyMetricListWhenProfileHasNoMetrics() {
+        when(metricProfileService.listProfiles()).thenReturn(List.of(MetricProfileVO.builder()
+                .id("empty")
+                .name("Empty")
+                .description(null)
+                .metrics(null)
+                .build()));
+
+        Object result = handler.execute(Map.of("cluster", "cluster-v5"));
+
+        List<Map<String, Object>> profiles = (List<Map<String, Object>>) result;
+        assertThat(profiles.get(0)).containsEntry("description", "");
+        assertThat(profiles.get(0)).containsEntry("metrics", List.of());
+    }
+
+    private static MetricProfileVO profile() {
+        return MetricProfileVO.builder()
+                .id("rocketmq5-native")
+                .name("RocketMQ 5.x Native")
+                .description("native metrics")
+                .metrics(List.of(MetricProfileVO.MetricMappingVO.builder()
+                        .semanticMetric("message_in_tps")
+                        .name("Message In TPS")
+                        .unit("messages/s")
+                        .prometheusMetric("rocketmq_messages_in_total")
+                        .promql("sum(rate(rocketmq_messages_in_total[1m])) by (cluster, node_id)")
+                        .labels(List.of("cluster", "node_id"))
+                        .build()))
+                .build();
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MetricsQueryToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MetricsQueryToolHandlerTest.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai.tool;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.cluster.metrics.MetricDataVO;
+import org.apache.rocketmq.studio.cluster.metrics.MetricQueryDTO;
+import org.apache.rocketmq.studio.cluster.metrics.MetricsService;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MetricsQueryToolHandlerTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Mock
+    private MetricsService metricsService;
+
+    @InjectMocks
+    private MetricsQueryToolHandler handler;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void executeShouldDelegateRawPromqlQueryAndProjectSamples() {
+        when(metricsService.query(any(MetricQueryDTO.class))).thenReturn(metricData());
+
+        Object result = handler.execute(Map.of(
+                "cluster", "cluster-v5",
+                "metric", "  sum(rate(rocketmq_messages_in_total[1m])) by (cluster)  ",
+                "start", 1700000000L,
+                "end", 1700000300L,
+                "step", " 30s "));
+
+        ArgumentCaptor<MetricQueryDTO> captor = ArgumentCaptor.forClass(MetricQueryDTO.class);
+        verify(metricsService).query(captor.capture());
+        assertThat(captor.getValue())
+                .extracting(MetricQueryDTO::getMetric, MetricQueryDTO::getProfileId,
+                        MetricQueryDTO::getSemanticMetric, MetricQueryDTO::getStart,
+                        MetricQueryDTO::getEnd, MetricQueryDTO::getStep)
+                .containsExactly("sum(rate(rocketmq_messages_in_total[1m])) by (cluster)",
+                        null, null, 1700000000L, 1700000300L, "30s");
+
+        Map<String, Object> output = (Map<String, Object>) result;
+        assertThat(output).containsEntry("resultType", "matrix");
+        assertThat(output).containsEntry("warnings", List.of("partial response"));
+        List<Map<String, Object>> series = (List<Map<String, Object>>) output.get("series");
+        assertThat(series).hasSize(1);
+        assertThat(series.get(0)).containsEntry("labels", Map.of("cluster", "cluster-v5"));
+        assertThat((List<?>) series.get(0).get("values")).hasSize(1);
+        assertThat(series.get(0)).containsEntry("histograms", List.of());
+    }
+
+    @Test
+    void executeShouldDelegateSemanticMetricSelection() {
+        when(metricsService.query(any(MetricQueryDTO.class))).thenReturn(emptyMetricData());
+
+        handler.execute(Map.of(
+                "cluster", "cluster-v5",
+                "profileId", " rocketmq5-native ",
+                "semanticMetric", " consumer_lag_messages ",
+                "start", 1700000000L,
+                "end", 1700000300L,
+                "step", "30s"));
+
+        ArgumentCaptor<MetricQueryDTO> captor = ArgumentCaptor.forClass(MetricQueryDTO.class);
+        verify(metricsService).query(captor.capture());
+        assertThat(captor.getValue())
+                .extracting(MetricQueryDTO::getMetric, MetricQueryDTO::getProfileId,
+                        MetricQueryDTO::getSemanticMetric)
+                .containsExactly(null, "rocketmq5-native", "consumer_lag_messages");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void executeShouldProjectHistogramSamples() {
+        MetricDataVO.MetricHistogramSampleVO histogramSample = MetricDataVO.MetricHistogramSampleVO.builder()
+                .timestamp(1700000000D)
+                .histogram(OBJECT_MAPPER.createObjectNode().put("count", "5"))
+                .build();
+        MetricDataVO.MetricSeriesVO series = MetricDataVO.MetricSeriesVO.builder()
+                .labels(Map.of("cluster", "cluster-v5"))
+                .histograms(List.of(histogramSample))
+                .build();
+        when(metricsService.query(any(MetricQueryDTO.class))).thenReturn(MetricDataVO.builder()
+                .resultType("histogram")
+                .series(List.of(series))
+                .warnings(null)
+                .build());
+
+        Object result = handler.execute(Map.of(
+                "cluster", "cluster-v5",
+                "metric", "rocketmq_histogram",
+                "start", 1700000000L,
+                "end", 1700000300L,
+                "step", "30s"));
+
+        Map<String, Object> output = (Map<String, Object>) result;
+        assertThat(output).containsEntry("warnings", List.of());
+        List<Map<String, Object>> outputSeries = (List<Map<String, Object>>) output.get("series");
+        assertThat(outputSeries.get(0)).containsEntry("values", List.of());
+        List<Map<String, Object>> histograms = (List<Map<String, Object>>) outputSeries.get(0).get("histograms");
+        assertThat(histograms).hasSize(1);
+        assertThat(histograms.get(0).get("histogram").toString()).contains("\"count\":\"5\"");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void executeShouldReturnEmptySeriesWhenMetricDataHasNullLists() {
+        when(metricsService.query(any(MetricQueryDTO.class))).thenReturn(MetricDataVO.builder()
+                .resultType(null)
+                .series(null)
+                .warnings(null)
+                .build());
+
+        Object result = handler.execute(Map.of(
+                "cluster", "cluster-v5",
+                "metric", "up",
+                "start", 1700000000L,
+                "end", 1700000300L,
+                "step", "30s"));
+
+        Map<String, Object> output = (Map<String, Object>) result;
+        assertThat(output).containsEntry("resultType", "");
+        assertThat(output).containsEntry("series", List.of());
+        assertThat(output).containsEntry("warnings", List.of());
+    }
+
+    @Test
+    void executeShouldRejectMissingStart() {
+        assertThatThrownBy(() -> handler.execute(Map.of(
+                "cluster", "cluster-v5",
+                "metric", "up",
+                "end", 1700000300L,
+                "step", "30s")))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("start is required");
+    }
+
+    @Test
+    void executeShouldRejectOutOfRangeTimestamp() {
+        BigInteger overflow = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+
+        assertThatThrownBy(() -> handler.execute(Map.of(
+                "cluster", "cluster-v5",
+                "metric", "up",
+                "start", overflow,
+                "end", 1700000300L,
+                "step", "30s")))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("64-bit integer");
+    }
+
+    private static MetricDataVO metricData() {
+        MetricDataVO.MetricSeriesVO series = MetricDataVO.MetricSeriesVO.builder()
+                .labels(Map.of("cluster", "cluster-v5"))
+                .values(List.of(MetricDataVO.MetricSampleVO.builder()
+                        .timestamp(1700000000D)
+                        .value("42")
+                        .build()))
+                .build();
+        return MetricDataVO.builder()
+                .resultType("matrix")
+                .series(List.of(series))
+                .warnings(List.of("partial response"))
+                .build();
+    }
+
+    private static MetricDataVO emptyMetricData() {
+        return MetricDataVO.builder()
+                .resultType("matrix")
+                .series(List.of())
+                .warnings(List.of())
+                .build();
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolCatalogTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolCatalogTest.java
@@ -42,6 +42,8 @@ class ToolCatalogTest {
                         "rmq.cluster.list",
                         "rmq.capabilities",
                         "rmq.dashboard.summary",
+                        "rmq.metrics.profile.list",
+                        "rmq.metrics.query",
                         "rmq.topic.list",
                         "rmq.group.list",
                         "rmq.message.query",

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
@@ -17,6 +17,11 @@
 package org.apache.rocketmq.studio.ops.ai.tool;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.cluster.metrics.MetricDataVO;
+import org.apache.rocketmq.studio.cluster.metrics.MetricProfileService;
+import org.apache.rocketmq.studio.cluster.metrics.MetricProfileVO;
+import org.apache.rocketmq.studio.cluster.metrics.MetricQueryDTO;
+import org.apache.rocketmq.studio.cluster.metrics.MetricsService;
 import org.apache.rocketmq.studio.auth.AuthenticatedUserContext;
 import org.apache.rocketmq.studio.cluster.broker.ClusterService;
 import org.apache.rocketmq.studio.cluster.broker.ClusterVO;
@@ -49,11 +54,13 @@ import org.springframework.core.io.ClassPathResource;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -64,6 +71,8 @@ class ToolGatewayServiceTest {
     private ToolCatalog catalog;
     private ClusterService clusterService;
     private DashboardService dashboardService;
+    private MetricsService metricsService;
+    private MetricProfileService metricProfileService;
     private MessageService messageService;
     private MetadataService metadataService;
     private AlertService alertService;
@@ -72,6 +81,8 @@ class ToolGatewayServiceTest {
     private ClusterListToolHandler clusterListHandler;
     private CapabilitiesToolHandler capabilitiesHandler;
     private DashboardSummaryToolHandler dashboardSummaryHandler;
+    private MetricProfileListToolHandler metricProfileListHandler;
+    private MetricsQueryToolHandler metricsQueryHandler;
     private TopicListToolHandler topicListHandler;
     private ConsumerGroupListToolHandler consumerGroupListHandler;
     private AlertRuleListToolHandler alertRuleListHandler;
@@ -86,6 +97,8 @@ class ToolGatewayServiceTest {
         catalog = canonicalCatalog();
         clusterService = mock(ClusterService.class);
         dashboardService = mock(DashboardService.class);
+        metricsService = mock(MetricsService.class);
+        metricProfileService = mock(MetricProfileService.class);
         messageService = mock(MessageService.class);
         metadataService = mock(MetadataService.class);
         alertService = mock(AlertService.class);
@@ -94,6 +107,8 @@ class ToolGatewayServiceTest {
         clusterListHandler = new ClusterListToolHandler(clusterService);
         capabilitiesHandler = new CapabilitiesToolHandler(clusterService, capabilityResolver);
         dashboardSummaryHandler = new DashboardSummaryToolHandler(dashboardService);
+        metricProfileListHandler = new MetricProfileListToolHandler(metricProfileService);
+        metricsQueryHandler = new MetricsQueryToolHandler(metricsService);
         topicListHandler = new TopicListToolHandler(metadataService);
         consumerGroupListHandler = new ConsumerGroupListToolHandler(metadataService);
         alertRuleListHandler = new AlertRuleListToolHandler(alertService);
@@ -106,6 +121,8 @@ class ToolGatewayServiceTest {
                 clusterListHandler,
                 capabilitiesHandler,
                 dashboardSummaryHandler,
+                metricProfileListHandler,
+                metricsQueryHandler,
                 topicListHandler,
                 consumerGroupListHandler,
                 alertRuleListHandler,
@@ -137,6 +154,8 @@ class ToolGatewayServiceTest {
                         "rmq.cluster.list",
                         "rmq.capabilities",
                         "rmq.dashboard.summary",
+                        "rmq.metrics.profile.list",
+                        "rmq.metrics.query",
                         "rmq.topic.list",
                         "rmq.group.list",
                         "rmq.message.query",
@@ -156,6 +175,8 @@ class ToolGatewayServiceTest {
                         "rmq.cluster.list",
                         "rmq.capabilities",
                         "rmq.dashboard.summary",
+                        "rmq.metrics.profile.list",
+                        "rmq.metrics.query",
                         "rmq.topic.list",
                         "rmq.group.list",
                         "rmq.alert.rule.list",
@@ -345,6 +366,92 @@ class ToolGatewayServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("input validation failed");
         verifyNoInteractions(dashboardService);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void executesMetricProfileListWithADataMinimizingProjection() {
+        when(metricProfileService.listProfiles()).thenReturn(List.of(metricProfile()));
+
+        Object output = gateway.execute("rmq.metrics.profile.list", Map.of("cluster", "cluster-v5"));
+
+        assertThat(output).isInstanceOf(List.class);
+        List<Map<String, Object>> profiles = (List<Map<String, Object>>) output;
+        assertThat(profiles).hasSize(1);
+        Map<String, Object> profile = profiles.get(0);
+        assertThat(profile).containsEntry("id", "rocketmq5-native");
+        assertThat(profile).containsEntry("name", "RocketMQ 5.x Native");
+        assertThat(profile).containsEntry("description", "native metrics");
+        List<Map<String, Object>> metrics = (List<Map<String, Object>>) profile.get("metrics");
+        assertThat(metrics.get(0)).containsAllEntriesOf(Map.of(
+                "semanticMetric", "consumer_lag_messages",
+                "name", "Consumer Lag",
+                "unit", "messages",
+                "prometheusMetric", "rocketmq_consumer_lag_messages",
+                "promql", "sum(rocketmq_consumer_lag_messages) by (cluster, topic, consumer_group)"));
+        assertThat(metrics.get(0)).containsEntry("labels", List.of("cluster", "topic", "consumer_group"));
+        verify(metricProfileService).listProfiles();
+    }
+
+    @Test
+    void rejectsMetricProfileListWithoutRequiredClusterBeforeHandlerRuns() {
+        assertThatThrownBy(() -> gateway.execute("rmq.metrics.profile.list", Map.of()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("input validation failed");
+        verifyNoInteractions(metricProfileService);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void executesMetricsQueryWithAValidatedOutputContract() {
+        when(metricsService.query(any(MetricQueryDTO.class))).thenReturn(metricData());
+
+        Object output = gateway.execute("rmq.metrics.query", Map.of(
+                "cluster", "cluster-v5",
+                "profileId", "rocketmq5-native",
+                "semanticMetric", "consumer_lag_messages",
+                "start", 1700000000L,
+                "end", 1700000300L,
+                "step", "30s"));
+
+        Map<String, Object> result = (Map<String, Object>) output;
+        assertThat(result).containsEntry("resultType", "matrix");
+        assertThat(result).containsEntry("warnings", List.of("partial response"));
+        List<Map<String, Object>> series = (List<Map<String, Object>>) result.get("series");
+        assertThat(series).hasSize(1);
+        assertThat(series.get(0)).containsEntry("labels", Map.of(
+                "cluster", "cluster-v5",
+                "topic", "TopicA"));
+        assertThat((List<?>) series.get(0).get("values")).hasSize(1);
+        verify(metricsService).query(any(MetricQueryDTO.class));
+    }
+
+    @Test
+    void rejectsMetricsQueryWithoutACompleteMetricSelectionBeforeHandlerRuns() {
+        assertThatThrownBy(() -> gateway.execute("rmq.metrics.query", Map.of(
+                "cluster", "cluster-v5",
+                "profileId", "rocketmq5-native",
+                "start", 1700000000L,
+                "end", 1700000300L,
+                "step", "30s")))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("input validation failed");
+        verifyNoInteractions(metricsService);
+    }
+
+    @Test
+    void rejectsMetricsQueryWithMixedRawAndSemanticSelectionBeforeHandlerRuns() {
+        assertThatThrownBy(() -> gateway.execute("rmq.metrics.query", Map.of(
+                "cluster", "cluster-v5",
+                "metric", "up",
+                "profileId", "rocketmq5-native",
+                "semanticMetric", "broker_health",
+                "start", 1700000000L,
+                "end", 1700000300L,
+                "step", "30s")))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("input validation failed");
+        verifyNoInteractions(metricsService);
     }
 
     @Test
@@ -570,6 +677,8 @@ class ToolGatewayServiceTest {
                 clusterListHandler,
                 capabilitiesHandler,
                 dashboardSummaryHandler,
+                metricProfileListHandler,
+                metricsQueryHandler,
                 topicListHandler,
                 consumerGroupListHandler,
                 alertRuleListHandler,
@@ -596,6 +705,8 @@ class ToolGatewayServiceTest {
                 clusterListHandler,
                 capabilitiesHandler,
                 dashboardSummaryHandler,
+                metricProfileListHandler,
+                metricsQueryHandler,
                 topicListHandler,
                 consumerGroupListHandler,
                 alertRuleListHandler,
@@ -650,6 +761,8 @@ class ToolGatewayServiceTest {
                 clusterListHandler,
                 capabilitiesHandler,
                 dashboardSummaryHandler,
+                metricProfileListHandler,
+                metricsQueryHandler,
                 topicListHandler,
                 consumerGroupListHandler,
                 alertRuleListHandler,
@@ -678,6 +791,8 @@ class ToolGatewayServiceTest {
                 clusterListHandler,
                 capabilitiesHandler,
                 dashboardSummaryHandler,
+                metricProfileListHandler,
+                metricsQueryHandler,
                 topicListHandler,
                 consumerGroupListHandler,
                 alertRuleListHandler,
@@ -707,6 +822,8 @@ class ToolGatewayServiceTest {
                 invalidClusterListHandler,
                 capabilitiesHandler,
                 dashboardSummaryHandler,
+                metricProfileListHandler,
+                metricsQueryHandler,
                 topicListHandler,
                 consumerGroupListHandler,
                 alertRuleListHandler,
@@ -782,6 +899,38 @@ class ToolGatewayServiceTest {
         group.setSubscribedTopics(List.of("order-topic"));
         group.setRetryMaxTimes(16);
         return group;
+    }
+
+    private static MetricProfileVO metricProfile() {
+        return MetricProfileVO.builder()
+                .id("rocketmq5-native")
+                .name("RocketMQ 5.x Native")
+                .description("native metrics")
+                .metrics(List.of(MetricProfileVO.MetricMappingVO.builder()
+                        .semanticMetric("consumer_lag_messages")
+                        .name("Consumer Lag")
+                        .unit("messages")
+                        .prometheusMetric("rocketmq_consumer_lag_messages")
+                        .promql("sum(rocketmq_consumer_lag_messages) by (cluster, topic, consumer_group)")
+                        .labels(List.of("cluster", "topic", "consumer_group"))
+                        .build()))
+                .build();
+    }
+
+    private static MetricDataVO metricData() {
+        MetricDataVO.MetricSeriesVO series = MetricDataVO.MetricSeriesVO.builder()
+                .labels(Map.of("cluster", "cluster-v5", "topic", "TopicA"))
+                .values(List.of(MetricDataVO.MetricSampleVO.builder()
+                        .timestamp(1700000000D)
+                        .value("42")
+                        .build()))
+                .histograms(Collections.emptyList())
+                .build();
+        return MetricDataVO.builder()
+                .resultType("matrix")
+                .series(List.of(series))
+                .warnings(List.of("partial response"))
+                .build();
     }
 
     private static AlertRuleVO alertRule(Long id, String name, String metric, boolean enabled) {


### PR DESCRIPTION
## What is the purpose of the change

This change adds read-only metrics observability tools to the Studio AI tool gateway, so AI/MCP/CLI callers can discover version-aware metric profiles and execute Prometheus range queries through the existing Studio metrics source.

It supports both raw PromQL and semantic metric selections (`profileId` + `semanticMetric`) while reusing the existing metrics validation and query window limits.

## Brief changelog

- Add `rmq.metrics.profile.list` to expose RocketMQ metric profiles and semantic PromQL mappings.
- Add `rmq.metrics.query` to execute range metric queries through `MetricsService`.
- Add data-minimizing projections for metric profiles and metric query results.
- Update tool catalog schemas and gateway/catalog tests for the new tools.

## Verifying this change

- `mvn -Dtest=ToolCatalogTest,ToolGatewayServiceTest,MetricProfileListToolHandlerTest,MetricsQueryToolHandlerTest test`
- `git diff --check`