### PR TITLE
fix(studio): render alert last-triggered time as UTC

### DIFF
--- a/web/src/pages/ops/alerts.tsx
+++ b/web/src/pages/ops/alerts.tsx
@@ -65,7 +65,7 @@ import {
 } from '../../services/opsService';
 import { attachThresholdUnit, normalizeDuration, normalizeMetric } from './alertRulePayload';
 import { tableScrollX } from '../../utils/table';
-import { formatDateTime } from '../../utils/format';
+import { formatUtcDateTime } from '../../utils/format';
 import { listInstances } from '../../services/instanceService';
 import type { Instance } from '../../api/instance';
 import { downloadBlob } from '../../utils/download';
@@ -696,7 +696,7 @@ const AlertsPage = ({ domain = 'CLUSTER' }: AlertsPageProps) => {
       sorter: (a, b) => (a.lastTriggered ?? '').localeCompare(b.lastTriggered ?? ''),
       render: (_, record) =>
         record.lastTriggered ? (
-          formatDateTime(record.lastTriggered)
+          formatUtcDateTime(record.lastTriggered)
         ) : (
           <span style={{ color: '#999' }}>{t('alerts.neverTriggered')}</span>
         ),


### PR DESCRIPTION
## Summary

Fix the alert rule "最近触发时间" (last-triggered) column rendering a UTC timestamp as browser-local time.

## Problem

The backend stamps `lastTriggered` as a UTC `LocalDateTime` without an offset suffix (e.g. `2026-08-23T23:30:00`). The rule page rendered it with `formatDateTime`, which parses offset-less ISO strings with `new Date(...)` as browser-local time. A rule that fired at 23:30 UTC showed 23:30 in every timezone.

## Fix

Use `formatUtcDateTime` (already used by the system-alert page), which appends `Z` to offset-less strings so they are parsed as UTC. This also covers `/ops/business-alerts`, which reuses the same `AlertsPage` component.

## Test plan

`cd web && npx tsc -b` passes.

Fixes #4174