### PR TITLE
fix(studio): escape SQL LIKE wildcards in user search

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
@@ -188,7 +188,7 @@ public class AuthService {
                     "search must not exceed " + MAX_USER_SEARCH_LENGTH + " characters");
         }
         QueryWrapper<RmqStudioUser> query = new QueryWrapper<RmqStudioUser>()
-                .like(!normalizedSearch.isEmpty(), "username", normalizedSearch)
+                .like(!normalizedSearch.isEmpty(), "username", escapeLike(normalizedSearch))
                 .eq(admin != null, "admin", admin)
                 .eq(enabled != null, "enabled", enabled)
                 .orderByAsc("username")
@@ -596,6 +596,10 @@ public class AuthService {
         if (!databaseBacked()) {
             throw new IllegalStateException("Studio user management requires database persistence");
         }
+    }
+
+    static String escapeLike(String search) {
+        return search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
     }
 
     private record AuthSession(LoginVO.UserInfo user, long expiresAtMillis) {

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceTest.java
@@ -54,6 +54,14 @@ class AuthServiceTest {
     }
 
     @Test
+    void escapeLikeShouldEscapeSqlWildcards() {
+        assertThat(AuthService.escapeLike("admin_")).isEqualTo("admin\\_");
+        assertThat(AuthService.escapeLike("admin%")).isEqualTo("admin\\%");
+        assertThat(AuthService.escapeLike("a\\b")).isEqualTo("a\\\\b");
+        assertThat(AuthService.escapeLike("plain")).isEqualTo("plain");
+    }
+
+    @Test
     void loginShouldReturnTokenForValidCredentials() {
         AuthProperties.User user = new AuthProperties.User();
         user.setUsername("testuser");


### PR DESCRIPTION
## Summary

Fix the Studio user search treating `_` and `%` in the query as SQL LIKE wildcards.

## Problem

`AuthService.listUsers` passed the raw username search into MyBatis-Plus `like("username", ...)` without escaping. A search for `admin_` matched `adminX` and `admin%` matched any suffix. Other search paths (e.g. message query history) already escape `\`, `%` and `_`.

## Fix

Escape `\`, `%` and `_` before building the LIKE condition, matching the existing `escapeLike` behavior.

## Test plan

Added a focused `escapeLike` regression test. `mvn test -Dtest=AuthServiceTest` — 17 tests, 0 failures.

Fixes #4223