### PR TITLE
fix(studio): resolve hostname brokers when guarding message id queries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/BrokerTopologyGuards.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/BrokerTopologyGuards.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.provider.apache;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collections;
@@ -101,10 +102,39 @@ public final class BrokerTopologyGuards {
             }
             for (String brokerAddr : brokerData.getBrokerAddrs().values()) {
                 if (StringUtils.hasText(brokerAddr)) {
-                    endpoints.add(brokerAddr.trim());
+                    String trimmed = brokerAddr.trim();
+                    endpoints.add(trimmed);
+                    String resolved = resolveBrokerAddrToIp(trimmed);
+                    if (resolved != null && !resolved.equals(trimmed)) {
+                        endpoints.add(resolved);
+                    }
                 }
             }
         }
         return endpoints;
+    }
+
+    /**
+     * Resolve a {@code host:port} broker address to its {@code ip:port} form, so a broker
+     * registered by hostname still matches the IP embedded in an offset msgId. Returns null
+     * when the address cannot be parsed or resolved.
+     */
+    private static String resolveBrokerAddrToIp(String brokerAddr) {
+        int sep = brokerAddr.lastIndexOf(':');
+        if (sep <= 0 || sep == brokerAddr.length() - 1) {
+            return null;
+        }
+        String host = brokerAddr.substring(0, sep);
+        String port = brokerAddr.substring(sep + 1);
+        // Strip brackets from an IPv6 literal such as "[::1]:10911".
+        if (host.startsWith("[") && host.endsWith("]")) {
+            host = host.substring(1, host.length() - 1);
+        }
+        try {
+            String ip = InetAddress.getByName(host).getHostAddress();
+            return ip + ":" + port;
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/BrokerTopologyGuardsTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/BrokerTopologyGuardsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.apache;
+
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.util.HashMap;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BrokerTopologyGuardsTest {
+
+    @Test
+    void knownBrokerEndpointsShouldIncludeResolvedIpForHostnameRegisteredBroker() throws Exception {
+        ClusterInfo info = new ClusterInfo();
+        HashMap<Long, String> addrs = new HashMap<>();
+        addrs.put(0L, "localhost:10911");
+        HashMap<String, BrokerData> brokerAddrTable = new HashMap<>();
+        brokerAddrTable.put("broker-a",
+                new BrokerData("DefaultCluster", "broker-a", new HashMap<>(addrs)));
+        info.setBrokerAddrTable(brokerAddrTable);
+
+        MQAdminExt admin = mock(MQAdminExt.class);
+        when(admin.examineBrokerClusterInfo()).thenReturn(info);
+
+        Set<String> endpoints = BrokerTopologyGuards.knownBrokerEndpoints(admin);
+
+        String resolvedIp = InetAddress.getByName("localhost").getHostAddress();
+        assertThat(endpoints).contains("localhost:10911");
+        assertThat(endpoints).contains(resolvedIp + ":10911");
+    }
+
+    @Test
+    void knownBrokerEndpointsShouldKeepPlainIpBrokerUnchanged() throws Exception {
+        ClusterInfo info = new ClusterInfo();
+        HashMap<Long, String> addrs = new HashMap<>();
+        addrs.put(0L, "10.0.0.11:10911");
+        HashMap<String, BrokerData> brokerAddrTable = new HashMap<>();
+        brokerAddrTable.put("broker-a",
+                new BrokerData("DefaultCluster", "broker-a", new HashMap<>(addrs)));
+        info.setBrokerAddrTable(brokerAddrTable);
+
+        MQAdminExt admin = mock(MQAdminExt.class);
+        when(admin.examineBrokerClusterInfo()).thenReturn(info);
+
+        Set<String> endpoints = BrokerTopologyGuards.knownBrokerEndpoints(admin);
+
+        assertThat(endpoints).contains("10.0.0.11:10911");
+    }
+}


### PR DESCRIPTION
## Summary

Fix message-id query returning no rows when the broker registers by hostname instead of an IP address.

## Problem

`BrokerTopologyGuards` compared the IP embedded in an offset `msgId` (from `decodedBrokerAddr`) directly against the broker addresses registered with the NameServer (`knownBrokerEndpoints`). When a broker registered by hostname (e.g. `repro-hostname-broker:10911`), the guard misclassified the embedded IP as off-cluster and rejected the lookup, so the message-id query returned zero rows even though the message existed and the official SDK could read it.

## Fix

Also register the resolved `ip:port` form of each known broker endpoint in `knownBrokerEndpoints`, so the embedded-IP comparison matches hostname-registered brokers. Plain-IP brokers are unchanged.

## Test plan

Added `BrokerTopologyGuardsTest` (JUnit 5 + Mockito) covering:
- a hostname-registered broker exposes both the hostname and the resolved IP;
- a plain-IP broker is kept unchanged.

Verified with `mvn test -Dtest=BrokerTopologyGuardsTest` (Java 21, `Tests run: 2, Failures: 0`).

Fixes #4181