### PR TITLE
fix(alert): acknowledge the alert state when a reminder event is acknowledged

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -570,8 +570,12 @@ public class AlertService {
         if (!alertRepository.acknowledgeAlert(alert)) {
             throw new BusinessException(404, "System alert not found: " + id);
         }
-        if ("FIRING".equalsIgnoreCase(alert.getTransition())
-                && alert.getRuleId() != null && hasText(alert.getFingerprint()) && alert.getTime() != null) {
+        // FIRING and REMINDER events belong to the same firing episode, so acknowledging
+        // either must ACK the active state; the repository only honors events whose time
+        // is not older than the current episode, which keeps stale events inert.
+        String transition = alert.getTransition();
+        if (alert.getRuleId() != null && hasText(alert.getFingerprint()) && alert.getTime() != null
+                && ("FIRING".equalsIgnoreCase(transition) || "REMINDER".equalsIgnoreCase(transition))) {
             alertStateRepository.acknowledge(new AlertStateKey(alert.getRuleId(), alert.getFingerprint()),
                     alert.getTime().toInstant(ZoneOffset.UTC));
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/mapper/RmqAlertStateMapper.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/mapper/RmqAlertStateMapper.java
@@ -33,7 +33,7 @@ public interface RmqAlertStateMapper extends BaseMapper<RmqAlertState> {
 
     @Update("UPDATE rmq_alert_state SET status = 'ACKED', gmt_modified = #{now}, version = version + 1 "
             + "WHERE rule_id = #{ruleId} AND fingerprint = #{fingerprint} AND status = 'FIRING' "
-            + "AND fired_at = #{firedAt}")
+            + "AND fired_at <= #{firedAt}")
     int acknowledgeFiring(@Param("ruleId") Long ruleId, @Param("fingerprint") String fingerprint,
             @Param("firedAt") LocalDateTime firedAt,
             @Param("now") LocalDateTime now);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -1234,6 +1234,20 @@ class AlertServiceTest {
     }
 
     @Test
+    void acknowledgingReminderEventShouldAcknowledgeItsActiveRuleStateTest() {
+        SystemAlertVO alert = SystemAlertVO.builder().id(1L).ruleId(7L).fingerprint("fingerprint")
+                .time(LocalDateTime.of(2026, 8, 22, 12, 30))
+                .transition("REMINDER").acknowledged(false).build();
+        when(alertRepository.findAlertById(1L)).thenReturn(Optional.of(alert));
+        when(alertRepository.acknowledgeAlert(any(SystemAlertVO.class))).thenReturn(true);
+
+        alertService.acknowledgeAlert(1L);
+
+        verify(alertStateRepository).acknowledge(new AlertStateKey(7L, "fingerprint"),
+                LocalDateTime.of(2026, 8, 22, 12, 30).toInstant(ZoneOffset.UTC));
+    }
+
+    @Test
     void acknowledgingResolvedEventMustNotAcknowledgeANewerFiringStateTest() {
         SystemAlertVO resolved = SystemAlertVO.builder().id(1L).ruleId(7L).fingerprint("fingerprint")
                 .transition("RESOLVED").acknowledged(false).build();

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/RmqAlertStateMapperIntegrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/RmqAlertStateMapperIntegrationTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import org.apache.rocketmq.studio.persistence.entity.RmqAlertState;
+import org.apache.rocketmq.studio.persistence.mapper.RmqAlertStateMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {"studio.auth.login-required=false"})
+class RmqAlertStateMapperIntegrationTest {
+    private static final long RULE_ID_BASE = 2749000L;
+
+    @Autowired
+    private RmqAlertStateMapper mapper;
+
+    @Test
+    void acknowledgeFiringShouldAcceptReminderTimesOfTheCurrentEpisodeTest() {
+        long ruleId = RULE_ID_BASE + 1;
+        LocalDateTime firedAt = LocalDateTime.of(2026, 9, 1, 12, 0);
+        insertFiringState(ruleId, firedAt);
+        try {
+            LocalDateTime reminderTime = firedAt.plusMinutes(30);
+
+            int updated = mapper.acknowledgeFiring(ruleId, "fingerprint", reminderTime,
+                    LocalDateTime.now());
+
+            assertThat(updated).isEqualTo(1);
+            assertThat(mapper.selectList(new QueryWrapper<RmqAlertState>()
+                    .eq("rule_id", ruleId)).stream().map(RmqAlertState::getStatus))
+                    .containsExactly("ACKED");
+        } finally {
+            cleanup(ruleId);
+        }
+    }
+
+    @Test
+    void acknowledgeFiringShouldRejectEventsOlderThanTheCurrentEpisodeTest() {
+        long ruleId = RULE_ID_BASE + 2;
+        LocalDateTime firedAt = LocalDateTime.of(2026, 9, 1, 12, 0);
+        insertFiringState(ruleId, firedAt);
+        try {
+            LocalDateTime staleEpisodeEventTime = firedAt.minusHours(1);
+
+            int updated = mapper.acknowledgeFiring(ruleId, "fingerprint", staleEpisodeEventTime,
+                    LocalDateTime.now());
+
+            assertThat(updated).isEqualTo(0);
+            assertThat(mapper.selectList(new QueryWrapper<RmqAlertState>()
+                    .eq("rule_id", ruleId)).stream().map(RmqAlertState::getStatus))
+                    .containsExactly("FIRING");
+        } finally {
+            cleanup(ruleId);
+        }
+    }
+
+    private void insertFiringState(long ruleId, LocalDateTime firedAt) {
+        cleanup(ruleId);
+        RmqAlertState state = new RmqAlertState();
+        state.setRuleId(ruleId);
+        state.setFingerprint("fingerprint");
+        state.setStatus("FIRING");
+        state.setConsecutiveHits(3);
+        state.setCurrentValue(90.0);
+        state.setFiredAt(firedAt);
+        state.setVersion(0);
+        mapper.insert(state);
+    }
+
+    private void cleanup(long ruleId) {
+        mapper.delete(new QueryWrapper<RmqAlertState>().eq("rule_id", ruleId));
+    }
+}


### PR DESCRIPTION
Fixes #4242.

## Problem / Evidence

Acknowledging a REMINDER system alert marks the event acknowledged but never ACKs the underlying alert state, so the reminder loop keeps producing new events and notification sends after the user acknowledged the alert.

Evidence chain (all verified in the current base):

1. REMINDER events are acknowledgeable in the shipped UI — `web/src/pages/ops/systemAlerts.tsx` renders the Acknowledge button for every row where `!alert.acknowledged && alert.transition !== 'RESOLVED'`, and the REMINDER row is the newest row for any alert firing longer than one reminder interval (default 30m).
2. `AlertService.acknowledgeAlert` gates the state update on `"FIRING".equalsIgnoreCase(alert.getTransition())` — REMINDER events skip `alertStateRepository.acknowledge` entirely.
3. Even with the whitelist widened, `RmqAlertStateMapper.acknowledgeFiring` requires `AND fired_at = #{firedAt}`; a REMINDER event's `time` is the reminder time (strictly after the current episode's `fired_at`), so the equality can never match.
4. The loop is real: `AlertStateMachine.advanceHit` emits REMINDER every reminder interval while the state is `FIRING`, and `NativeAlertProcessor`/`NativeAlertEvaluationService` enqueue a notification for both FIRING and REMINDER transitions. Only `ACKED` stops it (`advanceHit` returns NONE while ACKED).

Reproduced by the new service-level regression test: acknowledging an event with `transition("REMINDER")` invoked `alertStateRepository.acknowledge` zero times before the fix (red), and by the new H2 integration test: `acknowledgeFiring(ruleId, fingerprint, firedAt + 30min, now)` updated 0 rows before the fix (`expected: 1 but was: 0`).

## Root cause / Fix

Two coupled conditions excluded reminder events from the state transition they are part of:

1. `AlertService.acknowledgeAlert` now accepts `FIRING` or `REMINDER` transitions (both belong to the same firing episode).
2. The mapper predicate changes from `fired_at = #{firedAt}` to `fired_at <= #{firedAt}`.

The relaxed predicate preserves the stale-episode protection that `acknowledgingResolvedEventMustNotAcknowledgeANewerFiringStateTest` pins: all events of the current episode have `time >= fired_at` (the FIRING event's time equals `fired_at`, reminders are later), while every event of a previous episode precedes the current episode's `fired_at` (the condition must clear and re-accumulate PENDING before a new episode fires), so `fired_at <= event.time` matches exactly the current episode.

## Priority & scoring

PRIORITY 72 = impact 32 (the acknowledge action silently fails at its only purpose — stopping paging — for every alert firing longer than one reminder interval) + blast radius 12 (all native alert rules with reminders enabled, both API and UI paths) + reproducibility 18 (deterministic state machine transition; verified red→green by unit and H2 tests) + maintenance value 10 (completes the FIRING/REMINDER lifecycle contract the state machine already defines). FIX_CONFIDENCE 85: two-line condition widening plus a mapper predicate whose stale-episode safety is proven by both new tests and the untouched existing guard test.

## Tests

- New service regression `acknowledgingReminderEventShouldAcknowledgeItsActiveRuleStateTest` (`AlertServiceTest`): red before (acknowledge never invoked), green after.
- New H2 integration test `RmqAlertStateMapperIntegrationTest` (2 tests): reminder time of the current episode ACKs (`expected: 1 but was: 0` red before); an event older than the current episode does not ACK and the row stays FIRING (guard, green before and after).
- `mvn -o test -Dtest='AlertServiceTest,RmqAlertStateMapperIntegrationTest,MybatisPlusAlertStateRepositoryTest,AlertStateMachineTest'` → all pass; `mvn -o test -Dtest='org.apache.rocketmq.studio.ops.alert.*Test'` → 33 alert test classes all pass (AlertServiceTest 77/77 incl. the pre-existing FIRING and RESOLVED acknowledge tests unchanged).
- Full backend suite `mvn -o test` on this branch: **2154 tests, 2 failures — both pre-existing baseline failures (`AuthCorsIntegrationTest` ×2, documented in the repo's test baseline; the Aliyun baseline failure did not occur this run). Zero new failures.**
- `git diff` self-check: 4 files, +114/−3 (2 source files, 2 test files), no unrelated changes.

## Risk

Low. The only behavior change is that acknowledging a reminder event of the current firing episode now ACKs the state (stopping further reminders) — the action the UI already offers and operators already expect. RESOLVED events remain inert (existing test unchanged), and events older than the current episode still cannot ACK a newer firing state (new guard test). The atomicity of the two writes in `acknowledgeAlert` is a separate, already-reported concern (#4203) and is intentionally not touched here.
