### PR TITLE
fix(studio): preserve Unicode code points when truncating message properties

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/MessagePropertyDisplay.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/MessagePropertyDisplay.java
@@ -68,13 +68,15 @@ public final class MessagePropertyDisplay {
     /** True when any value exceeds {@link #MAX_PROPERTY_VALUE_CHARS} and would be abbreviated. */
     public static boolean hasOversizedProperty(Map<String, String> properties) {
         return properties != null && properties.values().stream()
-                .anyMatch(value -> value != null && value.length() > MAX_PROPERTY_VALUE_CHARS);
+                .anyMatch(value -> value != null
+                        && value.codePointCount(0, value.length()) > MAX_PROPERTY_VALUE_CHARS);
     }
 
     private static String abbreviate(String value) {
-        if (value == null || value.length() <= MAX_PROPERTY_VALUE_CHARS) {
+        if (value == null || value.codePointCount(0, value.length()) <= MAX_PROPERTY_VALUE_CHARS) {
             return value;
         }
-        return value.substring(0, MAX_PROPERTY_VALUE_CHARS) + "...";
+        int endIndex = value.offsetByCodePoints(0, MAX_PROPERTY_VALUE_CHARS);
+        return value.substring(0, endIndex) + "...";
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/MessagePropertyDisplayTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/MessagePropertyDisplayTest.java
@@ -64,4 +64,15 @@ class MessagePropertyDisplayTest {
         assertThat(MessagePropertyDisplay.hasOversizedProperty(Map.of("k", "short"))).isFalse();
         assertThat(MessagePropertyDisplay.hasOversizedProperty(null)).isFalse();
     }
+
+    @Test
+    void limitPropertiesShouldNotSplitSurrogatePairTest() {
+        // 1023 ASCII chars followed by an emoji (a supplementary character whose
+        // UTF-16 encoding straddles the 1024-char boundary) and a suffix.
+        String emoji = "😀"; // 😀
+        String value = "a".repeat(1023) + emoji + "suffix";
+        String truncated = MessagePropertyDisplay.limitProperties(Map.of("k", value)).get("k");
+        // The truncation must land on a code-point boundary and keep the emoji intact.
+        assertThat(truncated).isEqualTo("a".repeat(1023) + emoji + "...");
+    }
 }


### PR DESCRIPTION
## Summary

Fix message property values being truncated mid-surrogate-pair, producing unpaired surrogates.

## Problem

`MessagePropertyDisplay.abbreviate` used UTF-16 `length()`/`substring(0, 1024)`. When the boundary fell between the high and low surrogate of a supplementary character (e.g. an emoji), the truncated value contained an unpaired surrogate and rendered as a replacement character.

## Fix

Count code points (`codePointCount`) and truncate at a code-point boundary (`offsetByCodePoints`). `hasOversizedProperty` is updated to the same code-point semantics for consistency.

## Test plan

Added a regression test (1023 ASCII chars + emoji straddling the boundary). `mvn test -Dtest=MessagePropertyDisplayTest` — 6 tests, 0 failures.

Fixes #4167