### PR TITLE
[studio][ISSUE #4176] Make cloud instance endpoint read-only in the edit dialog

### DIFF
--- a/web/src/pages/instance/__tests__/InstancePage.test.tsx
+++ b/web/src/pages/instance/__tests__/InstancePage.test.tsx
@@ -81,6 +81,7 @@ const instance = (
   name: string,
   type: Instance['type'] = 'PROXY_CLUSTER',
   remark: Instance['remark'] = '',
+  vendor?: Instance['vendor'],
 ): Instance => ({
   id,
   name,
@@ -91,6 +92,7 @@ const instance = (
   consumerGroupCount: 1,
   gmtCreate: '2026-01-01T00:00:00Z',
   gmtModified: '2026-01-01T00:00:00Z',
+  ...(vendor ? { vendor } : {}),
 });
 
 const renderPage = () =>
@@ -367,6 +369,35 @@ describe('InstancePage', () => {
           instanceId: 'production-proxy',
           type: 'DIRECT',
           endpoint: 'namesrv-new:9876',
+        }),
+      ),
+    );
+  });
+
+  it('disables the endpoint field when editing a cloud instance', async () => {
+    const user = userEvent.setup();
+    vi.mocked(instanceService.listInstances).mockResolvedValue([
+      instance(3, 'aliyun-instance', 'CLOUD', '', 'ALIYUN'),
+    ]);
+    vi.mocked(instanceService.updateInstance).mockResolvedValue(
+      instance(3, 'aliyun-instance', 'CLOUD', '', 'ALIYUN'),
+    );
+    renderPage();
+
+    expect(await screen.findByText('aliyun-instance')).toBeInTheDocument();
+    const row = screen.getByRole('row', { name: /aliyun-instance/ });
+    await user.click(within(row).getByRole('button', { name: /编\s*辑/ }));
+    const dialog = await screen.findByRole('dialog');
+
+    const endpointInput = within(dialog).getByLabelText('接入地址');
+    expect(endpointInput).toBeDisabled();
+    await user.click(within(dialog).getByRole('button', { name: /保\s*存/ }));
+
+    await waitFor(() =>
+      expect(instanceService.updateInstance).toHaveBeenCalledWith(
+        expect.objectContaining({
+          instanceId: 'aliyun-instance',
+          endpoint: 'aliyun-instance:8080',
         }),
       ),
     );

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -1041,6 +1041,9 @@ const InstancePage = () => {
             extra={getEndpointExtra(editInstanceType)}
           >
             <Input
+              disabled={
+                editingInstance?.vendor === 'ALIYUN' || editingInstance?.vendor === 'TENCENT'
+              }
               placeholder={
                 editInstanceType === 'DIRECT'
                   ? t('instance.directEndpointPlaceholder')


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #4176

### Brief Description

The backend already ignores endpoint updates for Aliyun/Tencent instances and resolves the endpoint from the cloud catalog (`InstanceService.updateInstance` only calls `setEndpoint` for non-cloud vendors). The edit dialog still rendered an editable 接入地址 input and always showed success, so operators could believe an endpoint change was saved.

This change disables the endpoint field when editing a cloud instance, matching the existing cloud-only type lock and the `instance.cloudEndpointExtra` copy.

### How Did You Test This Change?

```text
Node 24 vitest run src/pages/instance/__tests__/InstancePage.test.tsx -t "disables the endpoint"
Test Files  1 passed (1)
Tests       1 passed | 23 skipped (24)

Node 24 vitest run src/pages/instance/__tests__/InstancePage.test.tsx -t "updates instance type and endpoint"
Test Files  1 passed (1)
Tests       1 passed | 23 skipped (24)
```

AI-assisted contribution; implementation and tests were reviewed and verified locally.
