### PR TITLE
Escape LIKE wildcards in instance search so names containing _ or % match literally

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
@@ -62,11 +62,12 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
 
     @Override
     public List<InstanceVO> search(String keyword) {
+        String pattern = escapeLike(keyword);
         return instanceMapper.selectList(
                 new QueryWrapper<RmqInstance>()
-                        .and(w -> w.like("name", keyword)
-                                .or().like("endpoint", keyword)
-                                .or().like("remark", keyword))
+                        .and(w -> w.like("name", pattern)
+                                .or().like("endpoint", pattern)
+                                .or().like("remark", pattern))
                         .orderByAsc("id")).stream()
                 .map(this::toVO)
                 .toList();
@@ -74,12 +75,13 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
 
     @Override
     public List<InstanceVO> findByTypeAndSearch(InstanceType type, String keyword) {
+        String pattern = escapeLike(keyword);
         return instanceMapper.selectList(
                 new QueryWrapper<RmqInstance>()
                         .eq("type", type.name())
-                        .and(w -> w.like("name", keyword)
-                                .or().like("endpoint", keyword)
-                                .or().like("remark", keyword))
+                        .and(w -> w.like("name", pattern)
+                                .or().like("endpoint", pattern)
+                                .or().like("remark", pattern))
                         .orderByAsc("id")).stream()
                 .map(this::toVO)
                 .toList();
@@ -193,6 +195,19 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
     private BusinessException invalidPersistedValue(Long instanceId, String field, String value) {
         return new BusinessException(500, "Invalid persisted instance " + field
                 + " for instance " + instanceId + ": " + value);
+    }
+
+    /**
+     * Escapes the SQL LIKE wildcards in a user-supplied keyword so instance
+     * names, endpoints and remarks are matched literally. Instance names
+     * commonly contain underscores, which would otherwise match any single
+     * character (mirrors QueryHistoryService).
+     */
+    private static String escapeLike(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return keyword;
+        }
+        return keyword.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
     }
 
     private RmqInstance toEntity(InstanceVO vo) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
@@ -110,6 +110,36 @@ class MybatisPlusInstanceRepositoryTest {
     }
 
     @Test
+    void searchShouldEscapeLikeWildcardsTest() {
+        when(instanceMapper.selectList(any(QueryWrapper.class))).thenReturn(List.of());
+
+        // "prod_cluster%" must match instances literally named that way instead of
+        // "_" standing in for any character and "%" for any suffix.
+        repository.search("prod_cluster%");
+
+        ArgumentCaptor<QueryWrapper<RmqInstance>> query = ArgumentCaptor.forClass(QueryWrapper.class);
+        verify(instanceMapper).selectList(query.capture());
+        query.getValue().getSqlSegment();
+        assertThat(query.getValue().getParamNameValuePairs())
+                .containsValue("%prod\\_cluster\\%%")
+                .doesNotContainValue("%prod_cluster%");
+    }
+
+    @Test
+    void findByTypeAndSearchShouldEscapeLikeWildcardsTest() {
+        when(instanceMapper.selectList(any(QueryWrapper.class))).thenReturn(List.of());
+
+        repository.findByTypeAndSearch(InstanceType.DIRECT, "prod_cluster%");
+
+        ArgumentCaptor<QueryWrapper<RmqInstance>> query = ArgumentCaptor.forClass(QueryWrapper.class);
+        verify(instanceMapper).selectList(query.capture());
+        query.getValue().getSqlSegment();
+        assertThat(query.getValue().getParamNameValuePairs())
+                .containsValue("%prod\\_cluster\\%%")
+                .doesNotContainValue("%prod_cluster%");
+    }
+
+    @Test
     void constructorShouldNotSeedDemoInstances() {
         when(instanceMapper.selectList(any(QueryWrapper.class))).thenReturn(List.of());
 


### PR DESCRIPTION
### Motivation

The instance search box passes its raw keyword into `LIKE` clauses over `name`, `endpoint` and `remark` (`MybatisPlusInstanceRepository.search` / `findByTypeAndSearch`, reached from `InstanceService.listInstances` for the instance list page). Since `_` and `%` are SQL LIKE wildcards:

- an underscore in an instance name (very common, e.g. `prod_cluster_1`) silently matches *any* single character, so searching `prod_cluster_1` also returns `prod-cluster-1`, `prodXclusterY1`, …
- a trailing `%` (e.g. pasted from a log line) matches every suffix.

So the search can silently return instances that do not contain the typed text at all.

### Changes

- Add a private `escapeLike` helper (same behaviour as the existing `QueryHistoryService.escapeLike`) and apply it to the keyword in both `search` and `findByTypeAndSearch`.

### Verification

`MybatisPlusInstanceRepositoryTest` — two new tests:

- `searchShouldEscapeLikeWildcardsTest`
- `findByTypeAndSearchShouldEscapeLikeWildcardsTest`

Both assert the bound LIKE value for `prod_cluster%` is `%prod\_cluster\%%` and not the unescaped pattern. Before the fix both fail; after it the class is green (18/18).

```
$ mvn -f server/pom.xml test -Dtest='MybatisPlusInstanceRepositoryTest'
(before) Tests run: 18, Failures: 2, Errors: 0
(after)  Tests run: 18, Failures: 0, Errors: 0
```