### PR TITLE
test(auth): align AuthCorsIntegrationTest with single session resolution

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCorsIntegrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCorsIntegrationTest.java
@@ -31,7 +31,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
-
+import java.util.Optional;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -107,13 +109,18 @@ class AuthCorsIntegrationTest {
                         .header(HttpHeaders.ORIGIN, FRONTEND_ORIGIN))
                 .andExpect(status().isUnauthorized());
 
-        verify(authService).isAuthenticated(null);
+        // The interceptor resolves the session once per request and now goes through
+        // getAuthenticatedUser only, so isAuthenticated is no longer part of the flow.
+        verify(authService).getAuthenticatedUser(null);
+        verify(authService, never()).isAuthenticated(any());
     }
+
     @Test
     void shouldRejectNonAdminMutationBeforeControllerExecution() throws Exception {
         String authorization = "Bearer reader-token";
-        when(authService.isAuthenticated(authorization)).thenReturn(true);
-        when(authService.isAdmin(authorization)).thenReturn(false);
+
+        when(authService.getAuthenticatedUser(authorization)).thenReturn(Optional.of(
+                LoginVO.UserInfo.builder().userId(7L).username("reader").admin(false).build()));
 
         mockMvc.perform(post("/api/instances/create")
                         .header(HttpHeaders.AUTHORIZATION, authorization)


### PR DESCRIPTION
## Problem

`mvn -B -ntp test` fails on the current `rocketmq-studio` head (`6c24d2ed`): 2 of 2151 tests fail, both in `AuthCorsIntegrationTest`.

```
[ERROR] Tests run: 4, Failures: 2, Errors: 0, Skipped: 0 -- in org.apache.rocketmq.studio.auth.AuthCorsIntegrationTest
[ERROR] Tests run: 2151, Failures: 2, Errors: 0, Skipped: 0
[INFO] BUILD FAILURE
```

```
AuthCorsIntegrationTest.shouldStillRejectAnonymousProtectedRequests
  Wanted but not invoked: AuthService.isAuthenticated(null)

AuthCorsIntegrationTest.shouldRejectNonAdminMutationBeforeControllerExecution
  java.lang.AssertionError: Status expected:<403> but was:<401>
```

Run on Ubuntu 22.04 with OpenJDK 21.0.12 and Maven 3.6.3, from `server/`, with no local changes.

## Root cause

`#2895` (`ddf82325`, [ISSUE #2892]) made `AuthInterceptor` resolve the session once per request. The interceptor now calls `authService.getAuthenticatedUser(...)` only — `isAuthenticated` is no longer part of the flow:

```java
var authenticatedUser = authService.getAuthenticatedUser(authorization).orElse(null);
if (authenticatedUser == null) {
    writeError(response, HttpStatus.UNAUTHORIZED, "Unauthorized");
    return false;
}
```

`AuthCorsIntegrationTest` was last changed on 2026-08-18 and still stubs and verifies that old pair of calls, so the mock answers `Optional.empty()` and the anonymous branch is taken before `requiresAdmin` is ever evaluated. That is why the non-admin mutation answers 401 instead of the expected 403.

The interceptor change is correct; only the test is stale. A/B on the same tree, with nothing but `AuthInterceptor.java` swapped for its pre-`#2895` revision (test untouched):

| `AuthCorsIntegrationTest` | result |
|---|---|
| head (`6c24d2ed`) | `Tests run: 4, Failures: 2` |
| head + pre-`#2895` `AuthInterceptor` | `Tests run: 4, Failures: 0` |

## Change

Test only — production code is untouched:

- `shouldStillRejectAnonymousProtectedRequests` verifies `getAuthenticatedUser(null)` and asserts that `isAuthenticated` is no longer called.
- `shouldRejectNonAdminMutationBeforeControllerExecution` stubs `getAuthenticatedUser` with a non-admin `LoginVO.UserInfo` instead of `isAuthenticated` + `isAdmin`, which also pins the 403 the interceptor is supposed to produce for an authenticated non-admin mutation.

## Verification

Ubuntu 22.04, OpenJDK 21.0.12, Maven 3.6.3, on `6c24d2ed` + this patch:

```
$ mvn -B -ntp test -Dtest=AuthCorsIntegrationTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0

$ mvn -B -ntp test
Tests run: 2151, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## Why this went unnoticed

`ci.yml` does not run on this branch. Every run is `startup_failure` with zero jobs created, including the run for the push of `6c24d2ed` itself:

```
$ gh api repos/apache/rocketmq-dashboard/actions/runs?per_page=1&branch=rocketmq-studio
name=CI event=push head=6c24d2ed conclusion=startup_failure
$ gh api repos/apache/rocketmq-dashboard/actions/runs/34460196153/jobs
total_count: 0
```

93 of the last 100 runs in the repository are `startup_failure` (the 5 successes are the scheduled stale-bot runs on `master`). So the server suite has to be run by hand, and it is red at head until this lands — worth knowing for anyone verifying a PR with `mvn -B -ntp test` on this branch.

I have not touched `ci.yml` here; if you want the workflow running again I can look into it separately.