### PR TITLE
fix(studio): escape SQL LIKE wildcards in data source and metadata search

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/SqlLikeUtils.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/SqlLikeUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * Helpers for building SQL {@code LIKE} predicates from user-supplied search strings.
+ *
+ * <p>MyBatis-Plus {@code like()} wraps the value with {@code %} and hands it to the SQL
+ * {@code LIKE} operator, which treats {@code %}, {@code _} and {@code \} as wildcard/escape
+ * characters. Search strings are user input, so those characters must be escaped to keep a
+ * literal match (a search for {@code prod_user} must not also match {@code prodXuser}).
+ */
+public final class SqlLikeUtils {
+
+    private SqlLikeUtils() {
+    }
+
+    /** Escape {@code \}, {@code %} and {@code _} so the value matches literally in a LIKE clause. */
+    public static String escape(String search) {
+        if (!StringUtils.hasText(search)) {
+            return search;
+        }
+        return search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.studio.persistence.mapper.RmqDataSourceMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqSettingsMapper;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.common.util.SqlLikeUtils;
 import org.apache.rocketmq.studio.settings.DataSourceVO;
 import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
 import org.apache.rocketmq.studio.settings.SettingsRepository;
@@ -147,7 +148,7 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
         String normalizedSearch = search == null || search.isBlank() ? null : search.trim();
         String normalizedType = type == null || type.isBlank() ? null : type.trim();
         QueryWrapper<RmqDataSource> query = new QueryWrapper<RmqDataSource>()
-                .like(normalizedSearch != null, "json", normalizedSearch)
+                .like(normalizedSearch != null, "json", SqlLikeUtils.escape(normalizedSearch))
                 .apply(normalizedType != null,
                         "LOWER(json) LIKE CONCAT('%\"type\":\"', LOWER({0}), '\"%')", normalizedType)
                 .orderByDesc("gmt_modified", "id");

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -42,6 +42,7 @@ import org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.util.Pagination;
 import org.apache.rocketmq.studio.common.util.MqResponseCodes;
+import org.apache.rocketmq.studio.common.util.SqlLikeUtils;
 import org.apache.rocketmq.studio.common.util.SubscriptionFilterModes;
 import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
 import org.apache.rocketmq.studio.common.util.SystemTopicFilter;
@@ -146,7 +147,7 @@ public class RocketMQMetadataProvider implements MetadataProvider {
                 .eq(instanceId != null, RmqTopic::getInstanceId, normalizeMetadataScope(instanceId))
                 .eq(StringUtils.hasText(clusterId), RmqTopic::getClusterId, clusterId)
                 .eq(StringUtils.hasText(type), RmqTopic::getTopicType, type)
-                .like(StringUtils.hasText(search), RmqTopic::getName, search)
+                .like(StringUtils.hasText(search), RmqTopic::getName, SqlLikeUtils.escape(search))
                 .orderByAsc(RmqTopic::getName);
 
         List<TopicVO> result = new ArrayList<>();
@@ -166,7 +167,7 @@ public class RocketMQMetadataProvider implements MetadataProvider {
                 .eq(instanceId != null, RmqTopic::getInstanceId, normalizeMetadataScope(instanceId))
                 .eq(StringUtils.hasText(clusterId), RmqTopic::getClusterId, clusterId)
                 .eq(StringUtils.hasText(type), RmqTopic::getTopicType, type)
-                .like(StringUtils.hasText(search), RmqTopic::getName, search)
+                .like(StringUtils.hasText(search), RmqTopic::getName, SqlLikeUtils.escape(search))
                 .notIn(RmqTopic::getName, TopicValidator.getSystemTopicSet())
                 .notLikeRight(RmqTopic::getName, "rmq_sys_")
                 .notLikeRight(RmqTopic::getName, "%RETRY%")
@@ -226,7 +227,7 @@ public class RocketMQMetadataProvider implements MetadataProvider {
         LambdaQueryWrapper<RmqGroup> query = new LambdaQueryWrapper<RmqGroup>()
                 .eq(instanceId != null, RmqGroup::getInstanceId, normalizeMetadataScope(instanceId))
                 .eq(StringUtils.hasText(clusterId), RmqGroup::getClusterId, clusterId)
-                .like(StringUtils.hasText(search), RmqGroup::getName, search)
+                .like(StringUtils.hasText(search), RmqGroup::getName, SqlLikeUtils.escape(search))
                 .orderByAsc(RmqGroup::getName);
 
         List<ConsumerGroupVO> result = new ArrayList<>();
@@ -243,7 +244,7 @@ public class RocketMQMetadataProvider implements MetadataProvider {
         LambdaQueryWrapper<RmqGroup> query = new LambdaQueryWrapper<RmqGroup>()
                 .eq(instanceId != null, RmqGroup::getInstanceId, normalizeMetadataScope(instanceId))
                 .eq(StringUtils.hasText(clusterId), RmqGroup::getClusterId, clusterId)
-                .like(StringUtils.hasText(search), RmqGroup::getName, search)
+                .like(StringUtils.hasText(search), RmqGroup::getName, SqlLikeUtils.escape(search))
                 .orderByAsc(RmqGroup::getName, RmqGroup::getId);
         Page<RmqGroup> result = groupMapper.selectPage(new Page<>(page, pageSize), query);
         List<ConsumerGroupVO> groups = result.getRecords().stream()

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/SqlLikeUtilsTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/SqlLikeUtilsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SqlLikeUtilsTest {
+
+    @Test
+    void escapeShouldEscapeLikeWildcards() {
+        assertThat(SqlLikeUtils.escape("prod_user")).isEqualTo("prod\\_user");
+        assertThat(SqlLikeUtils.escape("100%")).isEqualTo("100\\%");
+        assertThat(SqlLikeUtils.escape("a\\b")).isEqualTo("a\\\\b");
+    }
+
+    @Test
+    void escapeShouldLeavePlainTextAndBlankUntouched() {
+        assertThat(SqlLikeUtils.escape("plain")).isEqualTo("plain");
+        assertThat(SqlLikeUtils.escape(null)).isNull();
+        assertThat(SqlLikeUtils.escape("  ")).isEqualTo("  ");
+    }
+}


### PR DESCRIPTION
## Summary

Escape SQL LIKE wildcards in two remaining search paths that were not covered by the earlier per-surface fixes (#4223, #4229, #4192, #4193, #4194, #4232).

## Problem

- `MybatisPlusSettingsRepository.findDataSources` passed the raw search string into `like("json", ...)`.
- `RocketMQMetadataProvider` passed the raw search string into `like(RmqTopic::getName, ...)` / `like(RmqGroup::getName, ...)`.

Topic/group names and data source content can contain `%` and `_`, so a search treated those as LIKE wildcards and silently matched unrelated rows.

## Fix

Introduce a shared `SqlLikeUtils.escape` helper (extracted from the escaping already used by `QueryHistoryService`) and apply it to the remaining unescaped predicates.

## Test plan

Added `SqlLikeUtilsTest`. `mvn test -Dtest=SqlLikeUtilsTest` — 2 tests, 0 failures.