### PR TITLE
feat(topic): edit topic configuration from the topic page

### DIFF
--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -38,6 +38,7 @@ const topicServiceMocks = vi.hoisted(() => ({
   listTopics: vi.fn(),
   listTopicsPage: vi.fn(),
   sendTopicMessage: vi.fn(),
+  updateTopic: vi.fn(),
 }));
 
 const instanceServiceMocks = vi.hoisted(() => ({
@@ -262,6 +263,98 @@ describe('TopicPage', () => {
     expect(within(getTableBody()).getByText('topic-b')).toBeInTheDocument();
     expect(within(getTableBody()).getByText('server page response')).toBeInTheDocument();
     expect(within(getTableBody()).queryByText('create response')).not.toBeInTheDocument();
+  });
+
+  it('updates topic config through the update service and reloads the page', async () => {
+    topicServiceMocks.updateTopic.mockResolvedValue({
+      ...buildTopics(1)[0],
+      writeQueues: 16,
+      perm: 'RO',
+      remark: 'updated remark',
+    });
+    const user = userEvent.setup();
+    renderWithProviders();
+
+    expect(await screen.findByText('topic-01')).toBeInTheDocument();
+    const row = within(getTableBody()).getByText('topic-01').closest('tr') as HTMLElement;
+    await user.click(within(row).getByRole('button', { name: /配\s*置/ }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('编辑 Topic')).toBeInTheDocument();
+    const nameInput = within(dialog).getByLabelText('Topic 名称') as HTMLInputElement;
+    expect(nameInput).toBeDisabled();
+    expect(nameInput.value).toBe('topic-01');
+
+    const writeQueues = within(dialog).getByLabelText('写队列数') as HTMLInputElement;
+    expect(writeQueues.value).toBe('8');
+    await user.clear(writeQueues);
+    await user.type(writeQueues, '16');
+    await user.click(within(dialog).getByText('只读'));
+    await user.click(within(dialog).getByRole('button', { name: /保\s*存/ }));
+
+    await waitFor(() => expect(topicServiceMocks.updateTopic).toHaveBeenCalledTimes(1));
+    expect(topicServiceMocks.updateTopic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'topic-01',
+        writeQueues: 16,
+        perm: 'RO',
+        instanceId: 'instance-proxy-1',
+      }),
+    );
+    await waitFor(() => expect(topicServiceMocks.listTopicsPage).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText(/更新成功/)).toBeInTheDocument();
+  });
+
+  it('edits cloud topics without the broker-only fields', async () => {
+    instanceServiceMocks.listInstances.mockResolvedValue([
+      { ...selectedInstance, vendor: 'ALIYUN' },
+    ]);
+    topicServiceMocks.updateTopic.mockResolvedValue(buildTopics(1)[0]);
+    const user = userEvent.setup();
+    renderWithProviders();
+
+    expect(await screen.findByText('topic-01')).toBeInTheDocument();
+    const row = within(getTableBody()).getByText('topic-01').closest('tr') as HTMLElement;
+    await user.click(within(row).getByRole('button', { name: /配\s*置/ }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('编辑 Topic')).toBeInTheDocument();
+    expect(within(dialog).queryByLabelText('写队列数')).not.toBeInTheDocument();
+    expect(within(dialog).queryByText('只读')).not.toBeInTheDocument();
+
+    const remarkBox = within(dialog).getByLabelText('备注') as HTMLInputElement;
+    await user.clear(remarkBox);
+    await user.type(remarkBox, 'aliyun remark');
+    await user.click(within(dialog).getByRole('button', { name: /保\s*存/ }));
+
+    await waitFor(() => expect(topicServiceMocks.updateTopic).toHaveBeenCalledTimes(1));
+    expect(topicServiceMocks.updateTopic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'topic-01',
+        remark: 'aliyun remark',
+        instanceId: 'instance-proxy-1',
+      }),
+    );
+  });
+
+  it('opens a clean create dialog after a cancelled edit', async () => {
+    const user = userEvent.setup();
+    renderWithProviders();
+
+    expect(await screen.findByText('topic-01')).toBeInTheDocument();
+    const row = within(getTableBody()).getByText('topic-01').closest('tr') as HTMLElement;
+    await user.click(within(row).getByRole('button', { name: /配\s*置/ }));
+    const editDialog = await screen.findByRole('dialog');
+    await user.click(within(editDialog).getByRole('button', { name: /取\s*消/ }));
+
+    await user.click(screen.getByRole('button', { name: /创建 Topic/ }));
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('创建 Topic')).toBeInTheDocument();
+    await user.type(within(dialog).getByLabelText('Topic 名称'), 'topic-zz');
+    await user.click(within(dialog).getByRole('button', { name: /创\s*建/ }));
+
+    await waitFor(() => expect(topicServiceMocks.createTopic).toHaveBeenCalledTimes(1));
+    expect(topicServiceMocks.updateTopic).not.toHaveBeenCalled();
   });
 
   it('ignores duplicate Topic creates while the first request is pending', async () => {

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -48,6 +48,7 @@ import {
   SendOutlined,
   DeleteOutlined,
   EyeOutlined,
+  EditOutlined,
   ImportOutlined,
   ExportOutlined,
   SyncOutlined,
@@ -75,6 +76,7 @@ import {
   importTopics,
   listTopicsPage,
   sendTopicMessage,
+  updateTopic,
 } from '../../services/topicService';
 import { useInstanceFilter } from '../../hooks/useInstanceFilter';
 import type { Instance } from '../../api/instance';
@@ -371,6 +373,7 @@ const TopicPage = () => {
   const [selectedTopic, setSelectedTopic] = useState<Topic | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [creating, setCreating] = useState(false);
+  const [editingTopic, setEditingTopic] = useState<Topic | null>(null);
   const [form] = Form.useForm();
   const createTopicType = Form.useWatch('type', form);
   const [sendModalOpen, setSendModalOpen] = useState(false);
@@ -629,6 +632,8 @@ const TopicPage = () => {
       void openDetail(topic);
     } else if (key === 'route') {
       void openDetail(topic);
+    } else if (key === 'config') {
+      openEditConfig(topic);
     } else if (key === 'send') {
       setSendTopic(topic);
       setPropsMode('form');
@@ -751,6 +756,14 @@ const TopicPage = () => {
             onClick={() => handleAction('detail', record)}
           >
             详情
+          </Button>
+          <Button
+            size="small"
+            icon={<EditOutlined />}
+            style={{ borderColor: '#1677ff', color: '#1677ff' }}
+            onClick={() => handleAction('config', record)}
+          >
+            配置
           </Button>
           {!isCloudInstance && (
             <Button
@@ -1123,7 +1136,7 @@ const TopicPage = () => {
     );
   };
 
-  // ─── Create modal submit ──────────────────────────────────────
+  // ─── Create / edit modal submit ───────────────────────────────
   const handleCreate = async () => {
     if (createInFlightRef.current) return;
     if (!selectedInstanceId) {
@@ -1134,22 +1147,47 @@ const TopicPage = () => {
     setCreating(true);
     try {
       const values = await form.validateFields();
-      const created = await createTopic({
-        ...values,
-        instanceId: selectedInstanceId,
-      });
-      await reloadTopicPage();
-      message.success(`Topic「${created.name}」创建成功`);
+      if (editingTopic) {
+        const updated = await updateTopic({
+          ...values,
+          instanceId: selectedInstanceId,
+        });
+        await reloadTopicPage();
+        message.success(`Topic「${updated.name}」更新成功`);
+      } else {
+        const created = await createTopic({
+          ...values,
+          instanceId: selectedInstanceId,
+        });
+        await reloadTopicPage();
+        message.success(`Topic「${created.name}」创建成功`);
+      }
       setModalOpen(false);
+      setEditingTopic(null);
       form.resetFields();
     } catch (error) {
       if (!(error && typeof error === 'object' && 'errorFields' in error)) {
-        message.error('创建 Topic 失败，请稍后重试');
+        message.error(editingTopic ? '更新 Topic 失败，请稍后重试' : '创建 Topic 失败，请稍后重试');
       }
     } finally {
       createInFlightRef.current = false;
       setCreating(false);
     }
+  };
+
+  // Classic dashboard parity: the topic row's CONFIG action reuses the create
+  // dialog in update mode — name/type stay fixed, queue counts and perm change.
+  const openEditConfig = (topic: Topic) => {
+    setEditingTopic(topic);
+    form.setFieldsValue({
+      name: topic.name,
+      type: topic.type,
+      writeQueues: topic.writeQueues,
+      readQueues: topic.readQueues,
+      perm: topic.perm,
+      remark: topic.remark,
+    });
+    setModalOpen(true);
   };
 
   const handleImportFile = async (file: File) => {
@@ -1571,7 +1609,11 @@ const TopicPage = () => {
             type="primary"
             icon={<PlusOutlined />}
             disabled={!hasSelectedInstance}
-            onClick={() => setModalOpen(true)}
+            onClick={() => {
+              setEditingTopic(null);
+              form.resetFields();
+              setModalOpen(true);
+            }}
           >
             创建 Topic
           </Button>
@@ -1671,17 +1713,18 @@ const TopicPage = () => {
         )}
       </Modal>
 
-      {/* ── Create Topic Modal ────────────────────────────────── */}
+      {/* ── Create / Edit Topic Modal ─────────────────────────── */}
       <Modal
-        title="创建 Topic"
+        title={editingTopic ? '编辑 Topic' : '创建 Topic'}
         open={modalOpen}
         onCancel={() => {
           setModalOpen(false);
+          setEditingTopic(null);
           form.resetFields();
         }}
         onOk={handleCreate}
         confirmLoading={creating}
-        okText="创建"
+        okText={editingTopic ? '保存' : '创建'}
         cancelText="取消"
         width={560}
         destroyOnHidden
@@ -1712,7 +1755,7 @@ const TopicPage = () => {
               },
             ]}
           >
-            <Input placeholder="请输入 Topic 名称" />
+            <Input placeholder="请输入 Topic 名称" disabled={!!editingTopic} />
           </Form.Item>
 
           <Form.Item
@@ -1722,6 +1765,7 @@ const TopicPage = () => {
             extra={TOPIC_TYPE_CARDS.find((c) => c.value === createTopicType)?.desc}
           >
             <Segmented
+              disabled={!!editingTopic}
               options={TOPIC_TYPE_CARDS.filter((c) => !isCloudInstance || c.value !== 'LITE').map(
                 ({ value, label }) => ({ value, label }),
               )}


### PR DESCRIPTION
Fixes #4248.

## Source

- Parent project (classic dashboard, `master` of this repo): the topic list's row action "Topic CONFIG" (`frontend-new/src/pages/Topic/topic.jsx:498-500`) opens `TopicModifyDialog` in update mode (`frontend-new/src/components/topic/TopicModifyDialog.jsx`, `bIsUpdate`) — name and message type are disabled while write/read queue counts and perm stay editable, submitted via `createOrUpdateTopic` (`frontend-new/src/api/remoteApi/remoteApi.js:674`). Verified with `git show master:...`.
- In-repo evidence that this is an omission, not a design decision: `POST /api/topics/update` is documented in the project's own API reference (`docs/api-spec.md` §5.4), implemented for all three providers (`ApacheInstanceProvider.updateTopic` → `RocketMQAdminClientImpl.updateTopic`, plus `AliyunInstanceProvider` / `TencentInstanceProvider`), and the web service wrapper `topicService.updateTopic` exists with demo-mode support — but `git grep updateTopic -- web/src` shows **no page ever calls it**. `RocketMQAdminClientImpl.updateTopic` even comments on preserving values "on partial updates (e.g. perm or remark only)", written for update callers that never arrived in the UI.

## Current gap

Studio's topic page row actions are detail / send / delete only. Resizing queues, tightening permission (RW → RO/WO) or fixing a remark requires CLI access, while the whole backend path for it already exists.

## Project fit

- Zero new server code: this wires the UI to an endpoint the project already ships and documents.
- Follows the established Studio pattern of reusing the create dialog for resource management (vendor gating, in-flight guard, server-page reload) rather than porting the classic per-broker dialog wholesale.
- Cloud instances are covered honestly: the Aliyun/Tencent providers accept remark(-only) updates, so the edit dialog keeps the create dialog's vendor gating (no queue/perm fields for cloud), exactly matching what those APIs accept.

## Scope

Included: a 配置 row action opening the create dialog in edit mode (prefilled, name/type disabled per classic semantics), submit through `updateTopic` with the selected instance id, server-page reload, success/error feedback, and a state reset that keeps the create flow independent.

Not included: per-broker queue editing (Studio updates the topic through the provider API, not per broker), message-type changes (classic also disables them on update), AI tool surface changes, new server endpoints.

## Implementation

- `web/src/pages/instance/topic.tsx`: `editingTopic` state; `openEditConfig` prefills the form and opens the shared dialog; `handleCreate` branches to `topicService.updateTopic` when editing; modal title/okText switch (编辑 Topic / 保存); name input and type Segmented disabled in edit mode; the toolbar create button and dialog cancel clear `editingTopic` so the create flow can never submit an update; 配置 row button (all vendors, mirroring the server-side provider support).
- Tests in `web/src/pages/instance/__tests__/TopicPage.test.tsx` (3 new cases).

## Tests

Red first (feature absent on baseline `6c24d2ed`):

- `npx vitest run src/pages/instance/__tests__/TopicPage.test.tsx -t "topic"` → `Tests 2 failed | 13 passed | 11 skipped (26)`: both new edit cases failed at `getByRole('button', { name: /配\s*置/ })` (no such row button on baseline).
- `-t "clean create dialog"` → `Tests 1 failed | 25 skipped (26)` (same missing action).

Green after the change:

- `npx vitest run src/pages/instance/__tests__/TopicPage.test.tsx` → `Test Files 1 passed (1)`, `Tests 26 passed (26)` (23 pre-existing + 3 new: edit submit reloads the server page with `updateTopic` called with the changed queues/perm; cloud edit hides broker-only fields and submits remark-only; a cancelled edit leaves a clean create dialog — `updateTopic` not called).
- Full web `npx vitest run`: **984 tests, 8 failures / 7 files** — 6 failures in files untouched by this change (MetricsExplorer, ClientsPage, ClusterPage, MessagePage, AuditPage, NotificationDeliveriesPage — the documented load-flaky family) and 2 in TopicPage; TopicPage re-run in isolation right after: `Tests 26 passed (26)` (the full run executed concurrently with `npm run build`, the same overload pattern recorded in previous rounds).
- `npx tsc --noEmit` clean; eslint clean on both touched files; `npm run build` ✓ (built in 1m 21s). No backend changes — the update endpoint was already tested server-side.

## Compatibility & Risk

- Additive UI only; no API or data-model changes. Users of the existing create dialog see identical behavior (title, OK label and validation unchanged in create mode).
- The update call relies on the existing partial-update semantics of `UpdateTopicDTO` (cloud payloads omit queue/perm fields; the Apache provider preserves unset values) — the exact path its own comments were written for.
- Head: 3696930d (single commit, branch `feat/topic-config-edit` off `rocketmq-studio` @ 6c24d2ed).

