### PR TITLE
fix(studio): render user-management timestamps as UTC

### DIFF
--- a/web/src/pages/studio/UserManagement.tsx
+++ b/web/src/pages/studio/UserManagement.tsx
@@ -50,6 +50,7 @@ import {
 } from '../../api/studioUsers';
 import useAuthStore from '../../stores/authStore';
 import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
+import { formatUtcDateTime } from '../../utils/format';
 import { tableScrollX } from '../../utils/table';
 
 interface CreateFormValues {
@@ -63,7 +64,9 @@ interface PasswordFormValues {
   newPassword: string;
 }
 
-const dateTime = (value?: string) => (value ? new Date(value).toLocaleString() : '-');
+// AuthService stores Clock.systemUTC() LocalDateTime values without an offset.
+// formatUtcDateTime appends Z so the viewer's timezone is applied correctly.
+const dateTime = (value?: string) => formatUtcDateTime(value);
 const PAGE_SIZE_OPTIONS = [20, 50, 100];
 
 type RoleFilter = 'admin' | 'reader';

--- a/web/src/pages/studio/__tests__/UserManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/UserManagement.test.tsx
@@ -29,6 +29,7 @@ import {
   type StudioUser,
 } from '../../../api/studioUsers';
 import { downloadCsv } from '../../../utils/download';
+import { formatUtcDateTime } from '../../../utils/format';
 import UserManagementPage from '../UserManagement';
 
 type MockAuthState = { admin: boolean; userId: number; logout: () => void };
@@ -190,7 +191,7 @@ describe('UserManagementPage', () => {
 
     await screen.findByText('operator');
     expect(screen.getAllByText('2').length).toBeGreaterThan(0);
-    expect(screen.getByText(new Date('2026-08-22T09:30:00').toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(formatUtcDateTime('2026-08-22T09:30:00'))).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: '会话' }));
     await screen.findByText('注销 operator 的活跃会话？');
@@ -198,6 +199,14 @@ describe('UserManagementPage', () => {
 
     await waitFor(() => expect(revokeStudioUserSessions).toHaveBeenCalledWith(7));
     expect(listStudioUsers).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats offset-less session timestamps as UTC', async () => {
+    renderPage();
+
+    await screen.findByText('operator');
+    // AuthService writes Clock.systemUTC() LocalDateTime values without an offset.
+    expect(screen.getByText(formatUtcDateTime('2026-08-22T09:30:00'))).toBeInTheDocument();
   });
 
   it('blocks the row status switch while the same user revocation is in flight', async () => {


### PR DESCRIPTION
Fixes #4234.

## Problem / Evidence

Studio user management renders session and account timestamps with \
ew Date(value).toLocaleString()\. AuthService stores those fields as offset-less \LocalDateTime\ values from \Clock.systemUTC()\ (\AuthService.now()\ → \ZoneOffset.UTC\ for \last_seen_at\, \expires_at\, \password_changed_at\). JavaScript therefore treats them as browser-local wall-clock times.

Local reproduction (TZ \Asia/Shanghai\, UTC+8):

\\\
new Date('2026-08-22T09:30:00').toLocaleString()  →  2026/8/22 09:30:00   (wrong)
new Date('2026-08-22T09:30:00Z').toLocaleString() →  2026/8/22 17:30:00   (correct local)
\\\

Affected UI: user table columns 最近活跃 / 最近过期 / 创建时间, and the CSV export columns (Last Session Seen At, Nearest Session Expires At, Password Changed At, Created At, Modified At).

## Fix

Reuse the shared \ormatUtcDateTime\ helper (same approach as alert \lastTriggered\ #4174/#4199 and query-history \queriedAt\ #4221/#4222), which appends \Z\ for offset-less values before formatting into the viewer's timezone.

## Tests

\
px vitest run src/pages/studio/__tests__/UserManagement.test.tsx\ — **7 passed** (6 pre-existing + 1 new named regression \	reats offset-less session timestamps as UTC\; existing session-metadata assertion updated to the UTC helper).

Red light before the fix: the new/updated assertions expect \ormatUtcDateTime('2026-08-22T09:30:00')\ (17:30 CST here); the old helper rendered 09:30.

ESLint and Prettier clean on both changed files. Diff: 2 files, +14/−2.

## Risk

Low. Normal browsers already receive offset-less UTC wall-clock strings; only the display/export conversion changes. Response shapes and backend fields are unchanged.