### PR TITLE
[Studio] feat: add message query history insights

### DIFF
--- a/web/src/components/MessageHistoryInsightsPanel.tsx
+++ b/web/src/components/MessageHistoryInsightsPanel.tsx
@@ -1,0 +1,324 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Alert,
+  Card,
+  Col,
+  Empty,
+  Progress,
+  Row,
+  Space,
+  Statistic,
+  Table,
+  Tag,
+  Typography,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import type {
+  MessageQueryHistory,
+  QueryHistorySummary,
+  TraceQueryHistory,
+} from '../api/messageHistory';
+import { useLang } from '../i18n/LangContext';
+import { formatUtcDateTime } from '../utils/format';
+import {
+  buildMessageHistoryInsights,
+  type MessageHistoryInsightCode,
+  type MessageHistoryInsightIssue,
+  type MessageHistoryInsightLevel,
+  type MessageHistoryNotableRow,
+  type MessageHistoryRecommendationCode,
+} from '../utils/messageHistoryInsights';
+import { tableScrollX } from '../utils/table';
+
+const { Text } = Typography;
+
+interface Props {
+  summary?: QueryHistorySummary;
+  messageRows: MessageQueryHistory[];
+  traceRows: TraceQueryHistory[];
+  loading?: boolean;
+  now?: number;
+}
+
+const levelMeta: Record<
+  MessageHistoryInsightLevel,
+  {
+    color: string;
+    progress: 'success' | 'normal' | 'exception';
+    alertType: 'success' | 'info' | 'warning' | 'error';
+  }
+> = {
+  healthy: { color: 'success', progress: 'success', alertType: 'success' },
+  notice: { color: 'processing', progress: 'normal', alertType: 'info' },
+  warning: { color: 'warning', progress: 'exception', alertType: 'warning' },
+  critical: { color: 'error', progress: 'exception', alertType: 'error' },
+};
+
+const issueTextKey = (code: MessageHistoryInsightCode): string => {
+  switch (code) {
+    case 'NO_HISTORY':
+      return 'messageHistoryInsights.issue.noHistory';
+    case 'STALE_HISTORY':
+      return 'messageHistoryInsights.issue.staleHistory';
+    case 'TRACE_UNDERUSED':
+      return 'messageHistoryInsights.issue.traceUnderused';
+    case 'ZERO_RESULT_QUERIES':
+      return 'messageHistoryInsights.issue.zeroResultQueries';
+    case 'BROAD_TOPIC_QUERIES':
+      return 'messageHistoryInsights.issue.broadTopicQueries';
+    case 'LARGE_RESULT_QUERIES':
+      return 'messageHistoryInsights.issue.largeResultQueries';
+    case 'TRACE_WITHOUT_NODES':
+      return 'messageHistoryInsights.issue.traceWithoutNodes';
+    case 'TRACE_WITHOUT_CONSUMERS':
+      return 'messageHistoryInsights.issue.traceWithoutConsumers';
+    case 'FRAGMENTED_TRACE_TOPICS':
+      return 'messageHistoryInsights.issue.fragmentedTraceTopics';
+    case 'UNKNOWN_OPERATORS':
+      return 'messageHistoryInsights.issue.unknownOperators';
+    default:
+      return 'messageHistoryInsights.issue.unknown';
+  }
+};
+
+const issueShortTextKey = (code: MessageHistoryInsightCode): string =>
+  `${issueTextKey(code)}.short`;
+
+const recommendationTextKey = (code: MessageHistoryRecommendationCode): string => {
+  switch (code) {
+    case 'NARROW_QUERY_FILTERS':
+      return 'messageHistoryInsights.recommendation.narrowQueryFilters';
+    case 'REPLAY_ZERO_RESULTS':
+      return 'messageHistoryInsights.recommendation.replayZeroResults';
+    case 'PAIR_TRACE_LOOKUPS':
+      return 'messageHistoryInsights.recommendation.pairTraceLookups';
+    case 'STANDARDIZE_TRACE_TOPIC':
+      return 'messageHistoryInsights.recommendation.standardizeTraceTopic';
+    case 'CHECK_TRACE_COLLECTION':
+      return 'messageHistoryInsights.recommendation.checkTraceCollection';
+    case 'ADD_OPERATOR_CONTEXT':
+      return 'messageHistoryInsights.recommendation.addOperatorContext';
+    case 'KEEP_RECENT_BASELINE':
+      return 'messageHistoryInsights.recommendation.keepRecentBaseline';
+    default:
+      return 'messageHistoryInsights.recommendation.review';
+  }
+};
+
+const formatNumber = (value: number): string =>
+  value.toLocaleString(undefined, { maximumFractionDigits: 0 });
+
+const formatPercent = (value: number | null | undefined): string =>
+  value == null ? '-' : `${value.toLocaleString(undefined, { maximumFractionDigits: 1 })}%`;
+
+const formatAge = (hours: number | null): string => {
+  if (hours == null) return '-';
+  if (hours < 1) return '< 1h';
+  if (hours < 24) return `${hours.toLocaleString(undefined, { maximumFractionDigits: 1 })}h`;
+  return `${(hours / 24).toLocaleString(undefined, { maximumFractionDigits: 1 })}d`;
+};
+
+const MessageHistoryInsightsPanel = ({ summary, messageRows, traceRows, loading, now }: Props) => {
+  const { t } = useLang();
+  const insights = buildMessageHistoryInsights(summary, messageRows, traceRows, now);
+  const meta = levelMeta[insights.level];
+  const visibleIssues = insights.issues.slice(0, 5);
+
+  if (!loading && !summary && messageRows.length === 0 && traceRows.length === 0) {
+    return null;
+  }
+
+  const renderIssue = (issue: MessageHistoryInsightIssue) => (
+    <Tag
+      key={`${issue.code}-${issue.topic ?? issue.traceTopic ?? issue.count ?? 'global'}`}
+      color={levelMeta[issue.level].color}
+    >
+      {t(issueTextKey(issue.code), {
+        count: formatNumber(issue.count ?? 0),
+        ratio: formatPercent(issue.ratio),
+        value: issue.value == null ? '-' : formatAge(issue.value),
+        topic: issue.topic ?? '-',
+        traceTopic: issue.traceTopic ?? '-',
+      })}
+    </Tag>
+  );
+
+  const notableColumns: ColumnsType<MessageHistoryNotableRow> = [
+    {
+      title: t('common.type'),
+      dataIndex: 'kind',
+      key: 'kind',
+      width: 100,
+      render: (kind: MessageHistoryNotableRow['kind']) => (
+        <Tag>{t(`messageHistoryInsights.kind.${kind}`)}</Tag>
+      ),
+    },
+    {
+      title: 'Topic',
+      dataIndex: 'topic',
+      key: 'topic',
+      ellipsis: true,
+      render: (topic: string) => <Text ellipsis={{ tooltip: topic }}>{topic}</Text>,
+    },
+    {
+      title: t('messageHistoryInsights.detail'),
+      dataIndex: 'detail',
+      key: 'detail',
+      ellipsis: true,
+      render: (detail: string, row) => (
+        <Space direction="vertical" size={0}>
+          <Text ellipsis={{ tooltip: detail }}>{detail}</Text>
+          {row.traceTopic && (
+            <Text type="secondary" ellipsis={{ tooltip: row.traceTopic }}>
+              {row.traceTopic}
+            </Text>
+          )}
+        </Space>
+      ),
+    },
+    {
+      title: t('messageHistoryInsights.signal'),
+      key: 'signal',
+      width: 180,
+      render: (_, row) => (
+        <Space size={[4, 4]} wrap>
+          {row.reasons.slice(0, 2).map((reason) => (
+            <Tag key={reason} color={levelMeta[row.level].color}>
+              {t(issueShortTextKey(reason), {
+                count: formatNumber(row.resultCount ?? row.nodeCount ?? row.consumerCount ?? 0),
+                ratio: '-',
+                value: '-',
+                topic: row.topic,
+                traceTopic: row.traceTopic ?? '-',
+              })}
+            </Tag>
+          ))}
+        </Space>
+      ),
+    },
+    {
+      title: t('messageHistory.operator'),
+      dataIndex: 'queriedBy',
+      key: 'queriedBy',
+      width: 110,
+    },
+    {
+      title: t('messageHistory.queryTime'),
+      dataIndex: 'queriedAt',
+      key: 'queriedAt',
+      width: 170,
+      render: (value?: string) => formatUtcDateTime(value),
+    },
+  ];
+
+  return (
+    <Card
+      size="small"
+      title={t('messageHistoryInsights.title')}
+      extra={<Tag color={meta.color}>{t(`messageHistoryInsights.level.${insights.level}`)}</Tag>}
+      loading={loading}
+      style={{ marginBottom: 16 }}
+    >
+      <Row gutter={[12, 12]} style={{ marginBottom: 12 }}>
+        <Col xs={12} md={6}>
+          <Statistic
+            title={t('messageHistoryInsights.score')}
+            value={insights.score}
+            suffix="/100"
+          />
+          <Progress percent={insights.score} size="small" status={meta.progress} showInfo={false} />
+        </Col>
+        <Col xs={12} md={6}>
+          <Statistic
+            title={t('messageHistoryInsights.messageShare')}
+            value={formatPercent(insights.stats.messageQueryRatio)}
+          />
+          <Text type="secondary">
+            {t('messageHistoryInsights.totalQueries', {
+              count: formatNumber(insights.stats.totalQueries),
+            })}
+          </Text>
+        </Col>
+        <Col xs={12} md={6}>
+          <Statistic
+            title={t('messageHistoryInsights.traceShare')}
+            value={formatPercent(insights.stats.traceQueryRatio)}
+          />
+          <Text type="secondary">
+            {t('messageHistoryInsights.traceRows', {
+              count: formatNumber(insights.stats.visibleTraceRows),
+            })}
+          </Text>
+        </Col>
+        <Col xs={12} md={6}>
+          <Statistic
+            title={t('messageHistoryInsights.latestAge')}
+            value={formatAge(insights.stats.latestQueryAgeHours)}
+          />
+          <Text type="secondary">
+            {t('messageHistoryInsights.messageRows', {
+              count: formatNumber(insights.stats.visibleMessageRows),
+            })}
+          </Text>
+        </Col>
+      </Row>
+
+      <Alert
+        showIcon
+        type={meta.alertType}
+        message={t('messageHistoryInsights.findings')}
+        description={
+          visibleIssues.length === 0 ? (
+            t('messageHistoryInsights.healthyMessage')
+          ) : (
+            <Space direction="vertical" size={8}>
+              <Space size={[6, 6]} wrap>
+                {visibleIssues.map(renderIssue)}
+              </Space>
+              <Space size={[6, 6]} wrap>
+                {insights.recommendations.map((code) => (
+                  <Tag key={code}>{t(recommendationTextKey(code))}</Tag>
+                ))}
+              </Space>
+            </Space>
+          )
+        }
+        style={{ marginBottom: 12 }}
+      />
+
+      {insights.notableRows.length === 0 ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description={t('messageHistoryInsights.noNotableRows')}
+        />
+      ) : (
+        <Table
+          size="small"
+          rowKey="key"
+          columns={notableColumns}
+          dataSource={insights.notableRows}
+          pagination={false}
+          scroll={{ x: tableScrollX(notableColumns) }}
+        />
+      )}
+    </Card>
+  );
+};
+
+export default MessageHistoryInsightsPanel;

--- a/web/src/components/MessageQueryHistoryDrawer.tsx
+++ b/web/src/components/MessageQueryHistoryDrawer.tsx
@@ -16,6 +16,7 @@ import {
   type TraceQueryHistory,
 } from '../api/messageHistory';
 import { useLang } from '../i18n/LangContext';
+import MessageHistoryInsightsPanel from './MessageHistoryInsightsPanel';
 
 interface Props {
   open: boolean;
@@ -180,6 +181,12 @@ const MessageQueryHistoryDrawer = ({
           style={{ marginBottom: 12 }}
         />
       )}
+      <MessageHistoryInsightsPanel
+        summary={summary}
+        messageRows={messageRows}
+        traceRows={traceRows}
+        loading={loading}
+      />
       <Tabs
         activeKey={tab}
         onChange={(key) => {

--- a/web/src/components/__tests__/MessageHistoryInsightsPanel.test.tsx
+++ b/web/src/components/__tests__/MessageHistoryInsightsPanel.test.tsx
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { App } from 'antd';
+import type { ComponentProps } from 'react';
+import type {
+  MessageQueryHistory,
+  QueryHistorySummary,
+  TraceQueryHistory,
+} from '../../api/messageHistory';
+import { LangProvider } from '../../i18n/LangContext';
+import { LANGUAGE_STORAGE_KEY } from '../../i18n/languagePreference';
+import MessageHistoryInsightsPanel from '../MessageHistoryInsightsPanel';
+
+const NOW = Date.UTC(2026, 8, 10, 10, 0, 0);
+
+const summary = (overrides: Partial<QueryHistorySummary> = {}): QueryHistorySummary => ({
+  messageQueries: 6,
+  traceQueries: 4,
+  latestQueryAt: new Date(NOW - 20 * 60_000).toISOString(),
+  ...overrides,
+});
+
+const messageRow = (overrides: Partial<MessageQueryHistory> = {}): MessageQueryHistory => ({
+  id: 1,
+  queryType: 'KEY',
+  topic: 'orders',
+  messageKey: 'order-1',
+  resultCount: 3,
+  queriedBy: 'alice',
+  queriedAt: new Date(NOW - 10 * 60_000).toISOString(),
+  ...overrides,
+});
+
+const traceRow = (overrides: Partial<TraceQueryHistory> = {}): TraceQueryHistory => ({
+  id: 11,
+  msgId: 'msg-1',
+  topic: 'orders',
+  traceTopic: 'RMQ_SYS_TRACE_TOPIC',
+  nodeCount: 4,
+  consumerCount: 2,
+  queriedBy: 'alice',
+  queriedAt: new Date(NOW - 5 * 60_000).toISOString(),
+  ...overrides,
+});
+
+const renderPanel = (props: Partial<ComponentProps<typeof MessageHistoryInsightsPanel>> = {}) => {
+  localStorage.setItem(LANGUAGE_STORAGE_KEY, 'en');
+  return render(
+    <App>
+      <LangProvider>
+        <MessageHistoryInsightsPanel
+          summary={summary()}
+          messageRows={[messageRow()]}
+          traceRows={[traceRow()]}
+          now={NOW}
+          {...props}
+        />
+      </LangProvider>
+    </App>,
+  );
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+describe('MessageHistoryInsightsPanel', () => {
+  it('shows a healthy score when the loaded history has no risky rows', () => {
+    renderPanel();
+
+    expect(screen.getByText('Query History Insights')).toBeInTheDocument();
+    expect(screen.getByText('Healthy')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Recent query history looks healthy, with no broad searches, zero-result lookups, or trace collection gaps detected.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('No notable query rows')).toBeInTheDocument();
+  });
+
+  it('surfaces broad, empty, and oversized message search signals', () => {
+    renderPanel({
+      summary: summary({ messageQueries: 20, traceQueries: 0 }),
+      messageRows: [
+        messageRow({
+          id: 2,
+          queryType: 'TOPIC',
+          topic: 'orders',
+          messageKey: '',
+          resultCount: 0,
+          startTime: NOW - 48 * 3_600_000,
+          endTime: NOW,
+        }),
+        messageRow({
+          id: 3,
+          queryType: 'TOPIC',
+          topic: 'audit',
+          messageKey: '',
+          resultCount: 2_500,
+          startTime: NOW - 72 * 3_600_000,
+          endTime: NOW,
+          queriedBy: '',
+        }),
+      ],
+      traceRows: [],
+    });
+
+    expect(screen.getByText('Critical')).toBeInTheDocument();
+    expect(screen.getByText('Zero-result message searches: 1')).toBeInTheDocument();
+    expect(screen.getByText('Broad topic searches: 2')).toBeInTheDocument();
+    expect(screen.getByText('Large-result message searches: 1')).toBeInTheDocument();
+    expect(
+      screen.getByText('Add Key, Message ID, Tag, or a shorter time range'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('audit')).toBeInTheDocument();
+    expect(screen.getByText('Large result')).toBeInTheDocument();
+  });
+
+  it('surfaces trace collection gaps and trace topic fragmentation', () => {
+    renderPanel({
+      summary: summary({ messageQueries: 2, traceQueries: 8 }),
+      messageRows: [],
+      traceRows: [
+        traceRow({
+          id: 4,
+          msgId: 'msg-a',
+          traceTopic: 'TRACE_A',
+          nodeCount: 0,
+          consumerCount: 0,
+        }),
+        traceRow({
+          id: 5,
+          msgId: 'msg-b',
+          traceTopic: 'TRACE_B',
+          nodeCount: 1,
+          consumerCount: 0,
+        }),
+      ],
+    });
+
+    expect(screen.getByText('Warning')).toBeInTheDocument();
+    expect(screen.getByText('Trace lookups without node data: 1')).toBeInTheDocument();
+    expect(screen.getByText('Trace lookups without consumer data: 2')).toBeInTheDocument();
+    expect(screen.getByText('Trace topics in use: 2')).toBeInTheDocument();
+    expect(
+      screen.getByText('Check trace collection and client reporting configuration'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('TRACE_A')).toBeInTheDocument();
+  });
+});

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -525,6 +525,127 @@ const translations: Record<string, Record<Lang, string>> = {
   'messageHistory.traceTopic': { zh: '轨迹 Topic', en: 'Trace Topic' },
   'messageHistory.traceNodes': { zh: '轨迹节点', en: 'Trace Nodes' },
   'messageHistory.consumers': { zh: '消费者', en: 'Consumers' },
+  'messageHistoryInsights.title': { zh: '查询历史洞察', en: 'Query History Insights' },
+  'messageHistoryInsights.score': { zh: '健康分', en: 'Health Score' },
+  'messageHistoryInsights.messageShare': { zh: '消息查询占比', en: 'Message Query Share' },
+  'messageHistoryInsights.traceShare': { zh: '轨迹查询占比', en: 'Trace Query Share' },
+  'messageHistoryInsights.latestAge': { zh: '最近查询距今', en: 'Latest Query Age' },
+  'messageHistoryInsights.totalQueries': { zh: '共 {count} 次查询', en: '{count} total queries' },
+  'messageHistoryInsights.messageRows': {
+    zh: '已加载 {count} 条消息记录',
+    en: '{count} loaded message rows',
+  },
+  'messageHistoryInsights.traceRows': {
+    zh: '已加载 {count} 条轨迹记录',
+    en: '{count} loaded trace rows',
+  },
+  'messageHistoryInsights.findings': { zh: '风险信号与建议', en: 'Signals and Recommendations' },
+  'messageHistoryInsights.healthyMessage': {
+    zh: '最近查询历史较健康，暂未发现宽泛查询、空结果或轨迹采集异常。',
+    en: 'Recent query history looks healthy, with no broad searches, zero-result lookups, or trace collection gaps detected.',
+  },
+  'messageHistoryInsights.noNotableRows': {
+    zh: '没有需要关注的查询记录',
+    en: 'No notable query rows',
+  },
+  'messageHistoryInsights.detail': { zh: '查询条件', en: 'Query Detail' },
+  'messageHistoryInsights.signal': { zh: '信号', en: 'Signal' },
+  'messageHistoryInsights.level.healthy': { zh: '健康', en: 'Healthy' },
+  'messageHistoryInsights.level.notice': { zh: '关注', en: 'Notice' },
+  'messageHistoryInsights.level.warning': { zh: '告警', en: 'Warning' },
+  'messageHistoryInsights.level.critical': { zh: '严重', en: 'Critical' },
+  'messageHistoryInsights.kind.message': { zh: '消息', en: 'Message' },
+  'messageHistoryInsights.kind.trace': { zh: '轨迹', en: 'Trace' },
+  'messageHistoryInsights.issue.noHistory': {
+    zh: '暂无查询历史基线',
+    en: 'No query history baseline',
+  },
+  'messageHistoryInsights.issue.noHistory.short': { zh: '无基线', en: 'No baseline' },
+  'messageHistoryInsights.issue.staleHistory': {
+    zh: '最近查询已超过 {value}',
+    en: 'Latest query is older than {value}',
+  },
+  'messageHistoryInsights.issue.staleHistory.short': { zh: '历史过旧', en: 'Stale' },
+  'messageHistoryInsights.issue.traceUnderused': {
+    zh: '轨迹查询占比仅 {ratio}',
+    en: 'Trace query share is only {ratio}',
+  },
+  'messageHistoryInsights.issue.traceUnderused.short': { zh: '轨迹偏少', en: 'Low trace use' },
+  'messageHistoryInsights.issue.zeroResultQueries': {
+    zh: '{count} 条消息查询没有结果',
+    en: 'Zero-result message searches: {count}',
+  },
+  'messageHistoryInsights.issue.zeroResultQueries.short': { zh: '空结果', en: 'Zero result' },
+  'messageHistoryInsights.issue.broadTopicQueries': {
+    zh: '{count} 条 Topic 查询范围过宽',
+    en: 'Broad topic searches: {count}',
+  },
+  'messageHistoryInsights.issue.broadTopicQueries.short': { zh: '范围过宽', en: 'Broad filter' },
+  'messageHistoryInsights.issue.largeResultQueries': {
+    zh: '{count} 条消息查询结果过大',
+    en: 'Large-result message searches: {count}',
+  },
+  'messageHistoryInsights.issue.largeResultQueries.short': { zh: '结果过大', en: 'Large result' },
+  'messageHistoryInsights.issue.traceWithoutNodes': {
+    zh: '{count} 条轨迹没有节点数据',
+    en: 'Trace lookups without node data: {count}',
+  },
+  'messageHistoryInsights.issue.traceWithoutNodes.short': { zh: '无节点', en: 'No nodes' },
+  'messageHistoryInsights.issue.traceWithoutConsumers': {
+    zh: '{count} 条轨迹没有消费者数据',
+    en: 'Trace lookups without consumer data: {count}',
+  },
+  'messageHistoryInsights.issue.traceWithoutConsumers.short': {
+    zh: '无消费者',
+    en: 'No consumers',
+  },
+  'messageHistoryInsights.issue.fragmentedTraceTopics': {
+    zh: '检测到 {count} 个不同轨迹 Topic',
+    en: 'Trace topics in use: {count}',
+  },
+  'messageHistoryInsights.issue.fragmentedTraceTopics.short': {
+    zh: '轨迹 Topic 分散',
+    en: 'Split trace topics',
+  },
+  'messageHistoryInsights.issue.unknownOperators': {
+    zh: '{count} 条查询缺少操作者',
+    en: 'Queries missing operator context: {count}',
+  },
+  'messageHistoryInsights.issue.unknownOperators.short': { zh: '无操作者', en: 'No operator' },
+  'messageHistoryInsights.issue.unknown': { zh: '未知风险', en: 'Unknown signal' },
+  'messageHistoryInsights.issue.unknown.short': { zh: '未知', en: 'Unknown' },
+  'messageHistoryInsights.recommendation.narrowQueryFilters': {
+    zh: '增加 Key、Message ID、Tag 或更短时间范围',
+    en: 'Add Key, Message ID, Tag, or a shorter time range',
+  },
+  'messageHistoryInsights.recommendation.replayZeroResults': {
+    zh: '复核空结果查询的 Topic、时间范围和实例',
+    en: 'Review the topic, time range, and instance used by zero-result searches',
+  },
+  'messageHistoryInsights.recommendation.pairTraceLookups': {
+    zh: '对关键消息查询补充轨迹查询',
+    en: 'Pair important message searches with trace lookups',
+  },
+  'messageHistoryInsights.recommendation.standardizeTraceTopic': {
+    zh: '统一常用轨迹 Topic，降低排查分叉',
+    en: 'Standardize common trace topics to reduce troubleshooting branches',
+  },
+  'messageHistoryInsights.recommendation.checkTraceCollection': {
+    zh: '检查轨迹采集链路和客户端上报配置',
+    en: 'Check trace collection and client reporting configuration',
+  },
+  'messageHistoryInsights.recommendation.addOperatorContext': {
+    zh: '补齐查询操作者，便于审计和复盘',
+    en: 'Keep operator context for audit and follow-up',
+  },
+  'messageHistoryInsights.recommendation.keepRecentBaseline': {
+    zh: '保留近期查询基线，便于对比排障质量',
+    en: 'Keep a recent query baseline for troubleshooting quality comparison',
+  },
+  'messageHistoryInsights.recommendation.review': {
+    zh: '复核查询历史',
+    en: 'Review query history',
+  },
 
   // ─── Dead Letter Queue ───
   'dlq.title': { zh: '死信队列', en: 'Dead Letter Queue' },

--- a/web/src/utils/messageHistoryInsights.test.ts
+++ b/web/src/utils/messageHistoryInsights.test.ts
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type {
+  MessageQueryHistory,
+  QueryHistorySummary,
+  TraceQueryHistory,
+} from '../api/messageHistory';
+import {
+  buildMessageHistoryInsights,
+  messageHistoryInsightLevelRank,
+} from './messageHistoryInsights';
+
+const NOW = Date.UTC(2026, 8, 10, 10, 0, 0);
+
+const summary = (overrides: Partial<QueryHistorySummary> = {}): QueryHistorySummary => ({
+  messageQueries: 20,
+  traceQueries: 2,
+  latestQueryAt: new Date(NOW - 30 * 60_000).toISOString(),
+  ...overrides,
+});
+
+const messageRow = (overrides: Partial<MessageQueryHistory> = {}): MessageQueryHistory => ({
+  id: 1,
+  queryType: 'KEY',
+  topic: 'orders',
+  messageKey: 'order-1',
+  resultCount: 3,
+  queriedBy: 'alice',
+  queriedAt: new Date(NOW - 10 * 60_000).toISOString(),
+  ...overrides,
+});
+
+const traceRow = (overrides: Partial<TraceQueryHistory> = {}): TraceQueryHistory => ({
+  id: 11,
+  msgId: 'msg-1',
+  topic: 'orders',
+  traceTopic: 'RMQ_SYS_TRACE_TOPIC',
+  nodeCount: 4,
+  consumerCount: 2,
+  queriedBy: 'alice',
+  queriedAt: new Date(NOW - 5 * 60_000).toISOString(),
+  ...overrides,
+});
+
+describe('message history insights', () => {
+  it('returns a healthy result for recent balanced history rows', () => {
+    const insights = buildMessageHistoryInsights(
+      summary({ messageQueries: 6, traceQueries: 4 }),
+      [messageRow()],
+      [traceRow()],
+      NOW,
+    );
+
+    expect(insights.level).toBe('healthy');
+    expect(insights.score).toBe(100);
+    expect(insights.stats.totalQueries).toBe(10);
+    expect(insights.stats.messageQueryRatio).toBe(60);
+    expect(insights.stats.traceQueryRatio).toBe(40);
+    expect(insights.issues).toEqual([]);
+    expect(insights.recommendations).toEqual([]);
+    expect(insights.notableRows).toEqual([]);
+  });
+
+  it('flags zero-result, broad, and large message searches', () => {
+    const insights = buildMessageHistoryInsights(
+      summary({ messageQueries: 30, traceQueries: 0 }),
+      [
+        messageRow({
+          id: 2,
+          queryType: 'TOPIC',
+          topic: 'orders',
+          tag: '',
+          messageKey: '',
+          resultCount: 0,
+          startTime: NOW - 48 * 3_600_000,
+          endTime: NOW,
+        }),
+        messageRow({
+          id: 3,
+          queryType: 'TOPIC',
+          topic: 'audit',
+          messageKey: '',
+          resultCount: 2_500,
+          startTime: NOW - 72 * 3_600_000,
+          endTime: NOW,
+          queriedBy: '',
+        }),
+      ],
+      [],
+      NOW,
+    );
+
+    expect(insights.level).toBe('critical');
+    expect(insights.score).toBeLessThan(70);
+    expect(insights.stats.zeroResultQueries).toBe(1);
+    expect(insights.stats.broadTopicQueries).toBe(2);
+    expect(insights.stats.largeResultQueries).toBe(1);
+    expect(insights.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining([
+        'ZERO_RESULT_QUERIES',
+        'BROAD_TOPIC_QUERIES',
+        'LARGE_RESULT_QUERIES',
+        'TRACE_UNDERUSED',
+        'UNKNOWN_OPERATORS',
+      ]),
+    );
+    expect(insights.recommendations).toEqual(
+      expect.arrayContaining(['NARROW_QUERY_FILTERS', 'REPLAY_ZERO_RESULTS']),
+    );
+    expect(insights.notableRows[0]).toEqual(
+      expect.objectContaining({
+        kind: 'message',
+        level: 'critical',
+        topic: 'audit',
+        resultCount: 2500,
+      }),
+    );
+  });
+
+  it('flags trace rows without nodes, consumers, or a common trace topic', () => {
+    const insights = buildMessageHistoryInsights(
+      summary({ messageQueries: 5, traceQueries: 5 }),
+      [],
+      [
+        traceRow({
+          id: 4,
+          msgId: 'msg-a',
+          traceTopic: 'TRACE_A',
+          nodeCount: 0,
+          consumerCount: 0,
+        }),
+        traceRow({
+          id: 5,
+          msgId: 'msg-b',
+          traceTopic: 'TRACE_B',
+          nodeCount: 1,
+          consumerCount: 0,
+          queriedBy: '',
+        }),
+      ],
+      NOW,
+    );
+
+    expect(insights.level).toBe('warning');
+    expect(insights.stats.traceRowsWithoutNodes).toBe(1);
+    expect(insights.stats.traceRowsWithoutConsumers).toBe(2);
+    expect(insights.stats.customTraceTopicCount).toBe(2);
+    expect(insights.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining([
+        'TRACE_WITHOUT_NODES',
+        'TRACE_WITHOUT_CONSUMERS',
+        'FRAGMENTED_TRACE_TOPICS',
+        'UNKNOWN_OPERATORS',
+      ]),
+    );
+    expect(insights.recommendations).toEqual(
+      expect.arrayContaining(['CHECK_TRACE_COLLECTION', 'STANDARDIZE_TRACE_TOPIC']),
+    );
+  });
+
+  it('reports stale or empty query history from the summary', () => {
+    const stale = buildMessageHistoryInsights(
+      summary({
+        messageQueries: 1,
+        traceQueries: 0,
+        latestQueryAt: new Date(NOW - 96 * 3_600_000).toISOString(),
+      }),
+      [],
+      [],
+      NOW,
+    );
+    const empty = buildMessageHistoryInsights(
+      summary({ messageQueries: 0, traceQueries: 0, latestQueryAt: undefined }),
+      [],
+      [],
+      NOW,
+    );
+
+    expect(stale.stats.latestQueryAgeHours).toBe(96);
+    expect(stale.issues.map((issue) => issue.code)).toContain('STALE_HISTORY');
+    expect(empty.stats.totalQueries).toBe(0);
+    expect(empty.issues.map((issue) => issue.code)).toContain('NO_HISTORY');
+    expect(empty.recommendations).toContain('KEEP_RECENT_BASELINE');
+  });
+
+  it('normalizes invalid counters and exposes stable severity ranking', () => {
+    const insights = buildMessageHistoryInsights(
+      summary({
+        messageQueries: Number.NaN,
+        traceQueries: -1,
+        latestQueryAt: 'not-a-date',
+      }),
+      [messageRow({ resultCount: Number.NaN })],
+      [traceRow({ nodeCount: -1, consumerCount: Number.NaN })],
+      NOW,
+    );
+
+    expect(insights.stats.totalQueries).toBe(0);
+    expect(insights.stats.latestQueryAgeHours).toBeNull();
+    expect(insights.stats.zeroResultQueries).toBe(1);
+    expect(insights.stats.traceRowsWithoutNodes).toBe(1);
+    expect(messageHistoryInsightLevelRank('healthy')).toBeLessThan(
+      messageHistoryInsightLevelRank('warning'),
+    );
+    expect(messageHistoryInsightLevelRank('critical')).toBeGreaterThan(
+      messageHistoryInsightLevelRank('notice'),
+    );
+  });
+});

--- a/web/src/utils/messageHistoryInsights.ts
+++ b/web/src/utils/messageHistoryInsights.ts
@@ -1,0 +1,470 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  MessageQueryHistory,
+  QueryHistorySummary,
+  TraceQueryHistory,
+} from '../api/messageHistory';
+
+export type MessageHistoryInsightLevel = 'healthy' | 'notice' | 'warning' | 'critical';
+
+export type MessageHistoryInsightCode =
+  | 'NO_HISTORY'
+  | 'STALE_HISTORY'
+  | 'TRACE_UNDERUSED'
+  | 'ZERO_RESULT_QUERIES'
+  | 'BROAD_TOPIC_QUERIES'
+  | 'LARGE_RESULT_QUERIES'
+  | 'TRACE_WITHOUT_NODES'
+  | 'TRACE_WITHOUT_CONSUMERS'
+  | 'FRAGMENTED_TRACE_TOPICS'
+  | 'UNKNOWN_OPERATORS';
+
+export type MessageHistoryRecommendationCode =
+  | 'NARROW_QUERY_FILTERS'
+  | 'REPLAY_ZERO_RESULTS'
+  | 'PAIR_TRACE_LOOKUPS'
+  | 'STANDARDIZE_TRACE_TOPIC'
+  | 'CHECK_TRACE_COLLECTION'
+  | 'ADD_OPERATOR_CONTEXT'
+  | 'KEEP_RECENT_BASELINE';
+
+export interface MessageHistoryInsightIssue {
+  code: MessageHistoryInsightCode;
+  level: MessageHistoryInsightLevel;
+  count?: number;
+  ratio?: number;
+  value?: number;
+  queryType?: MessageQueryHistory['queryType'];
+  topic?: string;
+  traceTopic?: string;
+  operator?: string;
+}
+
+export interface MessageHistoryNotableRow {
+  key: string;
+  kind: 'message' | 'trace';
+  level: MessageHistoryInsightLevel;
+  reasons: MessageHistoryInsightCode[];
+  topic: string;
+  detail: string;
+  queriedBy: string;
+  queriedAt: string;
+  resultCount?: number;
+  nodeCount?: number;
+  consumerCount?: number;
+  traceTopic?: string;
+}
+
+export interface MessageHistoryInsightStats {
+  totalQueries: number;
+  messageQueries: number;
+  traceQueries: number;
+  messageQueryRatio: number | null;
+  traceQueryRatio: number | null;
+  latestQueryAgeHours: number | null;
+  visibleMessageRows: number;
+  visibleTraceRows: number;
+  zeroResultQueries: number;
+  broadTopicQueries: number;
+  largeResultQueries: number;
+  traceRowsWithoutNodes: number;
+  traceRowsWithoutConsumers: number;
+  customTraceTopicCount: number;
+  unknownOperators: number;
+}
+
+export interface MessageHistoryInsights {
+  level: MessageHistoryInsightLevel;
+  score: number;
+  stats: MessageHistoryInsightStats;
+  issues: MessageHistoryInsightIssue[];
+  recommendations: MessageHistoryRecommendationCode[];
+  notableRows: MessageHistoryNotableRow[];
+}
+
+const BROAD_QUERY_WINDOW_HOURS = 24;
+const STALE_HISTORY_HOURS = 72;
+const TRACE_UNDERUSED_MIN_TOTAL = 10;
+const TRACE_UNDERUSED_RATIO = 10;
+const LARGE_RESULT_WARNING = 500;
+const LARGE_RESULT_CRITICAL = 2_000;
+const MAX_NOTABLE_ROWS = 8;
+
+const levelWeight: Record<MessageHistoryInsightLevel, number> = {
+  healthy: 0,
+  notice: 1,
+  warning: 2,
+  critical: 3,
+};
+
+const issuePenalty: Record<MessageHistoryInsightCode, number> = {
+  NO_HISTORY: 12,
+  STALE_HISTORY: 8,
+  TRACE_UNDERUSED: 10,
+  ZERO_RESULT_QUERIES: 12,
+  BROAD_TOPIC_QUERIES: 12,
+  LARGE_RESULT_QUERIES: 16,
+  TRACE_WITHOUT_NODES: 18,
+  TRACE_WITHOUT_CONSUMERS: 10,
+  FRAGMENTED_TRACE_TOPICS: 8,
+  UNKNOWN_OPERATORS: 6,
+};
+
+const addUnique = <T>(items: T[], item: T) => {
+  if (!items.includes(item)) items.push(item);
+};
+
+const normalizeText = (value: string | undefined | null, fallback = '-'): string => {
+  const trimmed = value?.trim();
+  return trimmed || fallback;
+};
+
+const normalizeCount = (value: number | undefined | null): number => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.max(0, parsed);
+};
+
+const parseTimestamp = (value: string | number | undefined | null): number | null => {
+  if (value == null || value === '') return null;
+  const timestamp = typeof value === 'number' ? value : Date.parse(value);
+  return Number.isFinite(timestamp) && timestamp > 0 ? timestamp : null;
+};
+
+const roundedPercent = (value: number): number => Math.round(value * 10) / 10;
+
+const percent = (part: number, total: number): number | null => {
+  if (total <= 0) return null;
+  return roundedPercent((part / total) * 100);
+};
+
+const maxLevel = (levels: MessageHistoryInsightLevel[]): MessageHistoryInsightLevel =>
+  levels.reduce<MessageHistoryInsightLevel>(
+    (current, next) => (levelWeight[next] > levelWeight[current] ? next : current),
+    'healthy',
+  );
+
+const issueLevel = (code: MessageHistoryInsightCode): MessageHistoryInsightLevel => {
+  switch (code) {
+    case 'LARGE_RESULT_QUERIES':
+    case 'TRACE_WITHOUT_NODES':
+      return 'warning';
+    case 'ZERO_RESULT_QUERIES':
+    case 'BROAD_TOPIC_QUERIES':
+    case 'TRACE_UNDERUSED':
+    case 'TRACE_WITHOUT_CONSUMERS':
+    case 'FRAGMENTED_TRACE_TOPICS':
+      return 'notice';
+    case 'NO_HISTORY':
+    case 'STALE_HISTORY':
+    case 'UNKNOWN_OPERATORS':
+      return 'notice';
+    default:
+      return 'notice';
+  }
+};
+
+const scoreForIssues = (issues: MessageHistoryInsightIssue[]): number => {
+  const penalty = issues.reduce(
+    (sum, issue) => sum + issuePenalty[issue.code] * Math.max(1, Math.min(issue.count ?? 1, 5)),
+    0,
+  );
+  return Math.max(0, Math.min(100, 100 - penalty));
+};
+
+const queryWindowHours = (row: MessageQueryHistory): number | null => {
+  const start = parseTimestamp(row.startTime);
+  const end = parseTimestamp(row.endTime);
+  if (start == null || end == null || end <= start) return null;
+  return roundedPercent((end - start) / 3_600_000);
+};
+
+const isBroadTopicQuery = (row: MessageQueryHistory): boolean => {
+  if (row.queryType !== 'TOPIC') return false;
+  const hasNarrowField = Boolean(row.tag?.trim() || row.messageKey?.trim() || row.msgId?.trim());
+  if (hasNarrowField) return false;
+  const hours = queryWindowHours(row);
+  return hours == null || hours >= BROAD_QUERY_WINDOW_HOURS;
+};
+
+const messageRowReasons = (row: MessageQueryHistory): MessageHistoryInsightCode[] => {
+  const reasons: MessageHistoryInsightCode[] = [];
+  const resultCount = normalizeCount(row.resultCount);
+
+  if (resultCount === 0) reasons.push('ZERO_RESULT_QUERIES');
+  if (isBroadTopicQuery(row)) reasons.push('BROAD_TOPIC_QUERIES');
+  if (resultCount >= LARGE_RESULT_WARNING) reasons.push('LARGE_RESULT_QUERIES');
+  if (!row.queriedBy?.trim()) reasons.push('UNKNOWN_OPERATORS');
+
+  return reasons;
+};
+
+const traceRowReasons = (row: TraceQueryHistory): MessageHistoryInsightCode[] => {
+  const reasons: MessageHistoryInsightCode[] = [];
+  if (normalizeCount(row.nodeCount) === 0) reasons.push('TRACE_WITHOUT_NODES');
+  if (normalizeCount(row.consumerCount) === 0) reasons.push('TRACE_WITHOUT_CONSUMERS');
+  if (!row.queriedBy?.trim()) reasons.push('UNKNOWN_OPERATORS');
+  return reasons;
+};
+
+const messageDetail = (row: MessageQueryHistory): string => {
+  if (row.msgId?.trim()) return row.msgId.trim();
+  if (row.messageKey?.trim()) return row.messageKey.trim();
+  if (row.tag?.trim()) return row.tag.trim();
+  const hours = queryWindowHours(row);
+  return hours == null ? row.queryType : `${row.queryType} / ${hours}h`;
+};
+
+const toMessageNotableRow = (
+  row: MessageQueryHistory,
+  reasons: MessageHistoryInsightCode[],
+): MessageHistoryNotableRow => ({
+  key: `message-${row.id}`,
+  kind: 'message',
+  level:
+    normalizeCount(row.resultCount) >= LARGE_RESULT_CRITICAL
+      ? 'critical'
+      : maxLevel(reasons.map(issueLevel)),
+  reasons,
+  topic: normalizeText(row.topic),
+  detail: messageDetail(row),
+  queriedBy: normalizeText(row.queriedBy),
+  queriedAt: normalizeText(row.queriedAt),
+  resultCount: normalizeCount(row.resultCount),
+});
+
+const toTraceNotableRow = (
+  row: TraceQueryHistory,
+  reasons: MessageHistoryInsightCode[],
+): MessageHistoryNotableRow => ({
+  key: `trace-${row.id}`,
+  kind: 'trace',
+  level: maxLevel(reasons.map(issueLevel)),
+  reasons,
+  topic: normalizeText(row.topic),
+  detail: normalizeText(row.msgId),
+  queriedBy: normalizeText(row.queriedBy),
+  queriedAt: normalizeText(row.queriedAt),
+  nodeCount: normalizeCount(row.nodeCount),
+  consumerCount: normalizeCount(row.consumerCount),
+  traceTopic: normalizeText(row.traceTopic, 'default'),
+});
+
+const compareNotableRows = (left: MessageHistoryNotableRow, right: MessageHistoryNotableRow) =>
+  levelWeight[right.level] - levelWeight[left.level] ||
+  (right.resultCount ?? right.nodeCount ?? 0) - (left.resultCount ?? left.nodeCount ?? 0) ||
+  left.topic.localeCompare(right.topic) ||
+  left.detail.localeCompare(right.detail);
+
+const pushIssue = (
+  issues: MessageHistoryInsightIssue[],
+  code: MessageHistoryInsightCode,
+  count: number,
+  details: Partial<MessageHistoryInsightIssue> = {},
+) => {
+  if (count <= 0) return;
+  issues.push({
+    code,
+    level: details.level ?? issueLevel(code),
+    count,
+    ...details,
+  });
+};
+
+const recommendationsForIssues = (
+  issues: MessageHistoryInsightIssue[],
+): MessageHistoryRecommendationCode[] => {
+  const recommendations: MessageHistoryRecommendationCode[] = [];
+  for (const issue of issues) {
+    switch (issue.code) {
+      case 'NO_HISTORY':
+      case 'STALE_HISTORY':
+        addUnique(recommendations, 'KEEP_RECENT_BASELINE');
+        break;
+      case 'TRACE_UNDERUSED':
+        addUnique(recommendations, 'PAIR_TRACE_LOOKUPS');
+        break;
+      case 'ZERO_RESULT_QUERIES':
+        addUnique(recommendations, 'REPLAY_ZERO_RESULTS');
+        break;
+      case 'BROAD_TOPIC_QUERIES':
+      case 'LARGE_RESULT_QUERIES':
+        addUnique(recommendations, 'NARROW_QUERY_FILTERS');
+        break;
+      case 'TRACE_WITHOUT_NODES':
+      case 'TRACE_WITHOUT_CONSUMERS':
+        addUnique(recommendations, 'CHECK_TRACE_COLLECTION');
+        break;
+      case 'FRAGMENTED_TRACE_TOPICS':
+        addUnique(recommendations, 'STANDARDIZE_TRACE_TOPIC');
+        break;
+      case 'UNKNOWN_OPERATORS':
+        addUnique(recommendations, 'ADD_OPERATOR_CONTEXT');
+        break;
+      default:
+        break;
+    }
+  }
+  return recommendations.slice(0, 6);
+};
+
+export function buildMessageHistoryInsights(
+  summary: QueryHistorySummary | undefined,
+  messageRows: MessageQueryHistory[] | null | undefined,
+  traceRows: TraceQueryHistory[] | null | undefined,
+  now = Date.now(),
+): MessageHistoryInsights {
+  const messages = messageRows ?? [];
+  const traces = traceRows ?? [];
+  const messageQueries = normalizeCount(summary?.messageQueries);
+  const traceQueries = normalizeCount(summary?.traceQueries);
+  const totalQueries = messageQueries + traceQueries;
+  const latestQueryAt = parseTimestamp(summary?.latestQueryAt);
+  const latestQueryAgeHours =
+    latestQueryAt == null ? null : Math.max(0, roundedPercent((now - latestQueryAt) / 3_600_000));
+
+  const messageNotables = messages
+    .map((row) => {
+      const reasons = messageRowReasons(row);
+      return reasons.length > 0 ? toMessageNotableRow(row, reasons) : null;
+    })
+    .filter((row): row is MessageHistoryNotableRow => row != null);
+  const traceNotables = traces
+    .map((row) => {
+      const reasons = traceRowReasons(row);
+      return reasons.length > 0 ? toTraceNotableRow(row, reasons) : null;
+    })
+    .filter((row): row is MessageHistoryNotableRow => row != null);
+
+  const zeroResultQueries = messageNotables.filter((row) =>
+    row.reasons.includes('ZERO_RESULT_QUERIES'),
+  ).length;
+  const broadTopicQueries = messageNotables.filter((row) =>
+    row.reasons.includes('BROAD_TOPIC_QUERIES'),
+  ).length;
+  const largeResultQueries = messageNotables.filter((row) =>
+    row.reasons.includes('LARGE_RESULT_QUERIES'),
+  ).length;
+  const traceRowsWithoutNodes = traceNotables.filter((row) =>
+    row.reasons.includes('TRACE_WITHOUT_NODES'),
+  ).length;
+  const traceRowsWithoutConsumers = traceNotables.filter((row) =>
+    row.reasons.includes('TRACE_WITHOUT_CONSUMERS'),
+  ).length;
+  const unknownOperators = [...messageNotables, ...traceNotables].filter((row) =>
+    row.reasons.includes('UNKNOWN_OPERATORS'),
+  ).length;
+  const customTraceTopics = [
+    ...new Set(
+      traces
+        .map((row) => row.traceTopic?.trim())
+        .filter((traceTopic): traceTopic is string => Boolean(traceTopic)),
+    ),
+  ].sort();
+
+  const issues: MessageHistoryInsightIssue[] = [];
+  if (totalQueries === 0) {
+    pushIssue(issues, 'NO_HISTORY', 1);
+  }
+  if (
+    totalQueries > 0 &&
+    latestQueryAgeHours != null &&
+    latestQueryAgeHours >= STALE_HISTORY_HOURS
+  ) {
+    pushIssue(issues, 'STALE_HISTORY', 1, { value: latestQueryAgeHours });
+  }
+  const traceRatio = percent(traceQueries, totalQueries);
+  if (
+    totalQueries >= TRACE_UNDERUSED_MIN_TOTAL &&
+    traceRatio != null &&
+    traceRatio < TRACE_UNDERUSED_RATIO
+  ) {
+    pushIssue(issues, 'TRACE_UNDERUSED', 1, { ratio: traceRatio });
+  }
+  pushIssue(issues, 'ZERO_RESULT_QUERIES', zeroResultQueries, {
+    ratio: percent(zeroResultQueries, Math.max(messages.length, 1)) ?? undefined,
+    topic: messageNotables.find((row) => row.reasons.includes('ZERO_RESULT_QUERIES'))?.topic,
+  });
+  pushIssue(issues, 'BROAD_TOPIC_QUERIES', broadTopicQueries, {
+    topic: messageNotables.find((row) => row.reasons.includes('BROAD_TOPIC_QUERIES'))?.topic,
+  });
+  pushIssue(issues, 'LARGE_RESULT_QUERIES', largeResultQueries, {
+    level: messageNotables.some(
+      (row) =>
+        row.reasons.includes('LARGE_RESULT_QUERIES') &&
+        (row.resultCount ?? 0) >= LARGE_RESULT_CRITICAL,
+    )
+      ? 'critical'
+      : 'warning',
+    topic: messageNotables.find((row) => row.reasons.includes('LARGE_RESULT_QUERIES'))?.topic,
+  });
+  pushIssue(issues, 'TRACE_WITHOUT_NODES', traceRowsWithoutNodes, {
+    topic: traceNotables.find((row) => row.reasons.includes('TRACE_WITHOUT_NODES'))?.topic,
+  });
+  pushIssue(issues, 'TRACE_WITHOUT_CONSUMERS', traceRowsWithoutConsumers, {
+    topic: traceNotables.find((row) => row.reasons.includes('TRACE_WITHOUT_CONSUMERS'))?.topic,
+  });
+  if (customTraceTopics.length > 1) {
+    pushIssue(issues, 'FRAGMENTED_TRACE_TOPICS', customTraceTopics.length, {
+      traceTopic: customTraceTopics[0],
+    });
+  }
+  pushIssue(issues, 'UNKNOWN_OPERATORS', unknownOperators, {
+    operator: '-',
+  });
+
+  const sortedIssues = issues.sort(
+    (left, right) =>
+      levelWeight[right.level] - levelWeight[left.level] ||
+      (right.count ?? 0) - (left.count ?? 0) ||
+      left.code.localeCompare(right.code),
+  );
+  const score = scoreForIssues(sortedIssues);
+
+  return {
+    level: maxLevel(sortedIssues.map((issue) => issue.level)),
+    score,
+    stats: {
+      totalQueries,
+      messageQueries,
+      traceQueries,
+      messageQueryRatio: percent(messageQueries, totalQueries),
+      traceQueryRatio: traceRatio,
+      latestQueryAgeHours,
+      visibleMessageRows: messages.length,
+      visibleTraceRows: traces.length,
+      zeroResultQueries,
+      broadTopicQueries,
+      largeResultQueries,
+      traceRowsWithoutNodes,
+      traceRowsWithoutConsumers,
+      customTraceTopicCount: customTraceTopics.length,
+      unknownOperators,
+    },
+    issues: sortedIssues,
+    recommendations: recommendationsForIssues(sortedIssues),
+    notableRows: [...messageNotables, ...traceNotables]
+      .sort(compareNotableRows)
+      .slice(0, MAX_NOTABLE_ROWS),
+  };
+}
+
+export function messageHistoryInsightLevelRank(level: MessageHistoryInsightLevel): number {
+  return levelWeight[level];
+}


### PR DESCRIPTION
## What is the purpose of the change

Add a query history insights panel to the Message Query History drawer. The panel summarizes existing message and trace query history data into a health score, risk signals, notable rows, and recommendations so operators can quickly identify broad topic searches, zero-result queries, large result sets, trace collection gaps, fragmented trace topics, stale history, and missing operator context.

## Brief changelog

- Added message query history insight aggregation logic with unit tests.
- Added a MessageHistoryInsightsPanel to the query history drawer.
- Added localized insight labels and recommendations.
- Reused the existing UTC time formatter for queriedAt display.

## Verifying this change

- `npx prettier --write src/utils/messageHistoryInsights.ts src/utils/messageHistoryInsights.test.ts src/components/MessageHistoryInsightsPanel.tsx src/components/__tests__/MessageHistoryInsightsPanel.test.tsx src/components/MessageQueryHistoryDrawer.tsx src/i18n/translations.ts`
- `npm test -- src/utils/messageHistoryInsights.test.ts src/components/__tests__/MessageHistoryInsightsPanel.test.tsx src/components/__tests__/MessageQueryHistoryDrawer.test.tsx`
- `npx eslint src/utils/messageHistoryInsights.ts src/utils/messageHistoryInsights.test.ts src/components/MessageHistoryInsightsPanel.tsx src/components/__tests__/MessageHistoryInsightsPanel.test.tsx src/components/MessageQueryHistoryDrawer.tsx src/components/__tests__/MessageQueryHistoryDrawer.test.tsx src/i18n/translations.ts`
- `npm run build`
- `git diff --check`