### PR TITLE
Escape LIKE wildcards in operation-audit search so terms with % or _ match literally

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepository.java
@@ -57,11 +57,12 @@ public class MybatisPlusAuditRepository implements AuditRepository {
                                               String resourceType, String clusterId,
                                               LocalDateTime startDate, LocalDateTime endDate,
                                               String result, int page, int pageSize) {
+        String searchPattern = escapeLike(search);
         QueryWrapper<RmqOperationAudit> query = new QueryWrapper<RmqOperationAudit>()
                 .and(StringUtils.hasText(search), w -> w
-                        .like("operator", search)
-                        .or().like("resource_name", search)
-                        .or().like("detail", search))
+                        .like("operator", searchPattern)
+                        .or().like("resource_name", searchPattern)
+                        .or().like("detail", searchPattern))
                 .eq(StringUtils.hasText(operationType), "operation", operationType)
                 .eq(StringUtils.hasText(resourceType), "resource_type", resourceType)
                 .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
@@ -197,16 +198,29 @@ public class MybatisPlusAuditRepository implements AuditRepository {
     private void applyFilters(QueryWrapper<RmqOperationAudit> query, String search,
                               String operationType, String resourceType, String clusterId,
                               LocalDateTime startDate, LocalDateTime endDate, String result) {
+        String searchPattern = escapeLike(search);
         query.and(StringUtils.hasText(search), w -> w
-                        .like("operator", search)
-                        .or().like("resource_name", search)
-                        .or().like("detail", search))
+                        .like("operator", searchPattern)
+                        .or().like("resource_name", searchPattern)
+                        .or().like("detail", searchPattern))
                 .eq(StringUtils.hasText(operationType), "operation", operationType)
                 .eq(StringUtils.hasText(resourceType), "resource_type", resourceType)
                 .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
                 .ge(startDate != null, "gmt_create", startDate)
                 .le(endDate != null, "gmt_create", endDate)
                 .eq(StringUtils.hasText(result), "result", result);
+    }
+
+    /**
+     * Escapes the SQL LIKE wildcards in a user-supplied search term so the
+     * audit search matches operators, resource names and details literally
+     * instead of acting as a pattern (mirrors QueryHistoryService).
+     */
+    private static String escapeLike(String search) {
+        if (!StringUtils.hasText(search)) {
+            return search;
+        }
+        return search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
@@ -162,6 +162,48 @@ class MybatisPlusAuditRepositoryTest {
         verify(auditMapper).insert(any(RmqOperationAudit.class));
     }
 
+    @Test
+    void findPageEscapesLikeWildcardsInTheSearchTermTest() {
+        when(auditMapper.selectPage(any(IPage.class), any(Wrapper.class)))
+                .thenReturn(new Page<RmqOperationAudit>(1, 20).setRecords(List.of()));
+
+        // "100%_ok" must match operators/details containing that literal text
+        // instead of acting as a LIKE pattern that matches far more rows.
+        repository.findPage("100%_ok", null, null, null, null, null, null, 1, 20);
+
+        ArgumentCaptor<Wrapper<RmqOperationAudit>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(auditMapper).selectPage(any(IPage.class), queryCaptor.capture());
+        QueryWrapper<RmqOperationAudit> query = (QueryWrapper<RmqOperationAudit>) queryCaptor.getValue();
+        // Render the segment first: the nested and(...) conditions are applied lazily,
+        // and their bind parameters only show up in the wrapper afterwards.
+        query.getSqlSegment();
+        assertThat(query.getParamNameValuePairs())
+                .containsValue("%100\\%\\_ok%")
+                .doesNotContainValue("%100%_ok%");
+    }
+
+    @Test
+    void summarizeEscapesLikeWildcardsInEveryAggregateQueryTest() {
+        when(auditMapper.selectMaps(any(Wrapper.class))).thenReturn(List.of());
+        when(auditMapper.selectList(any(Wrapper.class))).thenReturn(List.of());
+
+        repository.summarize("100%", null, null, null, null, null, null);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Wrapper<RmqOperationAudit>> mapsCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(auditMapper, times(4)).selectMaps(mapsCaptor.capture());
+        ArgumentCaptor<Wrapper<RmqOperationAudit>> listCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(auditMapper).selectList(listCaptor.capture());
+        List<Wrapper<RmqOperationAudit>> queries = new java.util.ArrayList<>(mapsCaptor.getAllValues());
+        queries.add(listCaptor.getValue());
+        for (Wrapper<RmqOperationAudit> query : queries) {
+            assertThat(query.getSqlSegment()).contains("operator LIKE", "resource_name LIKE");
+            assertThat(((QueryWrapper<RmqOperationAudit>) query).getParamNameValuePairs())
+                    .containsValue("%100\\%%")
+                    .doesNotContainValue("%100%%");
+        }
+    }
+
     private static RmqOperationAudit auditRecord(Long id) {
         RmqOperationAudit audit = new RmqOperationAudit();
         audit.setId(id);


### PR DESCRIPTION
### Motivation

The operation-audit search box passes the raw term straight into `LIKE` clauses over `operator`, `resource_name` and `detail` (`MybatisPlusAuditRepository.findPage` and the shared `applyFilters` used by `summarize`/`exportLogs`). Because `%` and `_` are SQL LIKE wildcards:

- searching for an operator or topic name containing `%` (e.g. `100%`) matches every row whose text merely *ends* with `100`, and
- `_` matches any single character,

so the audit page and its summary cards can report wildly wrong results for these inputs.

### Changes

- Add a private `escapeLike` helper (same behaviour as the existing `QueryHistoryService.escapeLike`) and apply it to the search term in both `findPage` and `applyFilters`, so the page query, `summarize` aggregates and `exportLogs` all match the term literally.

### Verification

`MybatisPlusAuditRepositoryTest` — two new tests:

- `findPageEscapesLikeWildcardsInTheSearchTermTest`: searching `100%_ok` binds `%100\%\_ok%` instead of the unescaped pattern.
- `summarizeEscapesLikeWildcardsInEveryAggregateQueryTest`: every aggregate query built by `summarize` (result counts, distinct operators, both hotspot GROUP BYs, latest-at lookup) binds the escaped literal.

Before the fix both new tests fail; after it the class is green (11/11).

```
$ mvn -f server/pom.xml test -Dtest='MybatisPlusAuditRepositoryTest'
(before) Tests run: 11, Failures: 2, Errors: 0
(after)  Tests run: 11, Failures: 0, Errors: 0
```