### PR TITLE
[Studio] feat: add support diagnostics bundle export

### DIFF
--- a/web/src/pages/settings/AboutTab.tsx
+++ b/web/src/pages/settings/AboutTab.tsx
@@ -15,45 +15,151 @@
  * limitations under the License.
  */
 
-import { Descriptions, Divider, Space, Typography } from 'antd';
-import { BookOutlined, GithubOutlined, GlobalOutlined } from '@ant-design/icons';
+import { useMemo } from 'react';
+import { Alert, Button, Descriptions, Divider, Flex, Space, Typography, message } from 'antd';
+import {
+  BookOutlined,
+  CopyOutlined,
+  DownloadOutlined,
+  GithubOutlined,
+  GlobalOutlined,
+} from '@ant-design/icons';
+import { isMockMode } from '../../services/dataMode';
+import { downloadBlob } from '../../utils/download';
+import {
+  buildSupportBundleFilename,
+  buildSupportBundleSummary,
+  collectSupportBundle,
+  formatSupportBundle,
+  type SupportBundleProduct,
+} from '../../utils/supportBundle';
 
 const { Title, Text, Link: TypoLink } = Typography;
 
-export const AboutTab = () => (
-  <div style={{ maxWidth: 800 }}>
-    <Descriptions column={1} bordered size="small">
-      <Descriptions.Item label="版本">0.1.0</Descriptions.Item>
-      <Descriptions.Item label="构建提交">{__BUILD_COMMIT__}</Descriptions.Item>
-      <Descriptions.Item label="构建时间">{__BUILD_TIME__}</Descriptions.Item>
-      <Descriptions.Item label="RocketMQ 支持版本">4.x / 5.x</Descriptions.Item>
-      <Descriptions.Item label="前端框架">React 18 + Ant Design 5</Descriptions.Item>
-      <Descriptions.Item label="后端框架">Spring Boot 3 + RocketMQ MCP Server</Descriptions.Item>
-      <Descriptions.Item label="License">Apache 2.0</Descriptions.Item>
-    </Descriptions>
+const PRODUCT_INFO: SupportBundleProduct = {
+  name: 'RocketMQ Studio',
+  version: '0.1.0',
+  buildCommit: __BUILD_COMMIT__,
+  buildTime: __BUILD_TIME__,
+  rocketmqVersions: '4.x / 5.x',
+  frontendFramework: 'React 18 + Ant Design 5',
+  backendFramework: 'Spring Boot 3 + RocketMQ MCP Server',
+  license: 'Apache 2.0',
+};
 
-    <Divider />
+const createBundle = () =>
+  collectSupportBundle(PRODUCT_INFO, {
+    effectiveMockMode: isMockMode(),
+  });
 
-    <Title level={5}>相关链接</Title>
-    <Space size="middle" style={{ marginBottom: 24 }}>
-      <TypoLink href="https://github.com/apache/rocketmq" target="_blank" rel="noopener noreferrer">
-        <GithubOutlined /> GitHub
-      </TypoLink>
-      <TypoLink href="https://rocketmq.apache.org/docs/" target="_blank" rel="noopener noreferrer">
-        <BookOutlined /> 文档中心
-      </TypoLink>
-      <TypoLink href="https://rocketmq.apache.org/" target="_blank" rel="noopener noreferrer">
-        <GlobalOutlined /> RocketMQ 社区
-      </TypoLink>
-    </Space>
+const copyText = async (text: string) => {
+  if (!window.navigator.clipboard?.writeText) {
+    throw new Error('Clipboard API is unavailable');
+  }
+  await window.navigator.clipboard.writeText(text);
+};
 
-    <Divider />
+export const AboutTab = () => {
+  const supportBundle = useMemo(() => createBundle(), []);
+  const supportSummary = useMemo(() => buildSupportBundleSummary(supportBundle), [supportBundle]);
 
-    <Text type="secondary">
-      Copyright © {__BUILD_TIME__.slice(0, 4)} Apache Software Foundation. Licensed under the Apache
-      License, Version 2.0.
-    </Text>
-  </div>
-);
+  const handleCopySupportBundle = async () => {
+    try {
+      await copyText(formatSupportBundle(createBundle()));
+      message.success('支持信息包已复制');
+    } catch {
+      message.error('复制支持信息包失败');
+    }
+  };
+
+  const handleDownloadSupportBundle = () => {
+    const bundle = createBundle();
+    downloadBlob(
+      new Blob([formatSupportBundle(bundle)], { type: 'application/json;charset=utf-8' }),
+      buildSupportBundleFilename(bundle),
+    );
+    message.success('支持信息包已下载');
+  };
+
+  return (
+    <div style={{ maxWidth: 920 }}>
+      <Descriptions column={1} bordered size="small">
+        <Descriptions.Item label="版本">{PRODUCT_INFO.version}</Descriptions.Item>
+        <Descriptions.Item label="构建提交">{PRODUCT_INFO.buildCommit}</Descriptions.Item>
+        <Descriptions.Item label="构建时间">{PRODUCT_INFO.buildTime}</Descriptions.Item>
+        <Descriptions.Item label="RocketMQ 支持版本">
+          {PRODUCT_INFO.rocketmqVersions}
+        </Descriptions.Item>
+        <Descriptions.Item label="前端框架">{PRODUCT_INFO.frontendFramework}</Descriptions.Item>
+        <Descriptions.Item label="后端框架">{PRODUCT_INFO.backendFramework}</Descriptions.Item>
+        <Descriptions.Item label="License">{PRODUCT_INFO.license}</Descriptions.Item>
+      </Descriptions>
+
+      <Divider />
+
+      <Flex justify="space-between" align="center" gap={12} wrap style={{ marginBottom: 12 }}>
+        <Title level={5} style={{ margin: 0 }}>
+          支持信息包
+        </Title>
+        <Space>
+          <Button icon={<CopyOutlined />} onClick={() => void handleCopySupportBundle()}>
+            复制 JSON
+          </Button>
+          <Button icon={<DownloadOutlined />} onClick={handleDownloadSupportBundle}>
+            下载 JSON
+          </Button>
+        </Space>
+      </Flex>
+
+      <Alert
+        showIcon
+        type="info"
+        message="已脱敏：Token、密码、密钥、URL 查询参数和 sessionStorage 内容不会写入支持信息包。"
+        style={{ marginBottom: 12 }}
+      />
+
+      <Descriptions
+        column={{ xs: 1, sm: 1, md: 2 }}
+        bordered
+        size="small"
+        items={supportSummary.map((item) => ({
+          key: item.label,
+          label: item.label,
+          children: item.value,
+        }))}
+      />
+
+      <Divider />
+
+      <Title level={5}>相关链接</Title>
+      <Space size="middle" style={{ marginBottom: 24 }}>
+        <TypoLink
+          href="https://github.com/apache/rocketmq"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <GithubOutlined /> GitHub
+        </TypoLink>
+        <TypoLink
+          href="https://rocketmq.apache.org/docs/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <BookOutlined /> 文档中心
+        </TypoLink>
+        <TypoLink href="https://rocketmq.apache.org/" target="_blank" rel="noopener noreferrer">
+          <GlobalOutlined /> RocketMQ 社区
+        </TypoLink>
+      </Space>
+
+      <Divider />
+
+      <Text type="secondary">
+        Copyright © {PRODUCT_INFO.buildTime.slice(0, 4)} Apache Software Foundation. Licensed under
+        the Apache License, Version 2.0.
+      </Text>
+    </div>
+  );
+};
 
 export default AboutTab;

--- a/web/src/pages/settings/__tests__/AboutTab.test.tsx
+++ b/web/src/pages/settings/__tests__/AboutTab.test.tsx
@@ -15,9 +15,25 @@
  * limitations under the License.
  */
 
-import { render, screen } from '@testing-library/react';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { App } from 'antd';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { downloadBlob } from '../../../utils/download';
 import { AboutTab } from '../AboutTab';
+
+vi.mock('../../../services/dataMode', () => ({
+  isMockMode: vi.fn(() => false),
+}));
+
+vi.mock('../../../utils/download', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../../utils/download')>('../../../utils/download');
+  return {
+    ...actual,
+    downloadBlob: vi.fn(),
+  };
+});
 
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
@@ -36,6 +52,22 @@ beforeAll(() => {
 });
 
 describe('AboutTab', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    localStorage.clear();
+    window.history.pushState({}, '', '/settings');
+    if (!window.navigator.clipboard?.writeText) {
+      Object.defineProperty(window.navigator, 'clipboard', {
+        configurable: true,
+        writable: true,
+        value: {
+          writeText: vi.fn().mockResolvedValue(undefined),
+        },
+      });
+    }
+  });
+
   it('renders the injected build metadata and build-year copyright', () => {
     render(<AboutTab />);
 
@@ -47,5 +79,71 @@ describe('AboutTab', () => {
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText('2024-01-15 14:30:00')).not.toBeInTheDocument();
+  });
+
+  it('renders support bundle summary metadata', () => {
+    localStorage.setItem('rocketmq-studio-language', 'en');
+    localStorage.setItem('rocketmq-studio-theme', 'dark');
+    localStorage.setItem('rocketmq-studio-compact', 'true');
+
+    render(<AboutTab />);
+
+    expect(screen.getByText('支持信息包')).toBeInTheDocument();
+    expect(screen.getByText('API 前缀')).toBeInTheDocument();
+    expect(screen.getByText('/api')).toBeInTheDocument();
+    expect(screen.getByText('当前路径')).toBeInTheDocument();
+    expect(screen.getByText('/settings')).toBeInTheDocument();
+    expect(screen.getByText('界面偏好')).toBeInTheDocument();
+    expect(screen.getByText('en / dark / compact=yes')).toBeInTheDocument();
+  });
+
+  it('copies the support bundle JSON snapshot', async () => {
+    localStorage.setItem('token', 'legacy-token');
+    localStorage.setItem('rocketmq-studio-secret', 'secret-value');
+    localStorage.setItem('password', 'password-value');
+    localStorage.setItem('rocketmq-studio-language', 'zh');
+    window.history.pushState({}, '', '/settings?token=abc#unsafe');
+    const user = userEvent.setup();
+
+    render(
+      <App>
+        <AboutTab />
+      </App>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /复制 JSON/ }));
+
+    expect(await screen.findByText('支持信息包已复制')).toBeInTheDocument();
+  });
+
+  it('downloads the support bundle as JSON', async () => {
+    localStorage.setItem('token', 'legacy-token');
+    localStorage.setItem('rocketmq-studio-secret', 'secret-value');
+    localStorage.setItem('password', 'password-value');
+    window.history.pushState({}, '', '/settings?token=abc#unsafe');
+    const user = userEvent.setup();
+    render(
+      <App>
+        <AboutTab />
+      </App>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /下载 JSON/ }));
+
+    await waitFor(() => expect(downloadBlob).toHaveBeenCalledTimes(1));
+    const [blob, filename] = vi.mocked(downloadBlob).mock.calls[0];
+    expect(filename).toMatch(/^rocketmq-studio-support-.*\.json$/);
+    expect(blob.type).toBe('application/json;charset=utf-8');
+    const text = await blob.text();
+    const bundle = JSON.parse(text);
+    expect(bundle.product.buildCommit).toBe(__BUILD_COMMIT__);
+    expect(bundle.runtime.pathname).toBe('/settings');
+    expect(bundle.runtime.hasQueryString).toBe(true);
+    expect(bundle.redaction.unsafeLocalStorageKeysOmitted).toBe(3);
+    expect(text).not.toContain('legacy-token');
+    expect(text).not.toContain('secret-value');
+    expect(text).not.toContain('password-value');
+    expect(text).not.toContain('token=abc');
+    expect(text).not.toContain('#unsafe');
   });
 });

--- a/web/src/utils/supportBundle.test.ts
+++ b/web/src/utils/supportBundle.test.ts
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildSupportBundleFilename,
+  buildSupportBundleSummary,
+  collectSupportBundle,
+  formatSupportBundle,
+  type SupportBundleProduct,
+} from './supportBundle';
+
+const product: SupportBundleProduct = {
+  name: 'RocketMQ Studio',
+  version: '0.1.0',
+  buildCommit: 'abc1234',
+  buildTime: '2026-09-10 12:00',
+  rocketmqVersions: '4.x / 5.x',
+  frontendFramework: 'React 18 + Ant Design 5',
+  backendFramework: 'Spring Boot 3 + RocketMQ MCP Server',
+  license: 'Apache 2.0',
+};
+
+const generatedAt = new Date('2026-09-10T01:02:03.456Z');
+
+function seedSafePreferences() {
+  localStorage.setItem('rocketmq-studio-language', 'en');
+  localStorage.setItem('rocketmq-studio-theme', 'dark');
+  localStorage.setItem('rocketmq-studio-compact', 'true');
+  localStorage.setItem(
+    'rocketmq-studio-data-mode',
+    JSON.stringify({ state: { useMock: true }, version: 0 }),
+  );
+  localStorage.setItem('rocketmq-studio-user', 'operator-a');
+  localStorage.setItem('rocketmq-studio-user-id', '7');
+  localStorage.setItem('rocketmq-studio-user-admin', 'false');
+  localStorage.setItem('proxyAddr', 'proxy-a:8081');
+  localStorage.setItem('clusterId', 'DefaultCluster');
+  localStorage.setItem('rocketmq-studio.metric-profile', 'brokerThroughput');
+  localStorage.setItem('rocketmq-studio-message-trace-topic:instance-a', 'TRACE_TOPIC_A');
+}
+
+describe('support bundle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    window.history.pushState({}, '', '/');
+    vi.restoreAllMocks();
+  });
+
+  it('collects build, runtime, browser and allow-listed preference state', () => {
+    seedSafePreferences();
+
+    const bundle = collectSupportBundle(product, {
+      now: generatedAt,
+      effectiveMockMode: false,
+    });
+
+    expect(bundle.generatedAt).toBe('2026-09-10T01:02:03.456Z');
+    expect(bundle.product).toEqual(product);
+    expect(bundle.runtime.apiBaseUrl).toBe('/api');
+    expect(bundle.runtime.pathname).toBe('/');
+    expect(bundle.preferences).toMatchObject({
+      language: 'en',
+      theme: 'dark',
+      compactMode: 'yes',
+      effectiveDataMode: 'live',
+      persistedDataMode: 'mock',
+      authUserPresent: 'yes',
+      authUserIdPresent: 'yes',
+      authAdmin: 'no',
+      proxyAddressConfigured: 'yes',
+      clusterIdConfigured: 'yes',
+      metricsProfileConfigured: 'yes',
+      customTraceTopicScopes: 1,
+    });
+    expect(bundle.browser.storage.localStorage.status).toBe('available');
+    expect(bundle.browser.storage.sessionStorage.status).toBe('available');
+    expect(bundle.browser.viewport.width).toBe(window.innerWidth);
+  });
+
+  it('omits sensitive localStorage values from the formatted JSON', () => {
+    seedSafePreferences();
+    localStorage.setItem('token', 'bearer-token-value');
+    localStorage.setItem('rocketmq-studio-secret', 'signing-secret-value');
+    localStorage.setItem('password', 'plain-password-value');
+    localStorage.setItem('custom-ui-state', 'not-needed');
+    sessionStorage.setItem(
+      'rocketmq-studio-ai-chat-history',
+      JSON.stringify({ conversations: [{ content: 'incident details' }] }),
+    );
+
+    const text = formatSupportBundle(collectSupportBundle(product, { now: generatedAt }));
+
+    expect(text).toContain('"unsafeLocalStorageKeysOmitted": 3');
+    expect(text).toContain('"unknownLocalStorageKeysOmitted": 1');
+    expect(text).toContain('"sessionStorageValuesOmitted": true');
+    expect(text).not.toContain('bearer-token-value');
+    expect(text).not.toContain('signing-secret-value');
+    expect(text).not.toContain('plain-password-value');
+    expect(text).not.toContain('not-needed');
+    expect(text).not.toContain('incident details');
+    expect(text).not.toContain('TRACE_TOPIC_A');
+    expect(text).not.toContain('operator-a');
+    expect(text).not.toContain('proxy-a:8081');
+    expect(text).not.toContain('DefaultCluster');
+  });
+
+  it('strips query strings and hash fragments while recording their presence', () => {
+    window.history.pushState({}, '', '/settings?token=abc#frag');
+
+    const bundle = collectSupportBundle(product, { now: generatedAt });
+
+    expect(bundle.runtime.pathname).toBe('/settings');
+    expect(bundle.runtime.hasQueryString).toBe(true);
+    expect(bundle.runtime.hasHash).toBe(true);
+    expect(bundle.redaction.routeQueryAndHashOmitted).toBe(true);
+    expect(formatSupportBundle(bundle)).not.toContain('token=abc');
+    expect(formatSupportBundle(bundle)).not.toContain('#frag');
+  });
+
+  it('reports unavailable storage without throwing', () => {
+    const storage = {
+      get length() {
+        throw new Error('blocked');
+      },
+      key: () => {
+        throw new Error('blocked');
+      },
+      getItem: () => {
+        throw new Error('blocked');
+      },
+      setItem: () => {
+        throw new Error('blocked');
+      },
+      removeItem: () => {
+        throw new Error('blocked');
+      },
+      clear: () => undefined,
+    } as unknown as Storage;
+
+    const bundle = collectSupportBundle(product, {
+      now: generatedAt,
+      localStorageRef: storage,
+      sessionStorageRef: storage,
+    });
+
+    expect(bundle.browser.storage.localStorage).toMatchObject({
+      status: 'unavailable',
+      readable: false,
+      writable: false,
+      keyCount: 0,
+    });
+    expect(bundle.browser.storage.localStorage.error).toContain('Error: blocked');
+    expect(bundle.preferences.language).toBe('unknown');
+    expect(bundle.preferences.persistedDataMode).toBe('unset');
+  });
+
+  it('marks malformed persisted data mode separately from the effective data mode', () => {
+    localStorage.setItem('rocketmq-studio-data-mode', '{"state":');
+
+    const bundle = collectSupportBundle(product, {
+      now: generatedAt,
+      effectiveMockMode: true,
+    });
+
+    expect(bundle.preferences.persistedDataMode).toBe('invalid');
+    expect(bundle.preferences.effectiveDataMode).toBe('mock');
+  });
+
+  it('builds a stable support bundle filename from commit and generation time', () => {
+    const bundle = collectSupportBundle(
+      {
+        ...product,
+        buildCommit: 'feature/support bundle',
+      },
+      { now: generatedAt },
+    );
+
+    expect(buildSupportBundleFilename(bundle)).toBe(
+      'rocketmq-studio-support-feature_supp-2026-09-10T01-02-03-456Z.json',
+    );
+  });
+
+  it('returns compact summary rows for the About page', () => {
+    seedSafePreferences();
+
+    const summary = buildSupportBundleSummary(
+      collectSupportBundle(product, { now: generatedAt, effectiveMockMode: true }),
+    );
+
+    expect(summary).toEqual(
+      expect.arrayContaining([
+        { label: '构建', value: '0.1.0 / abc1234' },
+        { label: 'API 前缀', value: '/api' },
+        { label: '当前路径', value: window.location.pathname },
+        { label: '数据模式', value: 'mock' },
+        { label: '界面偏好', value: 'en / dark / compact=yes' },
+      ]),
+    );
+  });
+});

--- a/web/src/utils/supportBundle.ts
+++ b/web/src/utils/supportBundle.ts
@@ -1,0 +1,459 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { API_BASE_URL } from '../config';
+import { LANGUAGE_STORAGE_KEY } from '../i18n/languagePreference';
+import { COMPACT_STORAGE_KEY, THEME_STORAGE_KEY, type ThemeMode } from '../theme/themePreference';
+import {
+  USER_ADMIN_STORAGE_KEY,
+  USER_ID_STORAGE_KEY,
+  USER_STORAGE_KEY,
+} from '../stores/authStorage';
+
+type Availability = 'available' | 'unavailable';
+type KnownBoolean = 'yes' | 'no' | 'unknown';
+type DataMode = 'mock' | 'live' | 'unset' | 'invalid' | 'unknown';
+type ColorScheme = 'dark' | 'light' | 'unknown';
+type StorageKind = 'localStorage' | 'sessionStorage';
+
+export interface SupportBundleProduct {
+  name: string;
+  version: string;
+  buildCommit: string;
+  buildTime: string;
+  rocketmqVersions: string;
+  frontendFramework: string;
+  backendFramework: string;
+  license: string;
+}
+
+export interface StorageProbe {
+  status: Availability;
+  readable: boolean;
+  writable: boolean;
+  keyCount: number;
+  error?: string;
+}
+
+export interface SupportBundlePreferences {
+  language: 'zh' | 'en' | 'unknown';
+  theme: ThemeMode | 'unknown';
+  compactMode: KnownBoolean;
+  effectiveDataMode: Exclude<DataMode, 'unset' | 'invalid'>;
+  persistedDataMode: DataMode;
+  authUserPresent: KnownBoolean;
+  authUserIdPresent: KnownBoolean;
+  authAdmin: KnownBoolean;
+  proxyAddressConfigured: KnownBoolean;
+  clusterIdConfigured: KnownBoolean;
+  metricsProfileConfigured: KnownBoolean;
+  customTraceTopicScopes: number;
+}
+
+export interface SupportBundleRuntime {
+  apiBaseUrl: string;
+  origin: string;
+  pathname: string;
+  hasQueryString: boolean;
+  hasHash: boolean;
+  protocol: string;
+  online: KnownBoolean;
+}
+
+export interface SupportBundleBrowser {
+  userAgent: string;
+  language: string;
+  languages: string[];
+  platform: string;
+  cookieEnabled: KnownBoolean;
+  doNotTrack: string;
+  hardwareConcurrency: number | null;
+  maxTouchPoints: number | null;
+  colorScheme: ColorScheme;
+  timezone: string;
+  timezoneOffsetMinutes: number;
+  viewport: {
+    width: number;
+    height: number;
+    devicePixelRatio: number;
+  };
+  screen: {
+    width: number;
+    height: number;
+    colorDepth: number | null;
+  };
+  storage: Record<StorageKind, StorageProbe>;
+}
+
+export interface SupportBundleRedaction {
+  routeQueryAndHashOmitted: boolean;
+  unsafeLocalStorageKeysOmitted: number;
+  unknownLocalStorageKeysOmitted: number;
+  sessionStorageValuesOmitted: boolean;
+  notes: string[];
+}
+
+export interface SupportBundle {
+  generatedAt: string;
+  product: SupportBundleProduct;
+  runtime: SupportBundleRuntime;
+  browser: SupportBundleBrowser;
+  preferences: SupportBundlePreferences;
+  redaction: SupportBundleRedaction;
+}
+
+export interface SupportBundleSummaryItem {
+  label: string;
+  value: string;
+}
+
+export interface CollectSupportBundleOptions {
+  now?: Date;
+  windowRef?: Window;
+  navigatorRef?: Navigator;
+  localStorageRef?: Storage;
+  sessionStorageRef?: Storage;
+  effectiveMockMode?: boolean;
+}
+
+const DATA_MODE_STORAGE_KEY = 'rocketmq-studio-data-mode';
+const METRICS_PROFILE_STORAGE_KEY = 'rocketmq-studio.metric-profile';
+const TRACE_TOPIC_STORAGE_PREFIX = 'rocketmq-studio-message-trace-topic:';
+const PROXY_ADDRESS_STORAGE_KEY = 'proxyAddr';
+const CLUSTER_ID_STORAGE_KEY = 'clusterId';
+const SENSITIVE_KEY_PATTERN =
+  /(token|secret|password|credential|bearer|authorization|apikey|api-key|access[-_]?key)/i;
+
+const SAFE_LOCAL_STORAGE_KEYS = new Set([
+  LANGUAGE_STORAGE_KEY,
+  THEME_STORAGE_KEY,
+  COMPACT_STORAGE_KEY,
+  DATA_MODE_STORAGE_KEY,
+  USER_STORAGE_KEY,
+  USER_ID_STORAGE_KEY,
+  USER_ADMIN_STORAGE_KEY,
+  PROXY_ADDRESS_STORAGE_KEY,
+  CLUSTER_ID_STORAGE_KEY,
+  METRICS_PROFILE_STORAGE_KEY,
+]);
+
+const truncate = (value: string, maxLength = 240) =>
+  value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+
+const asKnownBoolean = (value: boolean | undefined | null): KnownBoolean => {
+  if (value === true) return 'yes';
+  if (value === false) return 'no';
+  return 'unknown';
+};
+
+const storageError = (error: unknown) =>
+  error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+
+function storageFromWindow(windowRef: Window | undefined, kind: StorageKind): Storage | undefined {
+  if (!windowRef) return undefined;
+  try {
+    return windowRef[kind];
+  } catch {
+    return undefined;
+  }
+}
+
+function readStorageValue(storage: Storage | undefined, key: string): string | null {
+  if (!storage) return null;
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function storageKeys(storage: Storage | undefined): string[] {
+  if (!storage) return [];
+  const keys: string[] = [];
+  try {
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index);
+      if (key) keys.push(key);
+    }
+  } catch {
+    return [];
+  }
+  return keys.sort((left, right) => left.localeCompare(right));
+}
+
+function probeStorage(storage: Storage | undefined, probeKey: string): StorageProbe {
+  if (!storage) {
+    return { status: 'unavailable', readable: false, writable: false, keyCount: 0 };
+  }
+
+  let readable = false;
+  let writable = false;
+  let keyCount = 0;
+  let error: string | undefined;
+
+  try {
+    keyCount = storage.length;
+    readable = true;
+  } catch (caught) {
+    error = storageError(caught);
+  }
+
+  try {
+    storage.setItem(probeKey, '1');
+    storage.removeItem(probeKey);
+    writable = true;
+    keyCount = storage.length;
+  } catch (caught) {
+    error = error ?? storageError(caught);
+  }
+
+  return {
+    status: readable || writable ? 'available' : 'unavailable',
+    readable,
+    writable,
+    keyCount,
+    ...(error ? { error: truncate(error) } : {}),
+  };
+}
+
+function parseLanguage(value: string | null): SupportBundlePreferences['language'] {
+  return value === 'zh' || value === 'en' ? value : 'unknown';
+}
+
+function parseTheme(value: string | null): SupportBundlePreferences['theme'] {
+  return value === 'light' || value === 'dark' || value === 'system' ? value : 'unknown';
+}
+
+function parseCompact(value: string | null): KnownBoolean {
+  if (value === 'true') return 'yes';
+  if (value === 'false') return 'no';
+  return 'unknown';
+}
+
+function parseDataMode(value: string | null): DataMode {
+  if (value == null || value.trim() === '') return 'unset';
+  try {
+    const parsed = JSON.parse(value) as { state?: { useMock?: unknown } };
+    if (parsed?.state?.useMock === true) return 'mock';
+    if (parsed?.state?.useMock === false) return 'live';
+    return 'invalid';
+  } catch {
+    return 'invalid';
+  }
+}
+
+function summarizePreferences(
+  storage: Storage | undefined,
+  keys: string[],
+  effectiveMockMode?: boolean,
+): SupportBundlePreferences {
+  const persistedDataMode = parseDataMode(readStorageValue(storage, DATA_MODE_STORAGE_KEY));
+  const effectiveDataMode =
+    effectiveMockMode === true
+      ? 'mock'
+      : effectiveMockMode === false
+        ? 'live'
+        : persistedDataMode === 'mock' || persistedDataMode === 'live'
+          ? persistedDataMode
+          : 'unknown';
+
+  return {
+    language: parseLanguage(readStorageValue(storage, LANGUAGE_STORAGE_KEY)),
+    theme: parseTheme(readStorageValue(storage, THEME_STORAGE_KEY)),
+    compactMode: parseCompact(readStorageValue(storage, COMPACT_STORAGE_KEY)),
+    effectiveDataMode,
+    persistedDataMode,
+    authUserPresent: asKnownBoolean(Boolean(readStorageValue(storage, USER_STORAGE_KEY))),
+    authUserIdPresent: asKnownBoolean(Boolean(readStorageValue(storage, USER_ID_STORAGE_KEY))),
+    authAdmin: parseCompact(readStorageValue(storage, USER_ADMIN_STORAGE_KEY)),
+    proxyAddressConfigured: asKnownBoolean(
+      Boolean(readStorageValue(storage, PROXY_ADDRESS_STORAGE_KEY)),
+    ),
+    clusterIdConfigured: asKnownBoolean(Boolean(readStorageValue(storage, CLUSTER_ID_STORAGE_KEY))),
+    metricsProfileConfigured: asKnownBoolean(
+      Boolean(readStorageValue(storage, METRICS_PROFILE_STORAGE_KEY)),
+    ),
+    customTraceTopicScopes: keys.filter((key) => key.startsWith(TRACE_TOPIC_STORAGE_PREFIX)).length,
+  };
+}
+
+function summarizeRuntime(windowRef: Window | undefined): SupportBundleRuntime {
+  const location = windowRef?.location;
+  return {
+    apiBaseUrl: API_BASE_URL,
+    origin: location?.origin ?? 'unknown',
+    pathname: location?.pathname ?? 'unknown',
+    hasQueryString: Boolean(location?.search),
+    hasHash: Boolean(location?.hash),
+    protocol: location?.protocol ?? 'unknown',
+    online: asKnownBoolean(windowRef?.navigator?.onLine),
+  };
+}
+
+function detectColorScheme(windowRef: Window | undefined): ColorScheme {
+  try {
+    if (windowRef?.matchMedia?.('(prefers-color-scheme: dark)').matches) return 'dark';
+    if (windowRef?.matchMedia?.('(prefers-color-scheme: light)').matches) return 'light';
+  } catch {
+    return 'unknown';
+  }
+  return 'unknown';
+}
+
+function summarizeBrowser(
+  windowRef: Window | undefined,
+  navigatorRef: Navigator | undefined,
+  localStorageProbe: StorageProbe,
+  sessionStorageProbe: StorageProbe,
+): SupportBundleBrowser {
+  const nav = navigatorRef ?? windowRef?.navigator;
+  const screen = windowRef?.screen;
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'unknown';
+
+  return {
+    userAgent: truncate(nav?.userAgent ?? 'unknown'),
+    language: nav?.language ?? 'unknown',
+    languages: Array.from(nav?.languages ?? []),
+    platform: nav?.platform ?? 'unknown',
+    cookieEnabled: asKnownBoolean(nav?.cookieEnabled),
+    doNotTrack: nav?.doNotTrack ?? 'unknown',
+    hardwareConcurrency:
+      typeof nav?.hardwareConcurrency === 'number' ? nav.hardwareConcurrency : null,
+    maxTouchPoints: typeof nav?.maxTouchPoints === 'number' ? nav.maxTouchPoints : null,
+    colorScheme: detectColorScheme(windowRef),
+    timezone,
+    timezoneOffsetMinutes: new Date().getTimezoneOffset(),
+    viewport: {
+      width: windowRef?.innerWidth ?? 0,
+      height: windowRef?.innerHeight ?? 0,
+      devicePixelRatio: windowRef?.devicePixelRatio ?? 1,
+    },
+    screen: {
+      width: screen?.width ?? 0,
+      height: screen?.height ?? 0,
+      colorDepth: typeof screen?.colorDepth === 'number' ? screen.colorDepth : null,
+    },
+    storage: {
+      localStorage: localStorageProbe,
+      sessionStorage: sessionStorageProbe,
+    },
+  };
+}
+
+function summarizeRedaction(keys: string[], runtime: SupportBundleRuntime): SupportBundleRedaction {
+  const traceTopicKeys = keys.filter((key) => key.startsWith(TRACE_TOPIC_STORAGE_PREFIX));
+  const knownKeys = new Set([...SAFE_LOCAL_STORAGE_KEYS, ...traceTopicKeys]);
+  const unsafe = keys.filter((key) => SENSITIVE_KEY_PATTERN.test(key));
+  const unknown = keys.filter((key) => !knownKeys.has(key) && !SENSITIVE_KEY_PATTERN.test(key));
+
+  return {
+    routeQueryAndHashOmitted: runtime.hasQueryString || runtime.hasHash,
+    unsafeLocalStorageKeysOmitted: unsafe.length,
+    unknownLocalStorageKeysOmitted: unknown.length,
+    sessionStorageValuesOmitted: true,
+    notes: [
+      'Local storage values are limited to allow-listed UI preferences and presence flags.',
+      'Token, password, secret, credential, bearer and authorization-like keys are omitted.',
+      'Route query strings, hash fragments and all sessionStorage values are omitted.',
+    ],
+  };
+}
+
+export function collectSupportBundle(
+  product: SupportBundleProduct,
+  options: CollectSupportBundleOptions = {},
+): SupportBundle {
+  const windowRef = options.windowRef ?? (typeof window === 'undefined' ? undefined : window);
+  const navigatorRef =
+    options.navigatorRef ?? (typeof navigator === 'undefined' ? undefined : navigator);
+  const localStorage = options.localStorageRef ?? storageFromWindow(windowRef, 'localStorage');
+  const sessionStorage =
+    options.sessionStorageRef ?? storageFromWindow(windowRef, 'sessionStorage');
+  const now = options.now ?? new Date();
+  const localKeys = storageKeys(localStorage);
+  const runtime = summarizeRuntime(windowRef);
+
+  return {
+    generatedAt: now.toISOString(),
+    product,
+    runtime,
+    browser: summarizeBrowser(
+      windowRef,
+      navigatorRef,
+      probeStorage(localStorage, '__rocketmq_studio_support_local_probe__'),
+      probeStorage(sessionStorage, '__rocketmq_studio_support_session_probe__'),
+    ),
+    preferences: summarizePreferences(localStorage, localKeys, options.effectiveMockMode),
+    redaction: summarizeRedaction(localKeys, runtime),
+  };
+}
+
+export function formatSupportBundle(bundle: SupportBundle): string {
+  return `${JSON.stringify(bundle, null, 2)}\n`;
+}
+
+export function buildSupportBundleFilename(bundle: SupportBundle): string {
+  const commit = bundle.product.buildCommit.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 12) || 'dev';
+  const timestamp = bundle.generatedAt.replace(/[:.]/g, '-');
+  return `rocketmq-studio-support-${commit}-${timestamp}.json`;
+}
+
+export function buildSupportBundleSummary(bundle: SupportBundle): SupportBundleSummaryItem[] {
+  const storage = bundle.browser.storage.localStorage;
+  return [
+    {
+      label: '构建',
+      value: `${bundle.product.version} / ${bundle.product.buildCommit}`,
+    },
+    {
+      label: '生成时间',
+      value: bundle.generatedAt,
+    },
+    {
+      label: 'API 前缀',
+      value: bundle.runtime.apiBaseUrl,
+    },
+    {
+      label: '当前路径',
+      value: bundle.runtime.pathname,
+    },
+    {
+      label: '数据模式',
+      value: bundle.preferences.effectiveDataMode,
+    },
+    {
+      label: '界面偏好',
+      value: `${bundle.preferences.language} / ${bundle.preferences.theme} / compact=${bundle.preferences.compactMode}`,
+    },
+    {
+      label: '本地存储',
+      value: `${storage.status}, ${storage.keyCount} keys`,
+    },
+    {
+      label: '浏览器',
+      value: `${bundle.browser.platform} / ${bundle.browser.language}`,
+    },
+    {
+      label: '视口',
+      value: `${bundle.browser.viewport.width}x${bundle.browser.viewport.height}@${bundle.browser.viewport.devicePixelRatio}`,
+    },
+    {
+      label: '时区',
+      value: bundle.browser.timezone,
+    },
+  ];
+}


### PR DESCRIPTION
## What is the purpose of the change

Add a support diagnostics bundle to the Studio About page so users can copy or download a redacted JSON snapshot when reporting environment-specific problems.

The bundle includes build metadata, API prefix, current pathname, browser/runtime details, viewport, timezone, storage availability, data mode, and UI preference presence. Sensitive values are intentionally omitted, including token/password/secret/credential-like localStorage keys, unknown localStorage values, all sessionStorage values, and URL query/hash content.

## Brief changelog

- Add support bundle collection, formatting, filename, summary, and redaction utilities.
- Add copy and download actions for the support bundle on the Studio About page.
- Add tests for diagnostics collection, redaction, filename generation, About page rendering, copy, and download behavior.

## Verifying this change

- `npm test -- supportBundle AboutTab --run`
- `npx eslint src/pages/settings/AboutTab.tsx src/pages/settings/__tests__/AboutTab.test.tsx src/utils/supportBundle.ts src/utils/supportBundle.test.ts`
- `git diff --check`
- `npm run build`