### PR TITLE
fix(consumer): reload the paginated group list after creating groups

### DIFF
--- a/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
+++ b/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
@@ -487,6 +487,38 @@ describe('Consumer page', () => {
     confirmSpy.mockRestore();
   });
 
+  it('reloads the paginated group list after creating a group', async () => {
+    const created = { ...group, name: 'cg-created' };
+    vi.mocked(consumerService.listConsumerGroupPage)
+      .mockResolvedValueOnce(groupPage([group]))
+      .mockResolvedValue(groupPage([created, group]));
+    const confirmSpy = vi.spyOn(Modal, 'confirm').mockImplementation((config) => {
+      void config.onOk?.();
+      return { destroy: vi.fn(), update: vi.fn() } as unknown as ReturnType<typeof Modal.confirm>;
+    });
+    const user = userEvent.setup();
+    renderWithProviders(<ConsumerPage />);
+
+    await screen.findByText('remote-cg');
+    expect(consumerService.listConsumerGroupPage).toHaveBeenCalledTimes(1);
+
+    const createButton = screen.getByRole('button', { name: '创建 Group' });
+    await waitFor(() => expect(createButton).toBeEnabled());
+    await user.click(createButton);
+    const dialog = await screen.findByRole('dialog');
+    await user.type(within(dialog).getByLabelText('Group 名称'), 'cg-created');
+    await user.click(within(dialog).getByRole('button', { name: /创\s*建/ }));
+
+    await waitFor(() => expect(consumerService.createConsumerGroup).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(consumerService.listConsumerGroupPage).toHaveBeenCalledTimes(2));
+    expect(consumerService.listConsumerGroupPage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ page: 1, pageSize: 20 }),
+    );
+    expect(await screen.findByText('cg-created')).toBeInTheDocument();
+    expect(screen.getByText('共 2 个 Group')).toBeInTheDocument();
+    confirmSpy.mockRestore();
+  });
+
   it('prefills the group search from the ?group= query parameter', async () => {
     renderWithProviders(<ConsumerPage />, '/instance/consumer?group=remote-cg');
 

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -370,7 +370,7 @@ const ConsumerPageContent = ({
     [t, selectedInstanceId, search],
   );
 
-  const reloadConsumerGroupPageAfterDelete = useCallback(async () => {
+  const reloadConsumerGroupPage = useCallback(async () => {
     await loadConsumerGroupPage(page, pageSize);
   }, [loadConsumerGroupPage, page, pageSize]);
 
@@ -822,10 +822,7 @@ const ConsumerPageContent = ({
     setImportRows([...nextRows]);
 
     if (createdGroups.length > 0) {
-      setGroups((previous) => {
-        const createdNames = new Set(createdGroups.map((group) => group.name));
-        return [...createdGroups, ...previous.filter((group) => !createdNames.has(group.name))];
-      });
+      await reloadConsumerGroupPage();
     }
 
     const failedCount = nextRows.filter((row) => row.status === 'failed').length;
@@ -1040,7 +1037,7 @@ const ConsumerPageContent = ({
                 cancelText: '取消',
                 onOk: async () => {
                   await deleteConsumerGroup(record.name, selectedInstanceId || undefined);
-                  await reloadConsumerGroupPageAfterDelete();
+                  await reloadConsumerGroupPage();
                   setSelectedRowKeys((prev) => prev.filter((key) => key !== record.name));
                   message.success(`消费组 ${record.name} 已删除`);
                 },
@@ -1471,7 +1468,7 @@ const ConsumerPageContent = ({
                       names,
                       selectedInstanceId || undefined,
                     );
-                    if (deleted.length > 0) await reloadConsumerGroupPageAfterDelete();
+                    if (deleted.length > 0) await reloadConsumerGroupPage();
                     if (failed.length > 0) {
                       message.warning(
                         `已删除 ${deleted.length} 个，失败 ${failed.length} 个：${failed.join(', ')}`,
@@ -2275,7 +2272,7 @@ const ConsumerPageContent = ({
                 onOk: async () => {
                   setSubmitting(true);
                   try {
-                    const created = await createConsumerGroup({
+                    await createConsumerGroup({
                       name: values.name,
                       subscriptionMode: values.subscriptionMode,
                       consumeType: values.consumeType,
@@ -2285,10 +2282,10 @@ const ConsumerPageContent = ({
                       subscribedTopics: [],
                       instanceId: selectedInstanceId,
                     });
-                    setGroups((prev) => [
-                      created,
-                      ...prev.filter((group) => group.name !== created.name),
-                    ]);
+                    // The list is server-paginated: refetch the current page so the new
+                    // group lands where the server sorts it and the total stays truthful,
+                    // mirroring the topic inventory behavior after create.
+                    await reloadConsumerGroupPage();
                     message.success(`消费组 ${values.name} 创建成功`);
                     setCreateModalOpen(false);
                     form.resetFields();


### PR DESCRIPTION
Fixes #4244.

## Problem / Evidence

Creating a consumer group — through the single create dialog or the CSV import — updates the group list only locally: `setGroups((prev) => [created, ...prev.filter(...)])` prepends the created group to the currently loaded rows without refetching the server-paginated list and without updating the pagination total.

The list is server-paginated (`loadConsumerGroupPage(page, pageSize)` fetches `listConsumerGroupPage({page, pageSize})` and sets both rows and `totalGroups`), and `autoRefresh` defaults to `false`, so the divergence persists until a manual refresh:

- the pagination footer keeps showing the pre-create total (`共 N 个 Group` with the stale N);
- on a full page the prepended row pushes the page's last row out of view;
- with the user on page > 1, the new group is injected into that page even though the server's ordering places it elsewhere.

The same file already refetches the page after single and batch delete — the create/import paths were the only list mutations that skipped the reload. This is the same defect class maintainers already fixed for the topic inventory (merged #3339) and that #3306 tracks for ACL users.

## Root cause / Fix

The create and import paths mutated the local array instead of reloading the paginated inventory. Fix (mirroring #3339's pattern on the topic page):

1. `reloadConsumerGroupPageAfterDelete` is renamed to the neutral `reloadConsumerGroupPage` (both existing delete call sites updated).
2. The single-create flow replaces its local prepend with `await reloadConsumerGroupPage()`.
3. The CSV import flow replaces its `setGroups` prepend with `await reloadConsumerGroupPage()` when at least one group was created.

## Priority & scoring

PRIORITY 76 = impact 28 (post-write inventory divergence: stale total, evicted rows, misplaced new group on an inventory operators rely on right after creating) + blast radius 12 (both list-mutating flows of the consumer group page) + reproducibility 20 (deterministic: create a group with default settings and read the footer) + maintenance value 16 (adopts the exact reload pattern maintainers merged for topics and this page already uses for deletes). FIX_CONFIDENCE 92: mechanical reuse of the in-file reload callback; the new regression test fails red before and passes green after, and the delete/import test suites pin the unchanged behavior.

## Tests

- New regression `reloads the paginated group list after creating a group` (`web/src/pages/instance/__tests__/ConsumerPage.test.tsx`): creates a group, asserts `listConsumerGroupPage` is re-fetched for the current page, the created group renders where the server returns it, and the footer shows the refreshed total. **Red before the fix** (`expected "vi.fn()" to be called 2 times, but got 1 times` — no reload happened), **green after**.
- `npx vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx` → **32/32 passed** (31 pre-existing, including the delete-reload, batch-delete, and CSV-import suites, unchanged).
- Full web suite `npx vitest run` on this branch: **982 passed (982) — zero failures**, including the CSV-import test that exercises the reloaded import path.
- `npx tsc --noEmit` clean; `npx eslint` on both changed files clean; `npm run build` succeeds.

## Risk

Low. The only behavior change is that the list is re-read from the server after a successful create/import instead of being patched locally; delete paths are untouched. The import result modal (per-row success/failure state) is driven by `importRows`, not by the group list, so partial-failure reporting is unaffected.
