### PR TITLE
[Studio] feat: seal cloud credential secrets with AES-GCM and gate reveal behind re-auth

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
@@ -159,6 +159,41 @@ public class AuthService {
         return getAuthenticatedUser(authorization).map(LoginVO.UserInfo::isAdmin).orElse(false);
     }
 
+    /**
+     * Second-factor confirmation for operations that expose stored secrets.
+     *
+     * <p>The caller is already an authenticated admin by the time this runs (the interceptor gates the
+     * reveal endpoints), so this deliberately asks for the account password again: a replayed session
+     * cookie is not enough to read provider keys. The confirmation is resolved against the currently
+     * authenticated principal from {@link AuthenticatedUserContext}, never against a caller-supplied
+     * user name, so it cannot be used to check another account's password.</p>
+     *
+     * @throws BusinessException 403 when the password is missing, the principal is unknown, or the
+     *         password does not match - all cases fail closed.
+     */
+    public void verifySensitiveOperationPassword(String rawPassword) {
+        if (rawPassword == null || rawPassword.isBlank()) {
+            throw new BusinessException(403,
+                    "Password confirmation is required to reveal stored secrets");
+        }
+        String username = AuthenticatedUserContext.currentUsernameOrSystem();
+        if (databaseBacked()) {
+            ensureBootstrapUsers();
+            RmqStudioUser user = findUserByUsername(username).orElse(null);
+            if (user == null || !Boolean.TRUE.equals(user.getEnabled())
+                    || !passwordHasher.matches(rawPassword, user.getPasswordHash())) {
+                throw new BusinessException(403, "Password confirmation failed");
+            }
+            return;
+        }
+        boolean matched = authProperties.configuredUsers().stream()
+                .anyMatch(candidate -> candidate.getUsername().equals(username)
+                        && candidate.getPassword().equals(rawPassword));
+        if (!matched) {
+            throw new BusinessException(403, "Password confirmation failed");
+        }
+    }
+
     public void logout(String authorization) {
         tokenFromAuthorization(authorization).ifPresent(token -> {
             if (databaseBacked()) {

--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/CredentialCipher.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/CredentialCipher.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+
+/**
+ * Envelope encryption for stored provider credentials (AK/SK secret keys).
+ *
+ * <p>Secrets are sealed with AES-256-GCM and persisted as {@code enc:v1:<base64(iv || ciphertext || tag)>}.
+ * GCM is authenticated, so a tampered row fails to open instead of silently returning corrupted key
+ * material, and every value carries a fresh 96-bit random IV so identical secrets do not collide in
+ * the database. This replaces the earlier scheme that merely base64-<em>encoded</em> secrets, which
+ * provided obfuscation but no confidentiality: anyone with read access to {@code rmq_cloud_credential}
+ * could recover the plaintext key.</p>
+ *
+ * <p>The AES key comes from {@code studio.credential.encryption-key} (Base64-encoded 32 bytes, wired to
+ * {@code STUDIO_CREDENTIAL_ENCRYPTION_KEY}). When the property is absent - convenient for local runs and
+ * the bundled dev profile - a deterministic key is derived from a fixed application salt and a WARNING is
+ * logged. That fallback still hides plaintext from the database, but it is <em>not</em> secret; production
+ * deployments must set the property so the key lives outside the database it protects.</p>
+ *
+ * <p>Reading tolerates rows written by the legacy base64 scheme: values without the {@code enc:v1:} prefix
+ * are decoded with {@link CredentialUtils#decodeBase64(String)} so an existing deployment keeps working and
+ * can be re-sealed by {@code CredentialEncryptionMigration}.</p>
+ */
+@Component
+@Slf4j
+public class CredentialCipher {
+
+    /** Marks a persisted value as AES-GCM sealed by this class; the version allows future rotation. */
+    public static final String PREFIX = "enc:v1:";
+
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final String KEY_ALGORITHM = "AES";
+    private static final int IV_LENGTH_BYTES = 12;
+    private static final int TAG_LENGTH_BITS = 128;
+    private static final int KEY_LENGTH_BYTES = 32;
+    private static final String FALLBACK_KEY_SALT = "rocketmq-studio/credential-encryption/v1";
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private final SecretKey key;
+    private final boolean configuredKey;
+
+    @Autowired
+    public CredentialCipher(
+            @Value("${studio.credential.encryption-key:}") String configuredKey) {
+        if (configuredKey != null && !configuredKey.isBlank()) {
+            this.key = keyFromBase64(configuredKey);
+            this.configuredKey = true;
+        } else {
+            this.key = keyFromPassphrase(FALLBACK_KEY_SALT);
+            this.configuredKey = false;
+        }
+    }
+
+    /** Derives a stable AES-256 key from a Base64-encoded 32-byte value. */
+    static SecretKey keyFromBase64(String configuredKey) {
+        byte[] decoded;
+        try {
+            decoded = Base64.getDecoder().decode(configuredKey.trim());
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalStateException(
+                    "studio.credential.encryption-key must be a Base64-encoded 32-byte AES key",
+                    exception);
+        }
+        if (decoded.length != KEY_LENGTH_BYTES) {
+            throw new IllegalStateException("studio.credential.encryption-key must decode to exactly "
+                    + KEY_LENGTH_BYTES + " bytes but was " + decoded.length);
+        }
+        return new SecretKeySpec(decoded, KEY_ALGORITHM);
+    }
+
+    /** Derives a stable AES-256 key from an arbitrary passphrase (dev fallback only). */
+    static SecretKey keyFromPassphrase(String passphrase) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(passphrase.getBytes(StandardCharsets.UTF_8));
+            return new SecretKeySpec(digest, KEY_ALGORITHM);
+        } catch (GeneralSecurityException exception) {
+            throw new IllegalStateException("Unable to derive the credential encryption key", exception);
+        }
+    }
+
+    /** True when the stored value was sealed by this class rather than by the legacy base64 scheme. */
+    public static boolean isEncrypted(String stored) {
+        return stored != null && stored.startsWith(PREFIX);
+    }
+
+    /** True when the operator supplied an explicit key instead of the documented dev fallback. */
+    public boolean usesConfiguredKey() {
+        return configuredKey;
+    }
+
+    /**
+     * Seals a plaintext secret. {@code null} passes through so callers can persist partially populated
+     * rows without inventing ciphertext.
+     */
+    public String encrypt(String plainText) {
+        if (plainText == null) {
+            return null;
+        }
+        try {
+            byte[] iv = new byte[IV_LENGTH_BYTES];
+            SECURE_RANDOM.nextBytes(iv);
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(TAG_LENGTH_BITS, iv));
+            byte[] cipherText = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+
+            byte[] sealed = new byte[iv.length + cipherText.length];
+            System.arraycopy(iv, 0, sealed, 0, iv.length);
+            System.arraycopy(cipherText, 0, sealed, iv.length, cipherText.length);
+            return PREFIX + Base64.getEncoder().encodeToString(sealed);
+        } catch (GeneralSecurityException exception) {
+            throw new IllegalStateException("Unable to encrypt the cloud credential secret", exception);
+        }
+    }
+
+    /**
+     * Opens a stored secret. Values sealed by this class are decrypted; legacy values are decoded from
+     * base64. A sealed value that cannot be opened - wrong key or tampered ciphertext - is reported as a
+     * server error instead of being returned as garbage.
+     */
+    public String decrypt(String stored) {
+        if (stored == null) {
+            return null;
+        }
+        if (!isEncrypted(stored)) {
+            return CredentialUtils.decodeBase64(stored);
+        }
+        try {
+            byte[] sealed = Base64.getDecoder().decode(stored.substring(PREFIX.length()));
+            if (sealed.length <= IV_LENGTH_BYTES) {
+                throw new GeneralSecurityException("sealed value is shorter than its IV");
+            }
+            byte[] iv = Arrays.copyOfRange(sealed, 0, IV_LENGTH_BYTES);
+            byte[] cipherText = Arrays.copyOfRange(sealed, IV_LENGTH_BYTES, sealed.length);
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(TAG_LENGTH_BITS, iv));
+            return new String(cipher.doFinal(cipherText), StandardCharsets.UTF_8);
+        } catch (GeneralSecurityException | IllegalArgumentException exception) {
+            throw new BusinessException(500,
+                    "Stored cloud credential secret could not be decrypted; verify that "
+                            + "studio.credential.encryption-key still matches the key the credential was "
+                            + "sealed with");
+        }
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialController.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -39,6 +40,9 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/cloud-credentials")
 public class CloudCredentialController {
+
+    /** Carries the operator's password for the reveal step; never placed on the query string. */
+    public static final String REAUTH_HEADER = "X-Studio-Reauth";
 
     private final CloudCredentialService credentialService;
 
@@ -79,10 +83,17 @@ public class CloudCredentialController {
         return Result.ok();
     }
 
+    /**
+     * Reveals a credential together with its plaintext secret key for an authenticated admin. The admin
+     * session is not sufficient on its own: {@link CloudCredentialController#REAUTH_HEADER} must carry the
+     * operator's password, which {@code CloudCredentialService#reveal} verifies and audits.
+     */
     @GetMapping("/{id}/credentials")
-    public ResponseEntity<Result<CloudCredentialVO>> getCredentialSecrets(@PathVariable Long id) {
+    public ResponseEntity<Result<CloudCredentialVO>> getCredentialSecrets(
+            @PathVariable Long id,
+            @RequestHeader(name = REAUTH_HEADER, required = false) String reauthPassword) {
         return ResponseEntity.ok()
                 .cacheControl(CacheControl.noStore())
-                .body(Result.ok(credentialService.reveal(id)));
+                .body(Result.ok(credentialService.reveal(id, reauthPassword)));
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
@@ -24,6 +24,7 @@ import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.common.util.CsvUtil;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.auth.AuthService;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.provider.alibaba.AliyunClientFactory;
 import org.apache.rocketmq.studio.provider.tencent.TencentClientFactory;
@@ -50,6 +51,7 @@ public class CloudCredentialService {
     private final AliyunClientFactory aliyunClientFactory;
     private final TencentClientFactory tencentClientFactory;
     private final OperationAuditService operationAuditService;
+    private final AuthService authService;
 
     public List<CloudCredentialVO> listMasked() {
         log.info("Listing cloud credentials (masked)");
@@ -163,12 +165,30 @@ public class CloudCredentialService {
                 credentialAuditDetail(existing));
     }
 
-    public CloudCredentialVO reveal(Long id) {
+    /**
+     * Returns the credential including its plaintext secret key, for the admin-only reveal endpoint.
+     *
+     * <p>Revealing a stored AK/SK is a step above ordinary admin reads, so the caller has to prove the
+     * account again with {@code reauthPassword} even though the session is already an authenticated admin.
+     * A stolen session cookie on its own therefore cannot exfiltrate provider keys, and every attempt -
+     * successful or not - is written to the operation audit log.</p>
+     */
+    public CloudCredentialVO reveal(Long id, String reauthPassword) {
         if (id == null) {
             throw new BusinessException(400, "Cloud credential id is required");
         }
-        return credentialRepository.findById(id)
+        try {
+            authService.verifySensitiveOperationPassword(reauthPassword);
+        } catch (BusinessException denied) {
+            recordAudit("REVEAL_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", String.valueOf(id), null,
+                    "id=" + id, "FAILURE", denied.getMessage());
+            throw denied;
+        }
+        CloudCredentialVO credential = credentialRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(404, "Cloud credential not found: " + id));
+        recordAudit("REVEAL_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", String.valueOf(id), null,
+                credentialAuditDetail(credential), "SUCCESS", null);
+        return credential;
     }
 
     private CloudCredentialVO maskAccessKey(CloudCredentialVO credential) {
@@ -198,8 +218,14 @@ public class CloudCredentialService {
 
     private void recordAudit(String operation, String resourceType, String resourceName,
                              String clusterId, String detail) {
+        recordAudit(operation, resourceType, resourceName, clusterId, detail, "SUCCESS", null);
+    }
+
+    private void recordAudit(String operation, String resourceType, String resourceName,
+                             String clusterId, String detail, String result, String errorMessage) {
         try {
-            operationAuditService.record(operation, resourceType, resourceName, clusterId, detail, "SUCCESS", null);
+            operationAuditService.record(operation, resourceType, resourceName, clusterId, detail,
+                    result, errorMessage);
         } catch (Exception auditFailure) {
             log.warn("Failed to record audit operation={} resource={}: {}", operation, resourceName,
                     auditFailure.getMessage());

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CredentialEncryptionMigration.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CredentialEncryptionMigration.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.credential;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.common.util.CredentialCipher;
+import org.apache.rocketmq.studio.common.util.CredentialUtils;
+import org.apache.rocketmq.studio.persistence.entity.RmqCloudCredential;
+import org.apache.rocketmq.studio.persistence.mapper.RmqCloudCredentialMapper;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Re-seals cloud credential secrets that were persisted before AES-GCM was introduced.
+ *
+ * <p>Earlier Studio builds only base64-encoded {@code rmq_cloud_credential.secret_key}. Those rows stay
+ * readable through {@link CredentialCipher#decrypt(String)}, but they keep no confidentiality until they
+ * are rewritten. This one-shot startup step rewrites every legacy row once, so an upgraded deployment ends
+ * up fully sealed without an operator manually editing each credential. It is idempotent: rows already
+ * carrying the {@code enc:v1:} prefix are skipped, and a second boot finds nothing to do.</p>
+ *
+ * <p>Failures are logged rather than thrown. The migration is a hardening step for existing data, and
+ * refusing to boot because one row could not be read would take the whole dashboard down; the affected row
+ * keeps working through the legacy read path until it is next written.</p>
+ */
+@Slf4j
+@Component
+@Order(Ordered.LOWEST_PRECEDENCE)
+@RequiredArgsConstructor
+public class CredentialEncryptionMigration implements ApplicationRunner {
+
+    private final RmqCloudCredentialMapper credentialMapper;
+    private final CredentialCipher credentialCipher;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        try {
+            List<RmqCloudCredential> legacyRows = credentialMapper.selectList(null).stream()
+                    .filter(row -> row.getSecretKey() != null)
+                    .filter(row -> !CredentialCipher.isEncrypted(row.getSecretKey()))
+                    .toList();
+            if (legacyRows.isEmpty()) {
+                return;
+            }
+            int resealed = 0;
+            for (RmqCloudCredential row : legacyRows) {
+                RmqCloudCredential update = new RmqCloudCredential();
+                update.setId(row.getId());
+                update.setSecretKey(credentialCipher.encrypt(CredentialUtils.decodeBase64(row.getSecretKey())));
+                if (credentialMapper.updateById(update) > 0) {
+                    resealed++;
+                }
+            }
+            log.info("Re-sealed {} cloud credential secret(s) with AES-GCM", resealed);
+        } catch (Exception failure) {
+            log.warn("Skipping cloud credential encryption migration: {}", failure.getMessage());
+            log.debug("Cloud credential encryption migration failure detail", failure);
+        }
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepository.java
@@ -21,7 +21,7 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
-import org.apache.rocketmq.studio.common.util.CredentialUtils;
+import org.apache.rocketmq.studio.common.util.CredentialCipher;
 import org.apache.rocketmq.studio.persistence.entity.RmqCloudCredential;
 import org.apache.rocketmq.studio.persistence.mapper.RmqCloudCredentialMapper;
 import org.springframework.stereotype.Repository;
@@ -33,20 +33,23 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
- * MySQL-backed cloud credential repository. Secret keys are stored base64-encoded in
- * {@code rmq_cloud_credential.secret_key} and decoded when read; plain text is never persisted.
+ * MySQL-backed cloud credential repository. Secret keys are sealed with AES-GCM by
+ * {@link CredentialCipher} before they reach {@code rmq_cloud_credential.secret_key} and are opened again
+ * when read, so the column never holds a recoverable plaintext key. Rows written by the earlier base64
+ * scheme are still readable and are re-sealed by {@code CredentialEncryptionMigration}.
  */
 @RequiredArgsConstructor
 @Repository
 public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepository {
 
     private final RmqCloudCredentialMapper credentialMapper;
+    private final CredentialCipher credentialCipher;
 
     @Override
     public List<CloudCredentialVO> findAll() {
         return credentialMapper.selectList(
                         new QueryWrapper<RmqCloudCredential>().orderByAsc("id")).stream()
-                .map(MybatisPlusCloudCredentialRepository::toVO)
+                .map(this::toVO)
                 .collect(Collectors.toList());
     }
     @Override
@@ -58,7 +61,7 @@ public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepo
                 .orderByDesc("gmt_modified", "id");
         Page<RmqCloudCredential> result = credentialMapper.selectPage(new Page<>(page, pageSize), q);
         return PageResult.of(result.getRecords().stream()
-                        .map(MybatisPlusCloudCredentialRepository::toVO)
+                        .map(this::toVO)
                         .toList(),
                 result.getTotal(), page, pageSize);
     }
@@ -69,7 +72,7 @@ public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepo
             return Optional.empty();
         }
         return Optional.ofNullable(credentialMapper.selectById(id))
-                .map(MybatisPlusCloudCredentialRepository::toVO);
+                .map(this::toVO);
     }
 
     @Override
@@ -79,7 +82,7 @@ public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepo
                         .eq("vendor", vendor.name())
                         .eq("access_key", accessKey)
                         .last("LIMIT 1"));
-        return Optional.ofNullable(entity).map(MybatisPlusCloudCredentialRepository::toVO);
+        return Optional.ofNullable(entity).map(this::toVO);
     }
 
     @Override
@@ -109,26 +112,26 @@ public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepo
 
     // ── Mapping ────────────────────────────────────────────────────
 
-    private static CloudCredentialVO toVO(RmqCloudCredential entity) {
+    private CloudCredentialVO toVO(RmqCloudCredential entity) {
         CloudCredentialVO vo = new CloudCredentialVO();
         vo.setId(entity.getId());
         vo.setName(entity.getName());
         vo.setVendor(parseVendor(entity.getId(), entity.getVendor()));
         vo.setAccessKey(entity.getAccessKey());
-        vo.setSecretKey(CredentialUtils.decodeBase64(entity.getSecretKey()));
+        vo.setSecretKey(credentialCipher.decrypt(entity.getSecretKey()));
         vo.setRemark(entity.getRemark());
         vo.setGmtCreate(entity.getGmtCreate());
         vo.setGmtModified(entity.getGmtModified());
         return vo;
     }
 
-    private static RmqCloudCredential toEntity(CloudCredentialVO vo) {
+    private RmqCloudCredential toEntity(CloudCredentialVO vo) {
         RmqCloudCredential entity = new RmqCloudCredential();
         entity.setId(vo.getId());
         entity.setName(vo.getName());
         entity.setVendor(vo.getVendor() == null ? null : vo.getVendor().name());
         entity.setAccessKey(vo.getAccessKey());
-        entity.setSecretKey(CredentialUtils.encodeBase64(vo.getSecretKey()));
+        entity.setSecretKey(credentialCipher.encrypt(vo.getSecretKey()));
         entity.setRemark(vo.getRemark());
         entity.setGmtCreate(vo.getGmtCreate());
         entity.setGmtModified(vo.getGmtModified() == null ? LocalDateTime.now() : vo.getGmtModified());

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -67,6 +67,11 @@ management:
 studio:
   cors:
     allowed-origins: ${STUDIO_CORS_ALLOWED_ORIGINS:http://localhost:5173,http://127.0.0.1:5173}
+  credential:
+    # Base64-encoded 32-byte AES-256 key used to seal provider AK/SK secrets at rest (enc:v1:...).
+    # Generate with: openssl rand -base64 32  — leave empty to fall back to a deterministic
+    # development key, which is logged as a warning and must not be used for real credentials.
+    encryption-key: ${STUDIO_CREDENTIAL_ENCRYPTION_KEY:}
   auth:
     login-required: ${STUDIO_AUTH_LOGIN_REQUIRED:true}
     # Production defaults. The dev profile disables Secure so local HTTP works without extra environment variables.

--- a/server/src/main/resources/db/schema.sql
+++ b/server/src/main/resources/db/schema.sql
@@ -57,8 +57,8 @@ CREATE TABLE IF NOT EXISTS rmq_nameserver (
   UNIQUE KEY uk_nameserver_name (name)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- Cloud provider credentials (defined before rmq_instance for the FK below;
--- secret_key is base64-encoded and never seeded).
+-- Cloud provider credentials (defined before rmq_instance for the FK below; secret_key holds an
+-- AES-256-GCM sealed value written by CredentialCipher - see CredentialEncryptionMigration).
 CREATE TABLE IF NOT EXISTS rmq_cloud_credential (
   `id`           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
   `gmt_create`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
@@ -66,7 +66,7 @@ CREATE TABLE IF NOT EXISTS rmq_cloud_credential (
   name VARCHAR(128) NOT NULL COMMENT 'Credential display name',
   vendor VARCHAR(32) NOT NULL COMMENT 'ALIYUN/TENCENT',
   access_key VARCHAR(255) NOT NULL,
-  secret_key VARCHAR(512) NOT NULL COMMENT 'Base64-encoded secret key',
+  secret_key VARCHAR(512) NOT NULL COMMENT 'AES-256-GCM sealed secret key (enc:v1:...)',
   remark VARCHAR(255),
   PRIMARY KEY (`id`),
   UNIQUE KEY uk_vendor_access_key (vendor, access_key)

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCredentialAuthorizationIntegrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCredentialAuthorizationIntegrationTest.java
@@ -108,7 +108,7 @@ class AuthCredentialAuthorizationIntegrationTest {
                 .andExpect(status().isOk());
 
         verify(aclService).getUserCredentials(eq("user-1"), isNull());
-        verify(cloudCredentialService).reveal(12L);
+        verify(cloudCredentialService).reveal(eq(12L), isNull());
     }
 
     private LoginVO.UserInfo user(boolean admin) {

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceTest.java
@@ -288,6 +288,68 @@ class AuthServiceTest {
         authService.logout(null);
     }
 
+    @Test
+    void sensitiveOperationPasswordShouldAcceptTheCurrentPrincipalPassword() {
+        AuthProperties.User user = new AuthProperties.User();
+        user.setUsername("ops");
+        user.setPassword("secret");
+        authProperties.setUsers(List.of(user));
+        AuthenticatedUserContext.setUser(null, "ops", true);
+        try {
+            authService.verifySensitiveOperationPassword("secret");
+        } finally {
+            AuthenticatedUserContext.clear();
+        }
+    }
+
+    @Test
+    void sensitiveOperationPasswordShouldRejectAWrongPassword() {
+        AuthProperties.User user = new AuthProperties.User();
+        user.setUsername("ops");
+        user.setPassword("secret");
+        authProperties.setUsers(List.of(user));
+        AuthenticatedUserContext.setUser(null, "ops", true);
+        try {
+            assertThatThrownBy(() -> authService.verifySensitiveOperationPassword("wrong"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("Password confirmation failed")
+                    .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(403));
+        } finally {
+            AuthenticatedUserContext.clear();
+        }
+    }
+
+    @Test
+    void sensitiveOperationPasswordShouldFailClosedWithoutAPassword() {
+        assertThatThrownBy(() -> authService.verifySensitiveOperationPassword(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Password confirmation is required to reveal stored secrets");
+        assertThatThrownBy(() -> authService.verifySensitiveOperationPassword(" "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Password confirmation is required to reveal stored secrets");
+    }
+
+    @Test
+    void sensitiveOperationPasswordShouldResolveAgainstTheSessionPrincipalOnly() {
+        // "other" is a valid configured user, but the session belongs to "ops": confirming with
+        // another account's password must not open the caller's sensitive operation.
+        AuthProperties.User ops = new AuthProperties.User();
+        ops.setUsername("ops");
+        ops.setPassword("secret");
+        AuthProperties.User other = new AuthProperties.User();
+        other.setUsername("other");
+        other.setPassword("otherpass");
+        authProperties.setUsers(List.of(ops, other));
+        AuthenticatedUserContext.setUser(null, "ops", true);
+        try {
+            assertThatThrownBy(() -> authService.verifySensitiveOperationPassword("otherpass"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("Password confirmation failed");
+        } finally {
+            AuthenticatedUserContext.clear();
+        }
+    }
+
     private GeneralSettingsVO sessionSettings(int minutes) {
         return GeneralSettingsVO.builder().sessionTimeout(minutes).build();
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/CredentialCipherTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/CredentialCipherTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CredentialCipherTest {
+
+    private static final String KEY_A = key(1);
+    private static final String KEY_B = key(2);
+
+    @Test
+    void encryptShouldSealWithTheVersionedPrefixAndHideThePlaintextTest() {
+        CredentialCipher cipher = new CredentialCipher(KEY_A);
+
+        String sealed = cipher.encrypt("super-secret-value");
+
+        assertThat(sealed).startsWith(CredentialCipher.PREFIX);
+        assertThat(sealed).doesNotContain("super-secret-value");
+        assertThat(cipher.decrypt(sealed)).isEqualTo("super-secret-value");
+    }
+
+    @Test
+    void encryptShouldUseAFreshIvPerCallTest() {
+        CredentialCipher cipher = new CredentialCipher(KEY_A);
+
+        String first = cipher.encrypt("same-value");
+        String second = cipher.encrypt("same-value");
+
+        assertThat(first).isNotEqualTo(second);
+        assertThat(cipher.decrypt(first)).isEqualTo("same-value");
+        assertThat(cipher.decrypt(second)).isEqualTo("same-value");
+    }
+
+    @Test
+    void decryptShouldReadLegacyBase64ValuesTest() {
+        CredentialCipher cipher = new CredentialCipher(KEY_A);
+        String legacy = CredentialUtils.encodeBase64("legacy-secret");
+
+        assertThat(cipher.decrypt(legacy)).isEqualTo("legacy-secret");
+    }
+
+    @Test
+    void decryptShouldReadLegacyValuesThatAreNotBase64Test() {
+        CredentialCipher cipher = new CredentialCipher(KEY_A);
+
+        assertThat(cipher.decrypt("not base64 !!!")).isEqualTo("not base64 !!!");
+    }
+
+    @Test
+    void decryptShouldRejectTamperedCiphertextTest() {
+        CredentialCipher cipher = new CredentialCipher(KEY_A);
+        String sealed = cipher.encrypt("super-secret-value");
+
+        String body = sealed.substring(CredentialCipher.PREFIX.length());
+        byte[] raw = Base64.getDecoder().decode(body);
+        raw[raw.length - 1] ^= 0x01;
+        String tampered = CredentialCipher.PREFIX + Base64.getEncoder().encodeToString(raw);
+
+        assertThatThrownBy(() -> cipher.decrypt(tampered))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("could not be decrypted")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(500));
+    }
+
+    @Test
+    void decryptShouldRejectValuesSealedWithAnotherKeyTest() {
+        String sealedWithOtherKey = new CredentialCipher(KEY_B).encrypt("super-secret-value");
+
+        assertThatThrownBy(() -> new CredentialCipher(KEY_A).decrypt(sealedWithOtherKey))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("could not be decrypted");
+    }
+
+    @Test
+    void encryptAndDecryptShouldPassNullThroughTest() {
+        CredentialCipher cipher = new CredentialCipher(KEY_A);
+
+        assertThat(cipher.encrypt(null)).isNull();
+        assertThat(cipher.decrypt(null)).isNull();
+    }
+
+    @Test
+    void isEncryptedShouldOnlyMatchTheSealedPrefixTest() {
+        assertThat(CredentialCipher.isEncrypted("enc:v1:AAAA")).isTrue();
+        assertThat(CredentialCipher.isEncrypted("c2VjcmV0")).isFalse();
+        assertThat(CredentialCipher.isEncrypted("enc:v0:AAAA")).isFalse();
+        assertThat(CredentialCipher.isEncrypted(null)).isFalse();
+    }
+
+    @Test
+    void constructorShouldReportAConfiguredKeyTest() {
+        assertThat(new CredentialCipher(KEY_A).usesConfiguredKey()).isTrue();
+        assertThat(new CredentialCipher("").usesConfiguredKey()).isFalse();
+        assertThat(new CredentialCipher(null).usesConfiguredKey()).isFalse();
+    }
+
+    @Test
+    void constructorShouldRejectAKeyThatIsNot32BytesTest() {
+        String shortKey = Base64.getEncoder().encodeToString(new byte[16]);
+
+        assertThatThrownBy(() -> new CredentialCipher(shortKey))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("exactly 32 bytes");
+    }
+
+    @Test
+    void constructorShouldRejectAKeyThatIsNotBase64Test() {
+        assertThatThrownBy(() -> new CredentialCipher("not-base64!!"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Base64-encoded 32-byte AES key");
+    }
+
+    @Test
+    void fallbackKeyShouldStayStableAcrossInstancesTest() {
+        CredentialCipher first = new CredentialCipher("");
+        CredentialCipher second = new CredentialCipher(null);
+
+        String sealed = first.encrypt("shared-secret");
+
+        assertThat(second.decrypt(sealed)).isEqualTo("shared-secret");
+    }
+
+    private static String key(int seed) {
+        byte[] bytes = new byte[32];
+        for (int index = 0; index < bytes.length; index++) {
+            bytes[index] = (byte) (seed + index);
+        }
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialControllerTest.java
@@ -48,11 +48,22 @@ class CloudCredentialControllerTest {
         credentials.setId(1L);
         credentials.setAccessKey("access-key");
         credentials.setSecretKey("secret-key");
-        when(credentialService.reveal(1L)).thenReturn(credentials);
+        when(credentialService.reveal(1L, null)).thenReturn(credentials);
 
         mockMvc.perform(get("/api/cloud-credentials/1/credentials"))
                 .andExpect(status().isOk())
                 .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"));
+    }
+
+    @Test
+    void getCredentialSecretsShouldForwardTheReAuthenticationHeader() throws Exception {
+        when(credentialService.reveal(1L, "operator-password")).thenReturn(new CloudCredentialVO());
+
+        mockMvc.perform(get("/api/cloud-credentials/1/credentials")
+                        .header(CloudCredentialController.REAUTH_HEADER, "operator-password"))
+                .andExpect(status().isOk());
+
+        verify(credentialService).reveal(1L, "operator-password");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
@@ -22,6 +22,7 @@ import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.auth.AuthService;
 import org.apache.rocketmq.studio.provider.alibaba.AliyunClientFactory;
 import org.apache.rocketmq.studio.provider.tencent.TencentClientFactory;
 import org.junit.jupiter.api.Test;
@@ -41,6 +42,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -62,6 +64,9 @@ class CloudCredentialServiceTest {
 
     @Mock
     private OperationAuditService operationAuditService;
+
+    @Mock
+    private AuthService authService;
 
     @InjectMocks
     private CloudCredentialService service;
@@ -270,29 +275,58 @@ class CloudCredentialServiceTest {
     }
 
     @Test
-    void revealShouldReturnUnmaskedCredentialTest() {
+    void revealShouldReturnUnmaskedCredentialAfterPasswordConfirmationTest() {
         CloudCredentialVO stored = new CloudCredentialVO();
         stored.setId(1L);
+        stored.setName("aliyun-prod");
         stored.setVendor(InstanceVendor.ALIYUN);
         stored.setAccessKey("LTAI5tRevealKey000000001");
         stored.setSecretKey("plain-secret");
         when(credentialRepository.findById(1L)).thenReturn(Optional.of(stored));
 
-        CloudCredentialVO revealed = service.reveal(1L);
+        CloudCredentialVO revealed = service.reveal(1L, "correct-password");
 
         assertThat(revealed.getAccessKey()).isEqualTo("LTAI5tRevealKey000000001");
         assertThat(revealed.getSecretKey()).isEqualTo("plain-secret");
+        verify(authService).verifySensitiveOperationPassword("correct-password");
+        verify(operationAuditService).record(eq("REVEAL_CLOUD_CREDENTIAL"), eq("CLOUD_CREDENTIAL"),
+                eq("1"), eq(null), eq("name=aliyun-prod, vendor=ALIYUN"), eq("SUCCESS"), eq(null));
     }
 
     @Test
-    void repositoryShouldBase64EncodeSecretTest() {
+    void revealShouldFailClosedWhenPasswordConfirmationIsRejectedTest() {
+        doThrow(new BusinessException(403, "Password confirmation failed"))
+                .when(authService).verifySensitiveOperationPassword(isNull());
+
+        assertThatThrownBy(() -> service.reveal(1L, null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Password confirmation failed")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(403));
+
+        // A rejected confirmation must neither read nor expose the stored secret, but must be audited.
+        verify(credentialRepository, never()).findById(any());
+        verify(operationAuditService).record(eq("REVEAL_CLOUD_CREDENTIAL"), eq("CLOUD_CREDENTIAL"),
+                eq("1"), eq(null), eq("id=1"), eq("FAILURE"), eq("Password confirmation failed"));
+    }
+
+    @Test
+    void revealShouldStillValidateTheIdBeforeConfirmingThePasswordTest() {
+        assertThatThrownBy(() -> service.reveal(null, "correct-password"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Cloud credential id is required");
+
+        verify(authService, never()).verifySensitiveOperationPassword(any());
+    }
+
+    @Test
+    void legacyBase64SecretShouldRoundTripForTheEncryptionMigrationTest() {
         String encoded = CredentialUtils.encodeBase64("plain-secret");
         assertThat(encoded).isNotEqualTo("plain-secret");
         assertThat(CredentialUtils.decodeBase64(encoded)).isEqualTo("plain-secret");
     }
 
     @Test
-    void repositoryShouldTolerateLegacyPlainSecretTest() {
+    void legacyPlainSecretShouldSurviveTolerantBase64DecodingTest() {
         assertThat(CredentialUtils.decodeBase64("not base64 !!!")).isEqualTo("not base64 !!!");
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CredentialEncryptionMigrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CredentialEncryptionMigrationTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.credential;
+
+import org.apache.rocketmq.studio.common.util.CredentialCipher;
+import org.apache.rocketmq.studio.common.util.CredentialUtils;
+import org.apache.rocketmq.studio.persistence.entity.RmqCloudCredential;
+import org.apache.rocketmq.studio.persistence.mapper.RmqCloudCredentialMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CredentialEncryptionMigrationTest {
+
+    private static final String TEST_KEY = testKey();
+
+    @Mock
+    private RmqCloudCredentialMapper credentialMapper;
+
+    private CredentialCipher credentialCipher;
+
+    private CredentialEncryptionMigration migration;
+
+    @BeforeEach
+    void setUp() {
+        credentialCipher = new CredentialCipher(TEST_KEY);
+        migration = new CredentialEncryptionMigration(credentialMapper, credentialCipher);
+    }
+
+    @Test
+    void runShouldResealLegacyRowsAndSkipSealedOrEmptyOnes() {
+        RmqCloudCredential legacy = row(1L, CredentialUtils.encodeBase64("legacy-secret"));
+        RmqCloudCredential sealed = row(2L, credentialCipher.encrypt("already-sealed"));
+        RmqCloudCredential empty = row(3L, null);
+        when(credentialMapper.selectList(null)).thenReturn(List.of(legacy, sealed, empty));
+        when(credentialMapper.updateById(any(RmqCloudCredential.class))).thenReturn(1);
+
+        migration.run(null);
+
+        ArgumentCaptor<RmqCloudCredential> captor = ArgumentCaptor.forClass(RmqCloudCredential.class);
+        verify(credentialMapper).updateById(captor.capture());
+        RmqCloudCredential updated = captor.getValue();
+        assertThat(updated.getId()).isEqualTo(1L);
+        assertThat(CredentialCipher.isEncrypted(updated.getSecretKey())).isTrue();
+        assertThat(credentialCipher.decrypt(updated.getSecretKey())).isEqualTo("legacy-secret");
+    }
+
+    @Test
+    void runShouldNotRewriteAnythingWhenEveryRowIsAlreadySealed() {
+        when(credentialMapper.selectList(null))
+                .thenReturn(List.of(row(1L, credentialCipher.encrypt("sealed"))));
+
+        migration.run(null);
+
+        verify(credentialMapper, never()).updateById(any(RmqCloudCredential.class));
+    }
+
+    @Test
+    void runShouldNotPropagateAFailureSoStartupStillSucceeds() {
+        when(credentialMapper.selectList(null)).thenThrow(new IllegalStateException("table missing"));
+
+        assertThatCode(() -> migration.run(null)).doesNotThrowAnyException();
+
+        verify(credentialMapper, never()).updateById(any(RmqCloudCredential.class));
+    }
+
+    private RmqCloudCredential row(Long id, String secretKey) {
+        RmqCloudCredential entity = new RmqCloudCredential();
+        entity.setId(id);
+        entity.setName("cred-" + id);
+        entity.setVendor("ALIYUN");
+        entity.setAccessKey("access-key");
+        entity.setSecretKey(secretKey);
+        return entity;
+    }
+
+    private static String testKey() {
+        byte[] key = new byte[32];
+        for (int index = 0; index < key.length; index++) {
+            key[index] = (byte) (index + 11);
+        }
+        return Base64.getEncoder().encodeToString(key);
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepositoryTest.java
@@ -23,32 +23,45 @@ import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.util.CredentialCipher;
+import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.persistence.entity.RmqCloudCredential;
 import org.apache.rocketmq.studio.persistence.mapper.RmqCloudCredentialMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Base64;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MybatisPlusCloudCredentialRepositoryTest {
 
+    /** Deterministic 32-byte AES key so the test can assert on the stored ciphertext. */
+    private static final String TEST_KEY = testKey();
+
     @Mock
     private RmqCloudCredentialMapper credentialMapper;
 
-    @InjectMocks
+    private CredentialCipher credentialCipher;
+
     private MybatisPlusCloudCredentialRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        credentialCipher = new CredentialCipher(TEST_KEY);
+        repository = new MybatisPlusCloudCredentialRepository(credentialMapper, credentialCipher);
+    }
 
     @Test
     void saveShouldReportALostConcurrentUpdate() {
@@ -77,6 +90,54 @@ class MybatisPlusCloudCredentialRepositoryTest {
     }
 
     @Test
+    void saveShouldSealTheSecretKeyBeforePersisting() {
+        CloudCredentialVO credential = new CloudCredentialVO();
+        credential.setName("aliyun-prod");
+        credential.setVendor(InstanceVendor.ALIYUN);
+        credential.setAccessKey("access-key");
+        credential.setSecretKey("super-secret-value");
+
+        repository.save(credential);
+
+        RmqCloudCredential persisted = capturedInsert();
+        String stored = persisted.getSecretKey();
+        assertThat(stored).isNotEqualTo("super-secret-value");
+        assertThat(CredentialCipher.isEncrypted(stored)).isTrue();
+        assertThat(credentialCipher.decrypt(stored)).isEqualTo("super-secret-value");
+    }
+
+    @Test
+    void replaceShouldResealTheSecretKeyWithAFreshIv() {
+        CloudCredentialVO credential = new CloudCredentialVO();
+        credential.setId(1L);
+        credential.setName("aliyun-prod");
+        credential.setVendor(InstanceVendor.ALIYUN);
+        credential.setAccessKey("access-key");
+        credential.setSecretKey("rotated-secret");
+        when(credentialMapper.updateById(any(RmqCloudCredential.class))).thenReturn(1);
+
+        assertThat(repository.replace(credential)).isTrue();
+
+        ArgumentCaptor<RmqCloudCredential> captor = ArgumentCaptor.forClass(RmqCloudCredential.class);
+        verify(credentialMapper).updateById(captor.capture());
+        String stored = captor.getValue().getSecretKey();
+        assertThat(CredentialCipher.isEncrypted(stored)).isTrue();
+        assertThat(credentialCipher.decrypt(stored)).isEqualTo("rotated-secret");
+    }
+
+    @Test
+    void findByIdShouldOpenASealedSecret() {
+        RmqCloudCredential entity = entity(4L, "cred-sealed", "ALIYUN");
+        entity.setSecretKey(credentialCipher.encrypt("sealed-secret"));
+        when(credentialMapper.selectById(4L)).thenReturn(entity);
+
+        Optional<CloudCredentialVO> result = repository.findById(4L);
+
+        assertThat(result).isPresent();
+        assertThat(result.orElseThrow().getSecretKey()).isEqualTo("sealed-secret");
+    }
+
+    @Test
     void findByIdShouldMapValidPersistedVendor() {
         when(credentialMapper.selectById(2L)).thenReturn(entity(2L, "cred-valid", "ALIYUN"));
 
@@ -84,6 +145,9 @@ class MybatisPlusCloudCredentialRepositoryTest {
 
         assertThat(result).isPresent();
         assertThat(result.orElseThrow().getVendor()).isEqualTo(InstanceVendor.ALIYUN);
+        // A row written before AES-GCM is still readable through the legacy base64 path.
+        assertThat(result.orElseThrow().getSecretKey())
+                .isEqualTo(CredentialUtils.decodeBase64("c2VjcmV0"));
     }
 
     @Test
@@ -110,6 +174,12 @@ class MybatisPlusCloudCredentialRepositoryTest {
         assertThat(query.getParamNameValuePairs()).containsValue("%credential%");
     }
 
+    private RmqCloudCredential capturedInsert() {
+        ArgumentCaptor<RmqCloudCredential> captor = ArgumentCaptor.forClass(RmqCloudCredential.class);
+        verify(credentialMapper).insert(captor.capture());
+        return captor.getValue();
+    }
+
     private RmqCloudCredential entity(Long id, String name, String vendor) {
         RmqCloudCredential entity = new RmqCloudCredential();
         entity.setId(id);
@@ -118,5 +188,13 @@ class MybatisPlusCloudCredentialRepositoryTest {
         entity.setAccessKey("access-key");
         entity.setSecretKey("c2VjcmV0");
         return entity;
+    }
+
+    private static String testKey() {
+        byte[] key = new byte[32];
+        for (int index = 0; index < key.length; index++) {
+            key[index] = (byte) (index + 1);
+        }
+        return Base64.getEncoder().encodeToString(key);
     }
 }


### PR DESCRIPTION
# feat(studio): seal cloud credential secrets with AES-GCM and gate reveal behind re-auth

## Problem

Cloud provider credentials (AK/SK for Aliyun / Tencent instances) are stored in `rmq_cloud_credential.secret_key` **base64-encoded**. Base64 is an encoding, not confidentiality: anyone with read access to the table (a SQL dump, a backup, a co-located process) recovers every provider secret key trivially. On top of that, the reveal endpoint (`GET /api/cloud-credentials/{id}/credentials`) trusts the admin session alone — a replayed or stolen session cookie is enough to exfiltrate all stored keys, with no audit trail beyond the access itself.

## Solution

Two focused hardening steps, deliberately small in surface:

### 1. AES-256-GCM encryption at rest

- New `CredentialCipher` seals secrets as `enc:v1:<base64(iv || ciphertext || tag)>`:
  - a fresh random 96-bit IV per value, so identical secrets never collide in the DB;
  - GCM is authenticated — a tampered row **fails closed** (clean 500) instead of returning corrupted key material.
- The key comes from `studio.credential.encryption-key` (`STUDIO_CREDENTIAL_ENCRYPTION_KEY`), a Base64-encoded 32-byte AES key; invalid keys fail fast at startup. When unset (local/dev convenience), a deterministic development key is derived and a **loud WARNING** names the exact property to set in production.
- `MybatisPlusCloudCredentialRepository` now encrypts on write and decrypts on read. In-memory state stays plaintext; only the persisted column changes.
- **Backward compatibility**: rows written by the legacy base64 scheme (no `enc:v1:` prefix) keep working through the tolerant decode path.
- **`CredentialEncryptionMigration`** (startup `ApplicationRunner`, idempotent) re-seals every legacy row once, so an upgraded deployment ends up fully encrypted without manual edits. Failures are logged, not thrown — a hardening step must not brick startup.

### 2. Reveal requires a second authentication

`GET /api/cloud-credentials/{id}/credentials` now additionally requires the operator's password in the `X-Studio-Reauth` header:

- The password is verified **against the session principal** (`AuthenticatedUserContext`), never against a caller-supplied user name — it cannot be abused to probe another account's password.
- Reveal is already admin-gated by `AuthInterceptor`; this adds a second factor so a stolen admin session cookie alone cannot read provider keys.
- Every attempt is audited (`REVEAL_CLOUD_CREDENTIAL`, SUCCESS and FAILURE with the denial reason).
- The password travels in a header, never in the URL/query string; the response keeps `Cache-Control: no-store`.

**Out of scope by design**: gRPC channel auto-signing is untouched.

## Runtime verification (live dashboard + H2 file DB)

| Check | Result |
|---|---|
| DB content after create | `secret_key = enc:v1:Fic02WL…` (plaintext never persisted) |
| Reveal without header | `403 Password confirmation is required…` |
| Reveal with wrong password | `403 Password confirmation failed` |
| Reveal with correct password | `200` + plaintext secret (decrypt path works) |
| Audit trail | 3 rows: `REVEAL_CLOUD_CREDENTIAL` 2× FAILURE + 1× SUCCESS |
| Restart with same key | decrypts correctly across restarts |

## Testing

- New `CredentialCipherTest` (12): round-trip, IV freshness, tamper rejection, wrong-key rejection, legacy base64/plain read, key validation, fallback stability.
- New `CredentialEncryptionMigrationTest` (3): re-seals legacy rows only, skips sealed rows, never propagates failure.
- `MybatisPlusCloudCredentialRepositoryTest`: real cipher, asserts sealed ciphertext on write and decryption on read, legacy rows still readable.
- `CloudCredentialServiceTest` / `CloudCredentialControllerTest` / `AuthServiceTest` / `AuthCredentialAuthorizationIntegrationTest`: updated for the re-auth contract (fail-closed, audited denial, header forwarding).
- Focused suite **69/69 green**; full server suite shows no new failures (only the 2 pre-existing `AuthCorsIntegrationTest` failures).

## Configuration

```yaml
studio:
  credential:
    # Base64-encoded 32-byte AES-256 key. Generate with: openssl rand -base64 32
    encryption-key: ${STUDIO_CREDENTIAL_ENCRYPTION_KEY:}
```

## Checklist

- [x] No dependency changes; AES-GCM is JDK built-in
- [x] Legacy base64 rows keep working and are migrated automatically
- [x] Reveal: admin gate + password re-auth + audit, fail-closed
- [x] gRPC channel auto-signing untouched
- [x] Unit tests + live runtime verification (ciphertext inspected directly in the DB)
