### PR TITLE
fix(studio): keep selected range when dashboard switches instances

### DIFF
--- a/web/src/components/MetricsExplorer.tsx
+++ b/web/src/components/MetricsExplorer.tsx
@@ -511,6 +511,10 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
     [profileId, profiles],
   );
   const selectedRange = RANGE_OPTIONS.find((range) => range.value === rangeId) ?? RANGE_OPTIONS[0];
+  const selectedRangeRef = useRef(selectedRange);
+  useEffect(() => {
+    selectedRangeRef.current = selectedRange;
+  }, [selectedRange]);
   const anyLoading =
     Object.values(panels).some((panel) => panel.loading) || Boolean(customPanel?.loading);
   const availableDataSources = useMemo(
@@ -649,7 +653,7 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
         const initialProfile =
           nextProfiles.find((profile) => profile.id === storedProfileId) ?? nextProfiles[0];
         setProfileId(initialProfile?.id ?? '');
-        void loadAll(initialProfile, RANGE_OPTIONS[0]);
+        void loadAll(initialProfile, selectedRangeRef.current);
       })
       .catch(() => {
         if (!cancelled) setProfileError(true);


### PR DESCRIPTION
## Summary

Fix the Metrics Explorer silently reverting to the 1h window when the dashboard switches instances.

## Problem

On the home dashboard, `MetricsExplorer` stays mounted while the instance selector changes. When `instanceId` changes, the profile-loading effect re-runs and reloads every panel, but hardcoded `RANGE_OPTIONS[0]` (1h) instead of the currently selected range. The charts then showed one hour of data while the Segmented control still displayed the user's selection.

## Fix

Track the selected range in a ref and reuse it when the effect reloads panels after an instance change, so the reload honors the current selection.

## Test plan

`cd web && npx tsc -b` passes.

Fixes #4188