### PR TITLE
Escape LIKE wildcards in cloud credential search so names with % or _ match literally

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepository.java
@@ -52,9 +52,10 @@ public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepo
     @Override
     public PageResult<CloudCredentialVO> findPage(InstanceVendor vendor, String search, int page, int pageSize) {
         String normalizedSearch = search == null || search.isBlank() ? null : search.trim();
+        String searchPattern = escapeLike(normalizedSearch);
         QueryWrapper<RmqCloudCredential> q = new QueryWrapper<RmqCloudCredential>()
                 .eq(vendor != null, "vendor", vendor == null ? null : vendor.name())
-                .like(normalizedSearch != null, "name", normalizedSearch)
+                .like(normalizedSearch != null, "name", searchPattern)
                 .orderByDesc("gmt_modified", "id");
         Page<RmqCloudCredential> result = credentialMapper.selectPage(new Page<>(page, pageSize), q);
         return PageResult.of(result.getRecords().stream()
@@ -142,5 +143,17 @@ public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepo
             throw new BusinessException(500, "Invalid persisted cloud credential vendor for credential "
                     + credentialId + ": " + vendor);
         }
+    }
+
+    /**
+     * Escapes the SQL LIKE wildcards in a credential-name search so % and _
+     * in the typed term are matched literally instead of acting as a pattern
+     * (mirrors QueryHistoryService).
+     */
+    private static String escapeLike(String search) {
+        if (search == null || search.isBlank()) {
+            return search;
+        }
+        return search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepositoryTest.java
@@ -110,6 +110,24 @@ class MybatisPlusCloudCredentialRepositoryTest {
         assertThat(query.getParamNameValuePairs()).containsValue("%credential%");
     }
 
+    @Test
+    void findPageShouldEscapeLikeWildcardsInTheSearchTerm() {
+        when(credentialMapper.selectPage(any(IPage.class), any(Wrapper.class)))
+                .thenReturn(new Page<RmqCloudCredential>(1, 20));
+
+        // "aliyun_prod%" must match credentials literally named that way instead of
+        // "_" matching any character and "%" matching every suffix.
+        repository.findPage(null, "aliyun_prod%", 1, 20);
+
+        ArgumentCaptor<Wrapper<RmqCloudCredential>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(credentialMapper).selectPage(any(IPage.class), queryCaptor.capture());
+        QueryWrapper<RmqCloudCredential> query = (QueryWrapper<RmqCloudCredential>) queryCaptor.getValue();
+        query.getCustomSqlSegment();
+        assertThat(query.getParamNameValuePairs())
+                .containsValue("%aliyun\\_prod\\%%")
+                .doesNotContainValue("%aliyun_prod%");
+    }
+
     private RmqCloudCredential entity(Long id, String name, String vendor) {
         RmqCloudCredential entity = new RmqCloudCredential();
         entity.setId(id);


### PR DESCRIPTION
### Motivation

`MybatisPlusCloudCredentialRepository.findPage` feeds the trimmed search term straight into a `LIKE` clause over the credential `name`. Because `%` and `_` are SQL LIKE wildcards, a term like `aliyun_prod%` matches every credential whose name starts with `aliyun` + any single character + `prod`, plus any suffix — silently listing credentials the user did not type.

### Changes

- Add a private `escapeLike` helper (same behaviour as the existing `QueryHistoryService.escapeLike`) and apply it to the normalized search term in `findPage`.

### Verification

`MybatisPlusCloudCredentialRepositoryTest` — new test `findPageShouldEscapeLikeWildcardsInTheSearchTerm` asserts the bound LIKE value for `aliyun_prod%` is `%aliyun\_prod\%%` and not the unescaped pattern. Before the fix it fails; after it the class is green (6/6).

```
$ mvn -f server/pom.xml test -Dtest='MybatisPlusCloudCredentialRepositoryTest'
(before) Tests run: 6, Failures: 1, Errors: 0
(after)  Tests run: 6, Failures: 0, Errors: 0
```

This is the same class of fix as the audit (`MybatisPlusAuditRepository`) and instance (`MybatisPlusInstanceRepository`) search paths, which also bind user input into LIKE clauses without escaping.