### PR TITLE
[Studio] feat: add LiteTopic capacity risk insights

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2730,6 +2730,128 @@ const translations: Record<string, Record<Lang, string>> = {
   'liteTopic.sessionStatus': { zh: '会话状态', en: 'Session Status' },
   'liteTopic.creationCount': { zh: '创建数量', en: 'Creation Count' },
   'liteTopic.liteTopics': { zh: 'LiteTopic 列表', en: 'LiteTopics' },
+  'liteTopicInsights.title': { zh: '容量风险洞察', en: 'Capacity Risk Insights' },
+  'liteTopicInsights.level.healthy': { zh: '健康', en: 'Healthy' },
+  'liteTopicInsights.level.notice': { zh: '提示', en: 'Notice' },
+  'liteTopicInsights.level.warning': { zh: '关注', en: 'Warning' },
+  'liteTopicInsights.level.critical': { zh: '高风险', en: 'Critical' },
+  'liteTopicInsights.topicUsage': { zh: 'Topic 配额', en: 'Topic Quota' },
+  'liteTopicInsights.sessionUsage': { zh: 'Session 配额', en: 'Session Quota' },
+  'liteTopicInsights.ttlAttention': { zh: 'TTL 关注项', en: 'TTL Attention' },
+  'liteTopicInsights.totalBacklog': { zh: '总积压', en: 'Total Backlog' },
+  'liteTopicInsights.remainingTopics': {
+    zh: '剩余 {count} 个 Topic 名额',
+    en: '{count} topic slots remaining',
+  },
+  'liteTopicInsights.sessions': { zh: '{count} 个活跃 Session', en: '{count} active sessions' },
+  'liteTopicInsights.ttlBreakdown': {
+    zh: '{expired} 个已过期，{expiring} 个即将过期',
+    en: '{expired} expired, {expiring} expiring soon',
+  },
+  'liteTopicInsights.patterns': { zh: '{count} 个模式', en: '{count} patterns' },
+  'liteTopicInsights.findings': { zh: '需要处理的容量信号', en: 'Capacity signals to review' },
+  'liteTopicInsights.healthyMessage': {
+    zh: '当前筛选范围内未发现 LiteTopic 容量风险',
+    en: 'No LiteTopic capacity risk found in the current filter',
+  },
+  'liteTopicInsights.backlogHotspots': { zh: '积压热点', en: 'Backlog Hotspots' },
+  'liteTopicInsights.ttlAttentionPatterns': {
+    zh: 'TTL 与空闲模式',
+    en: 'TTL and Idle Patterns',
+  },
+  'liteTopicInsights.namespacePressure': { zh: '命名空间压力', en: 'Namespace Pressure' },
+  'liteTopicInsights.patternLabel': { zh: '模式：{pattern}', en: 'Pattern: {pattern}' },
+  'liteTopicInsights.namespaceLabel': { zh: '命名空间：{namespace}', en: 'Namespace: {namespace}' },
+  'liteTopicInsights.patternSummary': {
+    zh: '{patterns} 个模式 / {topics} 个 Topic',
+    en: '{patterns} patterns / {topics} topics',
+  },
+  'liteTopicInsights.noBacklog': { zh: '当前没有积压热点', en: 'No backlog hotspot' },
+  'liteTopicInsights.noTtlRisk': { zh: '当前没有 TTL 风险', en: 'No TTL risk' },
+  'liteTopicInsights.issue.topicQuotaCritical': {
+    zh: 'Topic 配额已使用 {value}，接近上限 {limit}',
+    en: 'Topic quota usage is {value}, close to limit {limit}',
+  },
+  'liteTopicInsights.issue.topicQuotaWarning': {
+    zh: 'Topic 配额已使用 {value}',
+    en: 'Topic quota usage is {value}',
+  },
+  'liteTopicInsights.issue.sessionQuotaCritical': {
+    zh: 'Session 配额已使用 {value}，接近上限 {limit}',
+    en: 'Session quota usage is {value}, close to limit {limit}',
+  },
+  'liteTopicInsights.issue.sessionQuotaWarning': {
+    zh: 'Session 配额已使用 {value}',
+    en: 'Session quota usage is {value}',
+  },
+  'liteTopicInsights.issue.creationRateCritical': {
+    zh: '创建速率已使用 {value}，接近上限 {limit}',
+    en: 'Creation rate usage is {value}, close to limit {limit}',
+  },
+  'liteTopicInsights.issue.creationRateWarning': {
+    zh: '创建速率已使用 {value}',
+    en: 'Creation rate usage is {value}',
+  },
+  'liteTopicInsights.issue.expiredPatterns': {
+    zh: '{namespace} 下有 {count} 个已过期模式，代表模式 {pattern}',
+    en: '{count} expired patterns in {namespace}, example {pattern}',
+  },
+  'liteTopicInsights.issue.expiringPatterns': {
+    zh: '{namespace} 下有 {count} 个即将过期模式，代表模式 {pattern}',
+    en: '{count} patterns expiring soon in {namespace}, example {pattern}',
+  },
+  'liteTopicInsights.issue.backlogHotspot': {
+    zh: '{namespace}/{pattern} 当前积压 {count} 条',
+    en: '{namespace}/{pattern} has {count} backlogged messages',
+  },
+  'liteTopicInsights.issue.unknownTtlStatus': {
+    zh: '{count} 个模式返回未知 TTL 状态，代表模式 {pattern}',
+    en: '{count} patterns returned unknown TTL status, example {pattern}',
+  },
+  'liteTopicInsights.issue.idlePatterns': {
+    zh: '{count} 个模式长期无活跃会话，代表模式 {pattern}',
+    en: '{count} patterns have been idle for a long time, example {pattern}',
+  },
+  'liteTopicInsights.issue.unknown': {
+    zh: '未知 LiteTopic 容量信号',
+    en: 'Unknown LiteTopic capacity signal',
+  },
+  'liteTopicInsights.recommendation.requestTopicQuota': {
+    zh: '评估扩容 Topic 配额或清理过期模式',
+    en: 'Evaluate increasing topic quota or cleaning expired patterns',
+  },
+  'liteTopicInsights.recommendation.requestSessionQuota': {
+    zh: '评估扩容 Session 配额或回收空闲会话',
+    en: 'Evaluate increasing session quota or reclaiming idle sessions',
+  },
+  'liteTopicInsights.recommendation.throttleCreation': {
+    zh: '限制短时间内的 LiteTopic 创建速率',
+    en: 'Throttle short-term LiteTopic creation rate',
+  },
+  'liteTopicInsights.recommendation.extendTtl': {
+    zh: '对仍在使用的模式延长 TTL',
+    en: 'Extend TTL for patterns that are still in use',
+  },
+  'liteTopicInsights.recommendation.cleanExpired': {
+    zh: '清理已过期且无业务流量的模式',
+    en: 'Clean expired patterns without business traffic',
+  },
+  'liteTopicInsights.recommendation.drainBacklog': {
+    zh: '优先排查积压热点的消费能力',
+    en: 'Prioritize consumer capacity for backlog hotspots',
+  },
+  'liteTopicInsights.recommendation.checkUnknownStatus': {
+    zh: '检查返回未知状态的提供方数据',
+    en: 'Check provider data that returned unknown status',
+  },
+  'liteTopicInsights.recommendation.reviewIdlePatterns': {
+    zh: '复核长期空闲模式是否可以回收',
+    en: 'Review long-idle patterns for reclamation',
+  },
+  'liteTopicInsights.recommendation.review': {
+    zh: '复核 LiteTopic 使用情况',
+    en: 'Review LiteTopic usage',
+  },
 
   // ─── Common (additional) ───
   'common.loading': { zh: '加载中', en: 'Loading' },

--- a/web/src/pages/studio/LiteTopic.tsx
+++ b/web/src/pages/studio/LiteTopic.tsx
@@ -60,6 +60,7 @@ import {
   type LiteTopicSession,
 } from '../../api/liteTopic';
 import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
+import LiteTopicCapacityInsights from './LiteTopicCapacityInsights';
 
 const formatDuration = (ms: number | undefined | null): string => {
   if (ms == null) return '-';
@@ -787,6 +788,10 @@ const LiteTopicPage: React.FC = () => {
 
       {/* Quota Panel */}
       {renderQuotaPanel()}
+
+      {quota && (
+        <LiteTopicCapacityInsights quota={quota} topics={filteredTopicList} loading={loading} />
+      )}
 
       {/* Search / Filter Bar */}
       <Card variant="borderless" style={{ marginBottom: 16, borderRadius: 8 }}>

--- a/web/src/pages/studio/LiteTopicCapacityInsights.tsx
+++ b/web/src/pages/studio/LiteTopicCapacityInsights.tsx
@@ -1,0 +1,433 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Alert,
+  Card,
+  Col,
+  Empty,
+  Flex,
+  Progress,
+  Row,
+  Skeleton,
+  Space,
+  Statistic,
+  Table,
+  Tag,
+  Typography,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import type { LiteTopicItem, LiteTopicQuota } from '../../api/liteTopic';
+import { useLang } from '../../i18n/LangContext';
+import {
+  buildLiteTopicCapacityInsights,
+  type LiteTopicCapacityIssue,
+  type LiteTopicCapacityIssueCode,
+  type LiteTopicCapacityLevel,
+  type LiteTopicNamespaceSignal,
+  type LiteTopicPatternSignal,
+  type LiteTopicRecommendationCode,
+} from '../../utils/liteTopicCapacityInsights';
+import { tableScrollX } from '../../utils/table';
+
+const { Text } = Typography;
+
+interface Props {
+  quota: LiteTopicQuota | null;
+  topics: LiteTopicItem[];
+  loading: boolean;
+}
+
+const levelMeta: Record<
+  LiteTopicCapacityLevel,
+  { color: string; alertType: 'success' | 'info' | 'warning' | 'error' }
+> = {
+  healthy: { color: 'success', alertType: 'success' },
+  notice: { color: 'processing', alertType: 'info' },
+  warning: { color: 'warning', alertType: 'warning' },
+  critical: { color: 'error', alertType: 'error' },
+};
+
+const ttlStatusColor = (status: string): string => {
+  if (status === 'ACTIVE') return 'success';
+  if (status === 'EXPIRING_SOON') return 'warning';
+  if (status === 'EXPIRED') return 'error';
+  return 'default';
+};
+
+const issueTextKey = (code: LiteTopicCapacityIssueCode): string => {
+  switch (code) {
+    case 'TOPIC_QUOTA_CRITICAL':
+      return 'liteTopicInsights.issue.topicQuotaCritical';
+    case 'TOPIC_QUOTA_WARNING':
+      return 'liteTopicInsights.issue.topicQuotaWarning';
+    case 'SESSION_QUOTA_CRITICAL':
+      return 'liteTopicInsights.issue.sessionQuotaCritical';
+    case 'SESSION_QUOTA_WARNING':
+      return 'liteTopicInsights.issue.sessionQuotaWarning';
+    case 'CREATION_RATE_CRITICAL':
+      return 'liteTopicInsights.issue.creationRateCritical';
+    case 'CREATION_RATE_WARNING':
+      return 'liteTopicInsights.issue.creationRateWarning';
+    case 'EXPIRED_PATTERNS':
+      return 'liteTopicInsights.issue.expiredPatterns';
+    case 'EXPIRING_PATTERNS':
+      return 'liteTopicInsights.issue.expiringPatterns';
+    case 'BACKLOG_HOTSPOT':
+      return 'liteTopicInsights.issue.backlogHotspot';
+    case 'UNKNOWN_TTL_STATUS':
+      return 'liteTopicInsights.issue.unknownTtlStatus';
+    case 'IDLE_PATTERNS':
+      return 'liteTopicInsights.issue.idlePatterns';
+    default:
+      return 'liteTopicInsights.issue.unknown';
+  }
+};
+
+const recommendationTextKey = (code: LiteTopicRecommendationCode): string => {
+  switch (code) {
+    case 'REQUEST_TOPIC_QUOTA':
+      return 'liteTopicInsights.recommendation.requestTopicQuota';
+    case 'REQUEST_SESSION_QUOTA':
+      return 'liteTopicInsights.recommendation.requestSessionQuota';
+    case 'THROTTLE_CREATION':
+      return 'liteTopicInsights.recommendation.throttleCreation';
+    case 'EXTEND_TTL':
+      return 'liteTopicInsights.recommendation.extendTtl';
+    case 'CLEAN_EXPIRED':
+      return 'liteTopicInsights.recommendation.cleanExpired';
+    case 'DRAIN_BACKLOG':
+      return 'liteTopicInsights.recommendation.drainBacklog';
+    case 'CHECK_UNKNOWN_STATUS':
+      return 'liteTopicInsights.recommendation.checkUnknownStatus';
+    case 'REVIEW_IDLE_PATTERNS':
+      return 'liteTopicInsights.recommendation.reviewIdlePatterns';
+    default:
+      return 'liteTopicInsights.recommendation.review';
+  }
+};
+
+const formatPercent = (value: number | null): string =>
+  value == null ? '-' : `${value.toLocaleString(undefined, { maximumFractionDigits: 1 })}%`;
+
+const formatNumber = (value: number): string =>
+  value.toLocaleString(undefined, { maximumFractionDigits: 0 });
+
+const formatDuration = (ms: number | null): string => {
+  if (ms == null) return '-';
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  if (ms < 3_600_000) return `${(ms / 60_000).toFixed(1)}min`;
+  if (ms < 86_400_000) return `${(ms / 3_600_000).toFixed(1)}h`;
+  return `${(ms / 86_400_000).toFixed(1)}d`;
+};
+
+const formatLastActive = (timestamp: number | null): string => {
+  if (timestamp == null) return '-';
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? '-' : date.toLocaleString();
+};
+
+const renderQuotaProgress = (percent: number | null) => (
+  <Progress
+    percent={percent ?? 0}
+    showInfo={false}
+    size="small"
+    status={percent != null && percent >= 90 ? 'exception' : 'normal'}
+  />
+);
+
+const LiteTopicCapacityInsights = ({ quota, topics, loading }: Props) => {
+  const { t } = useLang();
+  const insights = buildLiteTopicCapacityInsights(quota, topics);
+  const level = levelMeta[insights.level];
+  const visibleIssues = insights.issues.slice(0, 5);
+  const ttlAndIdlePatterns = [...insights.ttlAttentionPatterns, ...insights.idlePatterns]
+    .filter(
+      (signal, index, allSignals) =>
+        allSignals.findIndex((item) => item.key === signal.key) === index,
+    )
+    .slice(0, 5);
+
+  const renderIssue = (issue: LiteTopicCapacityIssue) => (
+    <Tag key={`${issue.code}-${issue.pattern ?? 'global'}`} color={levelMeta[issue.level].color}>
+      {t(issueTextKey(issue.code), {
+        count: formatNumber(issue.count ?? 0),
+        value: issue.percent == null ? '-' : formatPercent(issue.percent),
+        pattern: issue.pattern ?? '-',
+        namespace: issue.namespace ?? '-',
+        limit: issue.limit == null ? '-' : formatNumber(issue.limit),
+      })}
+    </Tag>
+  );
+
+  const patternColumns: ColumnsType<LiteTopicPatternSignal> = [
+    {
+      title: t('liteTopic.pattern'),
+      dataIndex: 'topicPattern',
+      key: 'topicPattern',
+      render: (pattern: string, record) => (
+        <Flex vertical gap={2}>
+          <Text strong ellipsis={{ tooltip: pattern }}>
+            {t('liteTopicInsights.patternLabel', { pattern })}
+          </Text>
+          <Text type="secondary">
+            {t('liteTopicInsights.namespaceLabel', { namespace: record.namespace })}
+          </Text>
+        </Flex>
+      ),
+    },
+    {
+      title: t('liteTopic.backlog'),
+      dataIndex: 'totalBacklog',
+      key: 'totalBacklog',
+      width: 110,
+      align: 'right',
+      render: (value: number) => formatNumber(value),
+    },
+    {
+      title: t('liteTopic.avgTtl'),
+      dataIndex: 'averageTTL',
+      key: 'averageTTL',
+      width: 100,
+      render: (value: number | null) => formatDuration(value),
+    },
+    {
+      title: t('liteTopic.status'),
+      dataIndex: 'ttlStatus',
+      key: 'ttlStatus',
+      width: 120,
+      render: (status: string) => <Tag color={ttlStatusColor(status)}>{status}</Tag>,
+    },
+  ];
+
+  const namespaceColumns: ColumnsType<LiteTopicNamespaceSignal> = [
+    {
+      title: t('liteTopic.namespace'),
+      dataIndex: 'namespace',
+      key: 'namespace',
+      render: (namespace: string, record) => (
+        <Flex vertical gap={2}>
+          <Text strong>{t('liteTopicInsights.namespaceLabel', { namespace })}</Text>
+          <Text type="secondary">
+            {t('liteTopicInsights.patternSummary', {
+              patterns: formatNumber(record.patternCount),
+              topics: formatNumber(record.topicCount),
+            })}
+          </Text>
+        </Flex>
+      ),
+    },
+    {
+      title: t('liteTopic.backlog'),
+      dataIndex: 'totalBacklog',
+      key: 'totalBacklog',
+      width: 110,
+      align: 'right',
+      render: (value: number) => formatNumber(value),
+    },
+    {
+      title: t('liteTopic.consumers'),
+      dataIndex: 'consumerCount',
+      key: 'consumerCount',
+      width: 100,
+      align: 'right',
+      render: (value: number) => formatNumber(value),
+    },
+    {
+      title: t('liteTopic.status'),
+      key: 'status',
+      width: 120,
+      render: (_, record) => (
+        <Tag color={levelMeta[record.level].color}>
+          {t(`liteTopicInsights.level.${record.level}`)}
+        </Tag>
+      ),
+    },
+  ];
+  const ttlColumns: ColumnsType<LiteTopicPatternSignal> = [
+    ...patternColumns.slice(0, 3),
+    {
+      title: t('liteTopic.lastActive'),
+      dataIndex: 'lastActiveTime',
+      key: 'lastActiveTime',
+      width: 170,
+      render: (value: number | null) => formatLastActive(value),
+    },
+  ];
+
+  if (loading) {
+    return (
+      <Card title={t('liteTopicInsights.title')} style={{ marginBottom: 16 }}>
+        <Skeleton active paragraph={{ rows: 4 }} />
+      </Card>
+    );
+  }
+
+  if (!quota && topics.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card
+      title={t('liteTopicInsights.title')}
+      extra={<Tag color={level.color}>{t(`liteTopicInsights.level.${insights.level}`)}</Tag>}
+      style={{ marginBottom: 16, borderRadius: 8 }}
+    >
+      <Row gutter={[12, 12]} style={{ marginBottom: 16 }}>
+        <Col xs={12} lg={6}>
+          <Card size="small">
+            <Statistic
+              title={t('liteTopicInsights.topicUsage')}
+              value={formatPercent(insights.topicUsagePercent)}
+            />
+            {renderQuotaProgress(insights.topicUsagePercent)}
+            <Text type="secondary">
+              {t('liteTopicInsights.remainingTopics', {
+                count:
+                  insights.remainingTopicSlots == null
+                    ? '-'
+                    : formatNumber(insights.remainingTopicSlots),
+              })}
+            </Text>
+          </Card>
+        </Col>
+        <Col xs={12} lg={6}>
+          <Card size="small">
+            <Statistic
+              title={t('liteTopicInsights.sessionUsage')}
+              value={formatPercent(insights.sessionUsagePercent)}
+            />
+            {renderQuotaProgress(insights.sessionUsagePercent)}
+            <Text type="secondary">
+              {t('liteTopicInsights.sessions', { count: formatNumber(insights.totalSessions) })}
+            </Text>
+          </Card>
+        </Col>
+        <Col xs={12} lg={6}>
+          <Card size="small">
+            <Statistic
+              title={t('liteTopicInsights.ttlAttention')}
+              value={insights.expiredCount + insights.expiringSoonCount}
+            />
+            <Text type="secondary">
+              {t('liteTopicInsights.ttlBreakdown', {
+                expired: formatNumber(insights.expiredCount),
+                expiring: formatNumber(insights.expiringSoonCount),
+              })}
+            </Text>
+          </Card>
+        </Col>
+        <Col xs={12} lg={6}>
+          <Card size="small">
+            <Statistic
+              title={t('liteTopicInsights.totalBacklog')}
+              value={formatNumber(insights.totalBacklog)}
+            />
+            <Text type="secondary">
+              {t('liteTopicInsights.patterns', { count: formatNumber(insights.totalPatterns) })}
+            </Text>
+          </Card>
+        </Col>
+      </Row>
+
+      <Alert
+        showIcon
+        type={level.alertType}
+        message={t('liteTopicInsights.findings')}
+        description={
+          visibleIssues.length === 0 ? (
+            t('liteTopicInsights.healthyMessage')
+          ) : (
+            <Flex vertical gap={10}>
+              <Space size={[6, 6]} wrap>
+                {visibleIssues.map(renderIssue)}
+              </Space>
+              {insights.recommendations.length > 0 && (
+                <Space size={[6, 6]} wrap>
+                  {insights.recommendations.map((code) => (
+                    <Tag key={code}>{t(recommendationTextKey(code))}</Tag>
+                  ))}
+                </Space>
+              )}
+            </Flex>
+          )
+        }
+        style={{ marginBottom: 16 }}
+      />
+
+      <Row gutter={[12, 12]}>
+        <Col xs={24} lg={12}>
+          <Card size="small" title={t('liteTopicInsights.backlogHotspots')}>
+            {insights.backlogHotspots.length === 0 ? (
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description={t('liteTopicInsights.noBacklog')}
+              />
+            ) : (
+              <Table
+                size="small"
+                rowKey="key"
+                dataSource={insights.backlogHotspots}
+                columns={patternColumns}
+                pagination={false}
+                scroll={{ x: tableScrollX(patternColumns) }}
+              />
+            )}
+          </Card>
+        </Col>
+        <Col xs={24} lg={12}>
+          <Card size="small" title={t('liteTopicInsights.ttlAttentionPatterns')}>
+            {insights.ttlAttentionPatterns.length === 0 && insights.idlePatterns.length === 0 ? (
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description={t('liteTopicInsights.noTtlRisk')}
+              />
+            ) : (
+              <Table
+                size="small"
+                rowKey="key"
+                dataSource={ttlAndIdlePatterns}
+                columns={ttlColumns}
+                pagination={false}
+                scroll={{ x: tableScrollX(ttlColumns) }}
+              />
+            )}
+          </Card>
+        </Col>
+        <Col span={24}>
+          <Card size="small" title={t('liteTopicInsights.namespacePressure')}>
+            {insights.namespaceSignals.length === 0 ? (
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('common.noData')} />
+            ) : (
+              <Table
+                size="small"
+                rowKey="namespace"
+                dataSource={insights.namespaceSignals}
+                columns={namespaceColumns}
+                pagination={false}
+                scroll={{ x: tableScrollX(namespaceColumns) }}
+              />
+            )}
+          </Card>
+        </Col>
+      </Row>
+    </Card>
+  );
+};
+
+export default LiteTopicCapacityInsights;

--- a/web/src/pages/studio/__tests__/LiteTopicCapacityInsights.test.tsx
+++ b/web/src/pages/studio/__tests__/LiteTopicCapacityInsights.test.tsx
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, within } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { App } from 'antd';
+import type { LiteTopicItem, LiteTopicQuota } from '../../../api/liteTopic';
+import { LangProvider } from '../../../i18n/LangContext';
+import LiteTopicCapacityInsights from '../LiteTopicCapacityInsights';
+
+const quota: LiteTopicQuota = {
+  currentTopicCount: 92,
+  maxTopicCount: 100,
+  currentSessionCount: 81,
+  maxSessionCount: 100,
+  currentCreationRate: 20,
+  maxCreationRate: 100,
+};
+
+const topics: LiteTopicItem[] = [
+  {
+    namespace: 'default',
+    topicPattern: 'expired-*',
+    topicCount: 30,
+    consumerCount: 8,
+    totalBacklog: 120_000,
+    averageTTL: 3_600_000,
+    ttlStatus: 'EXPIRED',
+    lastActiveTime: Date.now() - 10_000,
+    sessionIds: ['session-a', 'session-b'],
+  },
+  {
+    namespace: 'payments',
+    topicPattern: 'soon-*',
+    topicCount: 4,
+    consumerCount: 1,
+    totalBacklog: 20,
+    averageTTL: 600_000,
+    ttlStatus: 'EXPIRING_SOON',
+    lastActiveTime: Date.now() - 5_000,
+    sessionIds: ['session-c'],
+  },
+];
+
+const renderPanel = (props = {}) =>
+  render(
+    <App>
+      <LangProvider>
+        <LiteTopicCapacityInsights quota={quota} topics={topics} loading={false} {...props} />
+      </LangProvider>
+    </App>,
+  );
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+describe('LiteTopicCapacityInsights', () => {
+  it('renders quota pressure, TTL findings, recommendations, and hotspot tables', () => {
+    renderPanel();
+
+    expect(screen.getByText('容量风险洞察')).toBeInTheDocument();
+    expect(screen.getAllByText('高风险')).not.toHaveLength(0);
+    expect(screen.getByText('Topic 配额')).toBeInTheDocument();
+    expect(screen.getByText('92%')).toBeInTheDocument();
+    expect(screen.getByText('剩余 8 个 Topic 名额')).toBeInTheDocument();
+    expect(screen.getByText('需要处理的容量信号')).toBeInTheDocument();
+    expect(screen.getByText(/Topic 配额已使用 92%/u)).toBeInTheDocument();
+    expect(screen.getByText(/expired-\* 当前积压 120,000 条/u)).toBeInTheDocument();
+    expect(screen.getByText('评估扩容 Topic 配额或清理过期模式')).toBeInTheDocument();
+    expect(screen.getByText('优先排查积压热点的消费能力')).toBeInTheDocument();
+
+    const hotspotCard = screen.getByText('积压热点').closest('.ant-card');
+    expect(hotspotCard).not.toBeNull();
+    expect(within(hotspotCard as HTMLElement).getByText('模式：expired-*')).toBeInTheDocument();
+    expect(within(hotspotCard as HTMLElement).getByText('120,000')).toBeInTheDocument();
+
+    const namespaceCard = screen.getByText('命名空间压力').closest('.ant-card');
+    expect(namespaceCard).not.toBeNull();
+    expect(within(namespaceCard as HTMLElement).getByText('命名空间：default')).toBeInTheDocument();
+    expect(
+      within(namespaceCard as HTMLElement).getByText('1 个模式 / 30 个 Topic'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a healthy empty state when usage is below thresholds', () => {
+    renderPanel({
+      quota: {
+        currentTopicCount: 10,
+        maxTopicCount: 100,
+        currentSessionCount: 5,
+        maxSessionCount: 100,
+        currentCreationRate: 1,
+        maxCreationRate: 100,
+      },
+      topics: [
+        {
+          namespace: 'default',
+          topicPattern: 'active-*',
+          topicCount: 1,
+          consumerCount: 1,
+          totalBacklog: 0,
+          ttlStatus: 'ACTIVE',
+          lastActiveTime: Date.now(),
+        },
+      ],
+    });
+
+    expect(screen.getAllByText('健康')).not.toHaveLength(0);
+    expect(screen.getByText('当前筛选范围内未发现 LiteTopic 容量风险')).toBeInTheDocument();
+    expect(screen.getByText('当前没有积压热点')).toBeInTheDocument();
+    expect(screen.getByText('当前没有 TTL 风险')).toBeInTheDocument();
+  });
+
+  it('shows a skeleton while LiteTopic data is refreshing', () => {
+    const { container } = renderPanel({ loading: true });
+
+    expect(screen.getByText('容量风险洞察')).toBeInTheDocument();
+    expect(container.querySelector('.ant-skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('需要处理的容量信号')).not.toBeInTheDocument();
+  });
+
+  it('does not render when both quota and topics are unavailable', () => {
+    renderPanel({ quota: null, topics: [] });
+
+    expect(screen.queryByText('容量风险洞察')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/utils/liteTopicCapacityInsights.test.ts
+++ b/web/src/utils/liteTopicCapacityInsights.test.ts
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { LiteTopicItem, LiteTopicQuota } from '../api/liteTopic';
+import {
+  buildLiteTopicCapacityInsights,
+  liteTopicCapacityLevelRank,
+} from './liteTopicCapacityInsights';
+
+const NOW = Date.UTC(2026, 8, 4, 10, 0, 0);
+
+const quota = (overrides: Partial<LiteTopicQuota> = {}): LiteTopicQuota => ({
+  currentTopicCount: 91,
+  maxTopicCount: 100,
+  currentSessionCount: 76,
+  maxSessionCount: 100,
+  currentCreationRate: 82,
+  maxCreationRate: 100,
+  usageRate: undefined,
+  sessionUsageRate: undefined,
+  ...overrides,
+});
+
+const topic = (overrides: Partial<LiteTopicItem> = {}): LiteTopicItem => ({
+  namespace: 'default',
+  topicPattern: 'orders-*',
+  topicCount: 10,
+  consumerCount: 2,
+  totalBacklog: 0,
+  averageTTL: 86_400_000,
+  ttlStatus: 'ACTIVE',
+  lastActiveTime: NOW - 3_600_000,
+  sessionIds: ['session-a'],
+  ...overrides,
+});
+
+describe('LiteTopic capacity insights', () => {
+  it('classifies quota saturation, creation rate pressure, and TTL risks', () => {
+    const insights = buildLiteTopicCapacityInsights(
+      quota(),
+      [
+        topic({
+          topicPattern: 'expired-*',
+          ttlStatus: 'EXPIRED',
+          totalBacklog: 120_000,
+          sessionIds: ['session-a', 'session-b'],
+        }),
+        topic({
+          topicPattern: 'expiring-*',
+          ttlStatus: 'EXPIRING_SOON',
+          totalBacklog: 12_000,
+        }),
+      ],
+      NOW,
+    );
+
+    expect(insights.level).toBe('critical');
+    expect(insights.topicUsagePercent).toBe(91);
+    expect(insights.sessionUsagePercent).toBe(76);
+    expect(insights.creationRatePercent).toBe(82);
+    expect(insights.remainingTopicSlots).toBe(9);
+    expect(insights.totalBacklog).toBe(132_000);
+    expect(insights.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining([
+        'TOPIC_QUOTA_CRITICAL',
+        'SESSION_QUOTA_WARNING',
+        'CREATION_RATE_WARNING',
+        'EXPIRED_PATTERNS',
+        'EXPIRING_PATTERNS',
+        'BACKLOG_HOTSPOT',
+      ]),
+    );
+    expect(insights.recommendations).toEqual(
+      expect.arrayContaining([
+        'REQUEST_TOPIC_QUOTA',
+        'REQUEST_SESSION_QUOTA',
+        'THROTTLE_CREATION',
+        'CLEAN_EXPIRED',
+        'EXTEND_TTL',
+        'DRAIN_BACKLOG',
+      ]),
+    );
+  });
+
+  it('uses provider ratios when present and accepts percent-shaped ratio values', () => {
+    const insights = buildLiteTopicCapacityInsights(
+      quota({
+        currentTopicCount: 10,
+        maxTopicCount: 100,
+        currentSessionCount: 10,
+        maxSessionCount: 100,
+        usageRate: 0.805,
+        sessionUsageRate: 88,
+      }),
+      [topic()],
+      NOW,
+    );
+
+    expect(insights.topicUsagePercent).toBe(80.5);
+    expect(insights.sessionUsagePercent).toBe(88);
+    expect(insights.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining(['TOPIC_QUOTA_WARNING', 'SESSION_QUOTA_WARNING']),
+    );
+  });
+
+  it('normalizes numeric API values before calculating insight totals', () => {
+    const insights = buildLiteTopicCapacityInsights(
+      quota({
+        currentTopicCount: '45' as unknown as number,
+        maxTopicCount: '50' as unknown as number,
+        currentSessionCount: '-1' as unknown as number,
+        maxSessionCount: '100' as unknown as number,
+        usageRate: undefined,
+        sessionUsageRate: undefined,
+      }),
+      [topic({ totalBacklog: '15000' as unknown as number })],
+      NOW,
+    );
+
+    expect(insights.topicUsagePercent).toBe(90);
+    expect(insights.sessionUsagePercent).toBe(0);
+    expect(insights.totalBacklog).toBe(15_000);
+    expect(insights.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining(['TOPIC_QUOTA_CRITICAL', 'BACKLOG_HOTSPOT']),
+    );
+  });
+
+  it('falls back to visible topic and session counts when quota is unavailable', () => {
+    const insights = buildLiteTopicCapacityInsights(
+      null,
+      [
+        topic({ topicPattern: 'a-*', topicCount: 3, sessionIds: ['a', 'b'] }),
+        topic({ topicPattern: 'b-*', topicCount: 5, consumerCount: 4, sessionIds: ['c'] }),
+      ],
+      NOW,
+    );
+
+    expect(insights.totalPatterns).toBe(2);
+    expect(insights.totalTopics).toBe(8);
+    expect(insights.totalConsumers).toBe(6);
+    expect(insights.totalSessions).toBe(3);
+    expect(insights.topicUsagePercent).toBeNull();
+    expect(insights.level).toBe('healthy');
+  });
+
+  it('flags long-idle and unknown-status patterns without marking them critical', () => {
+    const insights = buildLiteTopicCapacityInsights(
+      quota({
+        currentTopicCount: 20,
+        maxTopicCount: 100,
+        currentSessionCount: 10,
+        maxSessionCount: 100,
+        currentCreationRate: 1,
+        maxCreationRate: 100,
+      }),
+      [
+        topic({
+          topicPattern: 'idle-*',
+          totalBacklog: 0,
+          lastActiveTime: NOW - 96 * 3_600_000,
+        }),
+        topic({
+          topicPattern: 'mystery-*',
+          ttlStatus: 'UNKNOWN',
+          lastActiveTime: NOW - 30 * 60_000,
+        }),
+      ],
+      NOW,
+    );
+
+    expect(insights.level).toBe('notice');
+    expect(insights.idleCount).toBe(1);
+    expect(insights.unknownStatusCount).toBe(1);
+    expect(insights.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining(['IDLE_PATTERNS', 'UNKNOWN_TTL_STATUS']),
+    );
+    expect(insights.recommendations).toEqual(
+      expect.arrayContaining(['REVIEW_IDLE_PATTERNS', 'CHECK_UNKNOWN_STATUS']),
+    );
+  });
+
+  it('keeps full idle counts even when the insight table is capped', () => {
+    const idleTopics = Array.from({ length: 7 }, (_, index) =>
+      topic({
+        topicPattern: `idle-${index}-*`,
+        totalBacklog: 0,
+        lastActiveTime: NOW - (100 + index) * 3_600_000,
+      }),
+    );
+
+    const insights = buildLiteTopicCapacityInsights(
+      quota({
+        currentTopicCount: 20,
+        maxTopicCount: 100,
+        currentSessionCount: 10,
+        maxSessionCount: 100,
+        currentCreationRate: 1,
+        maxCreationRate: 100,
+      }),
+      idleTopics,
+      NOW,
+    );
+
+    expect(insights.idleCount).toBe(7);
+    expect(insights.idlePatterns).toHaveLength(5);
+    expect(insights.issues).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: 'IDLE_PATTERNS', count: 7 })]),
+    );
+  });
+
+  it('sorts hotspot and namespace signals by severity, backlog, and stable names', () => {
+    const insights = buildLiteTopicCapacityInsights(
+      quota({ currentTopicCount: 30, maxTopicCount: 100, currentSessionCount: 3 }),
+      [
+        topic({
+          namespace: 'beta',
+          topicPattern: 'medium-*',
+          topicCount: 4,
+          totalBacklog: 15_000,
+          ttlStatus: 'ACTIVE',
+        }),
+        topic({
+          namespace: 'alpha',
+          topicPattern: 'critical-*',
+          topicCount: 8,
+          totalBacklog: 200_000,
+          ttlStatus: 'ACTIVE',
+        }),
+        topic({
+          namespace: 'alpha',
+          topicPattern: 'expired-*',
+          topicCount: 2,
+          totalBacklog: 0,
+          ttlStatus: 'EXPIRED',
+        }),
+      ],
+      NOW,
+    );
+
+    expect(insights.backlogHotspots.map((signal) => signal.topicPattern)).toEqual([
+      'critical-*',
+      'medium-*',
+    ]);
+    expect(insights.namespaceSignals[0]).toEqual(
+      expect.objectContaining({
+        namespace: 'alpha',
+        patternCount: 2,
+        topicCount: 10,
+        level: 'critical',
+      }),
+    );
+  });
+
+  it('exposes a stable severity rank for UI sorting', () => {
+    expect(liteTopicCapacityLevelRank('healthy')).toBeLessThan(
+      liteTopicCapacityLevelRank('warning'),
+    );
+    expect(liteTopicCapacityLevelRank('critical')).toBeGreaterThan(
+      liteTopicCapacityLevelRank('notice'),
+    );
+  });
+});

--- a/web/src/utils/liteTopicCapacityInsights.ts
+++ b/web/src/utils/liteTopicCapacityInsights.ts
@@ -1,0 +1,557 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LiteTopicItem, LiteTopicQuota } from '../api/liteTopic';
+
+export type LiteTopicCapacityLevel = 'healthy' | 'notice' | 'warning' | 'critical';
+
+export type LiteTopicCapacityIssueCode =
+  | 'TOPIC_QUOTA_CRITICAL'
+  | 'TOPIC_QUOTA_WARNING'
+  | 'SESSION_QUOTA_CRITICAL'
+  | 'SESSION_QUOTA_WARNING'
+  | 'CREATION_RATE_CRITICAL'
+  | 'CREATION_RATE_WARNING'
+  | 'EXPIRED_PATTERNS'
+  | 'EXPIRING_PATTERNS'
+  | 'BACKLOG_HOTSPOT'
+  | 'UNKNOWN_TTL_STATUS'
+  | 'IDLE_PATTERNS';
+
+export type LiteTopicRecommendationCode =
+  | 'REQUEST_TOPIC_QUOTA'
+  | 'REQUEST_SESSION_QUOTA'
+  | 'THROTTLE_CREATION'
+  | 'EXTEND_TTL'
+  | 'CLEAN_EXPIRED'
+  | 'DRAIN_BACKLOG'
+  | 'CHECK_UNKNOWN_STATUS'
+  | 'REVIEW_IDLE_PATTERNS';
+
+export interface LiteTopicCapacityIssue {
+  code: LiteTopicCapacityIssueCode;
+  level: LiteTopicCapacityLevel;
+  count?: number;
+  percent?: number;
+  pattern?: string;
+  namespace?: string;
+  value?: number;
+  limit?: number;
+}
+
+export interface LiteTopicPatternSignal {
+  key: string;
+  namespace: string;
+  topicPattern: string;
+  topicCount: number;
+  consumerCount: number;
+  sessionCount: number;
+  totalBacklog: number;
+  averageTTL: number | null;
+  ttlStatus: string;
+  lastActiveTime: number | null;
+  idleHours: number | null;
+  level: LiteTopicCapacityLevel;
+  reasons: LiteTopicCapacityIssueCode[];
+}
+
+export interface LiteTopicNamespaceSignal {
+  namespace: string;
+  patternCount: number;
+  topicCount: number;
+  consumerCount: number;
+  sessionCount: number;
+  totalBacklog: number;
+  expiredCount: number;
+  expiringSoonCount: number;
+  level: LiteTopicCapacityLevel;
+}
+
+export interface LiteTopicCapacityInsights {
+  level: LiteTopicCapacityLevel;
+  totalPatterns: number;
+  totalTopics: number;
+  totalConsumers: number;
+  totalSessions: number;
+  totalBacklog: number;
+  topicUsagePercent: number | null;
+  sessionUsagePercent: number | null;
+  creationRatePercent: number | null;
+  remainingTopicSlots: number | null;
+  remainingSessionSlots: number | null;
+  activeCount: number;
+  expiringSoonCount: number;
+  expiredCount: number;
+  unknownStatusCount: number;
+  idleCount: number;
+  issues: LiteTopicCapacityIssue[];
+  recommendations: LiteTopicRecommendationCode[];
+  backlogHotspots: LiteTopicPatternSignal[];
+  ttlAttentionPatterns: LiteTopicPatternSignal[];
+  idlePatterns: LiteTopicPatternSignal[];
+  namespaceSignals: LiteTopicNamespaceSignal[];
+}
+
+const TOPIC_QUOTA_WARNING_PERCENT = 75;
+const TOPIC_QUOTA_CRITICAL_PERCENT = 90;
+const SESSION_QUOTA_WARNING_PERCENT = 75;
+const SESSION_QUOTA_CRITICAL_PERCENT = 90;
+const CREATION_RATE_WARNING_PERCENT = 80;
+const CREATION_RATE_CRITICAL_PERCENT = 95;
+const BACKLOG_WARNING_THRESHOLD = 10_000;
+const BACKLOG_CRITICAL_THRESHOLD = 100_000;
+const IDLE_HOURS_THRESHOLD = 72;
+const TOP_N = 5;
+
+const knownTtlStatuses = new Set(['ACTIVE', 'EXPIRING_SOON', 'EXPIRED']);
+
+const levelWeight: Record<LiteTopicCapacityLevel, number> = {
+  healthy: 0,
+  notice: 1,
+  warning: 2,
+  critical: 3,
+};
+
+const normalizeNumber = (value: number | undefined | null): number => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.max(0, parsed);
+};
+
+const normalizeOptionalNumber = (value: number | undefined | null): number | null => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  return Math.max(0, parsed);
+};
+
+const roundPercent = (value: number): number => Math.round(value * 10) / 10;
+
+const clampPercent = (value: number): number => Math.max(0, Math.min(100, roundPercent(value)));
+
+const percentFromRatioOrCounters = (
+  ratio: number | undefined,
+  current: number | undefined,
+  max: number | undefined,
+): number | null => {
+  if (Number.isFinite(ratio)) {
+    const raw = Number(ratio);
+    return clampPercent(raw <= 1 ? raw * 100 : raw);
+  }
+  const safeCurrent = normalizeOptionalNumber(current);
+  const safeMax = normalizeOptionalNumber(max);
+  if (safeCurrent == null || safeMax == null || safeMax <= 0) return null;
+  return clampPercent((safeCurrent / safeMax) * 100);
+};
+
+const quotaRemaining = (current: number | undefined, max: number | undefined): number | null => {
+  const safeCurrent = normalizeOptionalNumber(current);
+  const safeMax = normalizeOptionalNumber(max);
+  if (safeCurrent == null || safeMax == null || safeMax <= 0) return null;
+  return Math.max(0, safeMax - safeCurrent);
+};
+
+const normalizeText = (value: string | undefined | null, fallback = '-'): string => {
+  const text = value?.trim();
+  return text || fallback;
+};
+
+const normalizeTtlStatus = (value: string | undefined | null): string => {
+  const status = value?.trim().toUpperCase();
+  return status || 'UNKNOWN';
+};
+
+const maxLevel = (levels: LiteTopicCapacityLevel[]): LiteTopicCapacityLevel =>
+  levels.reduce<LiteTopicCapacityLevel>(
+    (current, next) => (levelWeight[next] > levelWeight[current] ? next : current),
+    'healthy',
+  );
+
+const issueLevel = (code: LiteTopicCapacityIssueCode): LiteTopicCapacityLevel => {
+  switch (code) {
+    case 'TOPIC_QUOTA_CRITICAL':
+    case 'SESSION_QUOTA_CRITICAL':
+    case 'CREATION_RATE_CRITICAL':
+      return 'critical';
+    case 'TOPIC_QUOTA_WARNING':
+    case 'SESSION_QUOTA_WARNING':
+    case 'CREATION_RATE_WARNING':
+    case 'EXPIRED_PATTERNS':
+    case 'BACKLOG_HOTSPOT':
+      return 'warning';
+    case 'EXPIRING_PATTERNS':
+    case 'UNKNOWN_TTL_STATUS':
+    case 'IDLE_PATTERNS':
+      return 'notice';
+    default:
+      return 'notice';
+  }
+};
+
+const addUnique = <T>(items: T[], item: T) => {
+  if (!items.includes(item)) items.push(item);
+};
+
+const patternKey = (item: LiteTopicItem): string =>
+  JSON.stringify([normalizeText(item.namespace, 'default'), normalizeText(item.topicPattern)]);
+
+const idleHours = (lastActiveTime: number | undefined | null, now: number): number | null => {
+  const time = normalizeOptionalNumber(lastActiveTime);
+  if (time == null || time <= 0 || time > now) return null;
+  return Math.floor((now - time) / 3_600_000);
+};
+
+const toPatternSignal = (item: LiteTopicItem, now: number): LiteTopicPatternSignal => {
+  const totalBacklog = normalizeNumber(item.totalBacklog);
+  const ttlStatus = normalizeTtlStatus(item.ttlStatus);
+  const idleForHours = idleHours(item.lastActiveTime, now);
+  const reasons: LiteTopicCapacityIssueCode[] = [];
+
+  if (ttlStatus === 'EXPIRED') reasons.push('EXPIRED_PATTERNS');
+  if (ttlStatus === 'EXPIRING_SOON') reasons.push('EXPIRING_PATTERNS');
+  if (!knownTtlStatuses.has(ttlStatus)) reasons.push('UNKNOWN_TTL_STATUS');
+  if (totalBacklog >= BACKLOG_WARNING_THRESHOLD) reasons.push('BACKLOG_HOTSPOT');
+  if (idleForHours != null && idleForHours >= IDLE_HOURS_THRESHOLD && totalBacklog === 0) {
+    reasons.push('IDLE_PATTERNS');
+  }
+
+  const backlogLevel =
+    totalBacklog >= BACKLOG_CRITICAL_THRESHOLD
+      ? 'critical'
+      : totalBacklog >= BACKLOG_WARNING_THRESHOLD
+        ? 'warning'
+        : 'healthy';
+
+  return {
+    key: patternKey(item),
+    namespace: normalizeText(item.namespace, 'default'),
+    topicPattern: normalizeText(item.topicPattern),
+    topicCount: normalizeNumber(item.topicCount),
+    consumerCount: normalizeNumber(item.consumerCount),
+    sessionCount: item.sessionIds?.length ?? 0,
+    totalBacklog,
+    averageTTL: normalizeOptionalNumber(item.averageTTL),
+    ttlStatus,
+    lastActiveTime: normalizeOptionalNumber(item.lastActiveTime),
+    idleHours: idleForHours,
+    level: maxLevel([backlogLevel, ...reasons.map(issueLevel)]),
+    reasons,
+  };
+};
+
+const compareSignalSeverity = (left: LiteTopicPatternSignal, right: LiteTopicPatternSignal) =>
+  levelWeight[right.level] - levelWeight[left.level] ||
+  right.totalBacklog - left.totalBacklog ||
+  right.topicCount - left.topicCount ||
+  left.namespace.localeCompare(right.namespace) ||
+  left.topicPattern.localeCompare(right.topicPattern);
+
+const namespaceSignals = (signals: LiteTopicPatternSignal[]): LiteTopicNamespaceSignal[] => {
+  const namespaces = new Map<string, LiteTopicNamespaceSignal>();
+  for (const signal of signals) {
+    const current =
+      namespaces.get(signal.namespace) ??
+      ({
+        namespace: signal.namespace,
+        patternCount: 0,
+        topicCount: 0,
+        consumerCount: 0,
+        sessionCount: 0,
+        totalBacklog: 0,
+        expiredCount: 0,
+        expiringSoonCount: 0,
+        level: 'healthy',
+      } satisfies LiteTopicNamespaceSignal);
+    current.patternCount += 1;
+    current.topicCount += signal.topicCount;
+    current.consumerCount += signal.consumerCount;
+    current.sessionCount += signal.sessionCount;
+    current.totalBacklog += signal.totalBacklog;
+    if (signal.ttlStatus === 'EXPIRED') current.expiredCount += 1;
+    if (signal.ttlStatus === 'EXPIRING_SOON') current.expiringSoonCount += 1;
+    current.level = maxLevel([current.level, signal.level]);
+    namespaces.set(signal.namespace, current);
+  }
+
+  return [...namespaces.values()].sort(
+    (left, right) =>
+      levelWeight[right.level] - levelWeight[left.level] ||
+      right.totalBacklog - left.totalBacklog ||
+      right.topicCount - left.topicCount ||
+      left.namespace.localeCompare(right.namespace),
+  );
+};
+
+const pushQuotaIssue = (
+  issues: LiteTopicCapacityIssue[],
+  code: LiteTopicCapacityIssueCode,
+  percentValue: number | null,
+  value: number | undefined,
+  limit: number | undefined,
+) => {
+  if (percentValue == null) return;
+  issues.push({
+    code,
+    level: issueLevel(code),
+    percent: percentValue,
+    value: normalizeOptionalNumber(value) ?? undefined,
+    limit: normalizeOptionalNumber(limit) ?? undefined,
+  });
+};
+
+const buildIssues = (
+  quota: LiteTopicQuota | null | undefined,
+  signals: LiteTopicPatternSignal[],
+  topicUsagePercent: number | null,
+  sessionUsagePercent: number | null,
+  creationRatePercent: number | null,
+): LiteTopicCapacityIssue[] => {
+  const issues: LiteTopicCapacityIssue[] = [];
+
+  if (topicUsagePercent != null && topicUsagePercent >= TOPIC_QUOTA_CRITICAL_PERCENT) {
+    pushQuotaIssue(
+      issues,
+      'TOPIC_QUOTA_CRITICAL',
+      topicUsagePercent,
+      quota?.currentTopicCount,
+      quota?.maxTopicCount,
+    );
+  } else if (topicUsagePercent != null && topicUsagePercent >= TOPIC_QUOTA_WARNING_PERCENT) {
+    pushQuotaIssue(
+      issues,
+      'TOPIC_QUOTA_WARNING',
+      topicUsagePercent,
+      quota?.currentTopicCount,
+      quota?.maxTopicCount,
+    );
+  }
+
+  if (sessionUsagePercent != null && sessionUsagePercent >= SESSION_QUOTA_CRITICAL_PERCENT) {
+    pushQuotaIssue(
+      issues,
+      'SESSION_QUOTA_CRITICAL',
+      sessionUsagePercent,
+      quota?.currentSessionCount,
+      quota?.maxSessionCount,
+    );
+  } else if (sessionUsagePercent != null && sessionUsagePercent >= SESSION_QUOTA_WARNING_PERCENT) {
+    pushQuotaIssue(
+      issues,
+      'SESSION_QUOTA_WARNING',
+      sessionUsagePercent,
+      quota?.currentSessionCount,
+      quota?.maxSessionCount,
+    );
+  }
+
+  if (creationRatePercent != null && creationRatePercent >= CREATION_RATE_CRITICAL_PERCENT) {
+    pushQuotaIssue(
+      issues,
+      'CREATION_RATE_CRITICAL',
+      creationRatePercent,
+      quota?.currentCreationRate,
+      quota?.maxCreationRate,
+    );
+  } else if (creationRatePercent != null && creationRatePercent >= CREATION_RATE_WARNING_PERCENT) {
+    pushQuotaIssue(
+      issues,
+      'CREATION_RATE_WARNING',
+      creationRatePercent,
+      quota?.currentCreationRate,
+      quota?.maxCreationRate,
+    );
+  }
+
+  const expired = signals.filter((signal) => signal.ttlStatus === 'EXPIRED');
+  const expiring = signals.filter((signal) => signal.ttlStatus === 'EXPIRING_SOON');
+  const unknown = signals.filter((signal) => !knownTtlStatuses.has(signal.ttlStatus));
+  const idle = signals.filter((signal) => signal.reasons.includes('IDLE_PATTERNS'));
+  const backlogHotspot = signals.find((signal) => signal.reasons.includes('BACKLOG_HOTSPOT'));
+
+  if (expired.length > 0) {
+    issues.push({
+      code: 'EXPIRED_PATTERNS',
+      level: 'warning',
+      count: expired.length,
+      pattern: expired[0].topicPattern,
+      namespace: expired[0].namespace,
+    });
+  }
+  if (expiring.length > 0) {
+    issues.push({
+      code: 'EXPIRING_PATTERNS',
+      level: expiring.length >= 3 ? 'warning' : 'notice',
+      count: expiring.length,
+      pattern: expiring[0].topicPattern,
+      namespace: expiring[0].namespace,
+    });
+  }
+  if (backlogHotspot) {
+    issues.push({
+      code: 'BACKLOG_HOTSPOT',
+      level: backlogHotspot.totalBacklog >= BACKLOG_CRITICAL_THRESHOLD ? 'critical' : 'warning',
+      count: backlogHotspot.totalBacklog,
+      pattern: backlogHotspot.topicPattern,
+      namespace: backlogHotspot.namespace,
+    });
+  }
+  if (unknown.length > 0) {
+    issues.push({
+      code: 'UNKNOWN_TTL_STATUS',
+      level: 'notice',
+      count: unknown.length,
+      pattern: unknown[0].topicPattern,
+      namespace: unknown[0].namespace,
+    });
+  }
+  if (idle.length > 0) {
+    issues.push({
+      code: 'IDLE_PATTERNS',
+      level: 'notice',
+      count: idle.length,
+      pattern: idle[0].topicPattern,
+      namespace: idle[0].namespace,
+    });
+  }
+
+  return issues.sort(
+    (left, right) =>
+      levelWeight[right.level] - levelWeight[left.level] ||
+      (right.percent ?? right.count ?? 0) - (left.percent ?? left.count ?? 0) ||
+      left.code.localeCompare(right.code),
+  );
+};
+
+const recommendationsForIssues = (
+  issues: LiteTopicCapacityIssue[],
+): LiteTopicRecommendationCode[] => {
+  const recommendations: LiteTopicRecommendationCode[] = [];
+  for (const issue of issues) {
+    switch (issue.code) {
+      case 'TOPIC_QUOTA_CRITICAL':
+      case 'TOPIC_QUOTA_WARNING':
+        addUnique(recommendations, 'REQUEST_TOPIC_QUOTA');
+        break;
+      case 'SESSION_QUOTA_CRITICAL':
+      case 'SESSION_QUOTA_WARNING':
+        addUnique(recommendations, 'REQUEST_SESSION_QUOTA');
+        break;
+      case 'CREATION_RATE_CRITICAL':
+      case 'CREATION_RATE_WARNING':
+        addUnique(recommendations, 'THROTTLE_CREATION');
+        break;
+      case 'EXPIRED_PATTERNS':
+        addUnique(recommendations, 'CLEAN_EXPIRED');
+        break;
+      case 'EXPIRING_PATTERNS':
+        addUnique(recommendations, 'EXTEND_TTL');
+        break;
+      case 'BACKLOG_HOTSPOT':
+        addUnique(recommendations, 'DRAIN_BACKLOG');
+        break;
+      case 'UNKNOWN_TTL_STATUS':
+        addUnique(recommendations, 'CHECK_UNKNOWN_STATUS');
+        break;
+      case 'IDLE_PATTERNS':
+        addUnique(recommendations, 'REVIEW_IDLE_PATTERNS');
+        break;
+      default:
+        break;
+    }
+  }
+  return recommendations.slice(0, 6);
+};
+
+export function buildLiteTopicCapacityInsights(
+  quota: LiteTopicQuota | null | undefined,
+  items: LiteTopicItem[] | null | undefined,
+  now = Date.now(),
+): LiteTopicCapacityInsights {
+  const signals = (items ?? []).map((item) => toPatternSignal(item, now));
+  const totalTopics =
+    normalizeOptionalNumber(quota?.currentTopicCount) ??
+    signals.reduce((sum, signal) => sum + signal.topicCount, 0);
+  const totalSessions =
+    normalizeOptionalNumber(quota?.currentSessionCount) ??
+    signals.reduce((sum, signal) => sum + signal.sessionCount, 0);
+  const totalConsumers = signals.reduce((sum, signal) => sum + signal.consumerCount, 0);
+  const totalBacklog = signals.reduce((sum, signal) => sum + signal.totalBacklog, 0);
+  const topicUsagePercent = percentFromRatioOrCounters(
+    quota?.usageRate,
+    quota?.currentTopicCount,
+    quota?.maxTopicCount,
+  );
+  const sessionUsagePercent = percentFromRatioOrCounters(
+    quota?.sessionUsageRate,
+    quota?.currentSessionCount,
+    quota?.maxSessionCount,
+  );
+  const creationRatePercent = percentFromRatioOrCounters(
+    undefined,
+    quota?.currentCreationRate,
+    quota?.maxCreationRate,
+  );
+  const issues = buildIssues(
+    quota,
+    signals,
+    topicUsagePercent,
+    sessionUsagePercent,
+    creationRatePercent,
+  );
+
+  const backlogSignals = signals
+    .filter((signal) => signal.totalBacklog > 0)
+    .sort(compareSignalSeverity);
+  const ttlAttentionSignals = signals
+    .filter(
+      (signal) =>
+        ['EXPIRED', 'EXPIRING_SOON'].includes(signal.ttlStatus) ||
+        signal.reasons.includes('UNKNOWN_TTL_STATUS'),
+    )
+    .sort(compareSignalSeverity);
+  const idleSignals = signals
+    .filter((signal) => signal.reasons.includes('IDLE_PATTERNS'))
+    .sort((left, right) => (right.idleHours ?? 0) - (left.idleHours ?? 0));
+
+  return {
+    level: maxLevel(issues.map((issue) => issue.level)),
+    totalPatterns: signals.length,
+    totalTopics,
+    totalConsumers,
+    totalSessions,
+    totalBacklog,
+    topicUsagePercent,
+    sessionUsagePercent,
+    creationRatePercent,
+    remainingTopicSlots: quotaRemaining(quota?.currentTopicCount, quota?.maxTopicCount),
+    remainingSessionSlots: quotaRemaining(quota?.currentSessionCount, quota?.maxSessionCount),
+    activeCount: signals.filter((signal) => signal.ttlStatus === 'ACTIVE').length,
+    expiringSoonCount: signals.filter((signal) => signal.ttlStatus === 'EXPIRING_SOON').length,
+    expiredCount: signals.filter((signal) => signal.ttlStatus === 'EXPIRED').length,
+    unknownStatusCount: signals.filter((signal) => !knownTtlStatuses.has(signal.ttlStatus)).length,
+    idleCount: idleSignals.length,
+    issues,
+    recommendations: recommendationsForIssues(issues),
+    backlogHotspots: backlogSignals.slice(0, TOP_N),
+    ttlAttentionPatterns: ttlAttentionSignals.slice(0, TOP_N),
+    idlePatterns: idleSignals.slice(0, TOP_N),
+    namespaceSignals: namespaceSignals(signals).slice(0, TOP_N),
+  };
+}
+
+export function liteTopicCapacityLevelRank(level: LiteTopicCapacityLevel): number {
+  return levelWeight[level];
+}


### PR DESCRIPTION
## What is the purpose of the change

Add a capacity risk insights panel to the LiteTopic page so operators can quickly identify quota pressure, TTL risks, backlog hotspots, idle patterns, and namespace-level pressure from existing LiteTopic data.

## Brief changelog

- Add a LiteTopic capacity insights model for quota usage, TTL status, backlog, idle pattern, and namespace pressure analysis.
- Add a LiteTopic capacity insights panel to the LiteTopic page.
- Add Chinese and English translations for the new insights UI.
- Add unit and component tests for the insights model, panel, and LiteTopic page integration.

## Verifying this change

- `npm test -- src/utils/liteTopicCapacityInsights.test.ts src/pages/studio/__tests__/LiteTopicCapacityInsights.test.tsx src/pages/studio/__tests__/LiteTopic.test.tsx`
- `npx eslint src/utils/liteTopicCapacityInsights.ts src/utils/liteTopicCapacityInsights.test.ts src/pages/studio/LiteTopicCapacityInsights.tsx src/pages/studio/__tests__/LiteTopicCapacityInsights.test.tsx src/pages/studio/LiteTopic.tsx src/pages/studio/__tests__/LiteTopic.test.tsx src/i18n/translations.ts`
- `npm run build`
- `git diff --check`