### PR TITLE
fix(studio): render query history timestamps as UTC

### DIFF
--- a/web/src/components/MessageQueryHistoryDrawer.tsx
+++ b/web/src/components/MessageQueryHistoryDrawer.tsx
@@ -16,6 +16,7 @@ import {
   type TraceQueryHistory,
 } from '../api/messageHistory';
 import { useLang } from '../i18n/LangContext';
+import { formatUtcDateTime } from '../utils/format';
 
 interface Props {
   open: boolean;
@@ -26,11 +27,7 @@ interface Props {
 }
 
 const PAGE_SIZE = 20;
-const formatTime = (value?: string) => {
-  if (!value) return '-';
-  const timestamp = new Date(value);
-  return Number.isNaN(timestamp.getTime()) ? '-' : timestamp.toLocaleString();
-};
+const formatTime = (value?: string) => formatUtcDateTime(value);
 
 const MessageQueryHistoryDrawer = ({
   open,


### PR DESCRIPTION
## Summary

Fix the query history drawer rendering UTC timestamps as browser-local time.

## Problem

`MessageQueryHistoryDrawer.formatTime` used `toLocaleString()`, which treats the offset-less UTC `LocalDateTime` values from `QueryHistoryService` as browser-local time, shifting displayed timestamps by the viewer offset. Same class of bug as the alert rule `lastTriggered` display issue (#4174).

## Fix

Use the existing `formatUtcDateTime` helper, which appends `Z` to offset-less strings so they are parsed as UTC.

## Test plan

`cd web && npx tsc -b` passes.

Fixes #4221