### PR TITLE
fix(studio): reset the create-user form when the dialog is dismissed

### DIFF
--- a/web/src/pages/studio/UserManagement.tsx
+++ b/web/src/pages/studio/UserManagement.tsx
@@ -510,7 +510,10 @@ const UserManagementPage = () => {
         title="新建 Studio 用户"
         open={createOpen}
         onOk={() => void createUser()}
-        onCancel={() => setCreateOpen(false)}
+        onCancel={() => {
+          setCreateOpen(false);
+          createForm.resetFields();
+        }}
       >
         <Form form={createForm} layout="vertical" initialValues={{ admin: false }}>
           <Form.Item name="username" label="用户名" rules={[{ required: true }, { max: 128 }]}>

--- a/web/src/pages/studio/__tests__/UserManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/UserManagement.test.tsx
@@ -246,4 +246,22 @@ describe('UserManagementPage', () => {
     expect(setStudioUserEnabled).toHaveBeenCalledWith(7, false);
     await act(async () => resolveUpdate());
   });
+
+  it('clears the create-user form after the dialog is dismissed', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole('button', { name: '新建用户' }));
+    await user.type(await screen.findByLabelText('用户名'), 'temp-operator');
+    await user.type(screen.getByLabelText('初始密码'), 'initial-pass-123');
+    await user.click(screen.getByLabelText('管理员权限'));
+    expect(screen.getByLabelText('管理员权限')).toBeChecked();
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await user.click(await screen.findByRole('button', { name: '新建用户' }));
+
+    expect(await screen.findByLabelText('用户名')).toHaveValue('');
+    expect(screen.getByLabelText('初始密码')).toHaveValue('');
+    expect(screen.getByLabelText('管理员权限')).not.toBeChecked();
+  });
 });


### PR DESCRIPTION
Fixes #4252.

## Problem / Evidence

The create-user dialog on the Studio user management page keeps its form mounted across open/close cycles and the cancel path only calls `setCreateOpen(false)`. A dismissed attempt therefore keeps the typed username, the typed initial password and the toggled admin switch, and the next open pre-fills all of them. An operator who changes only the username then creates the account with the previous attempt's password and admin flag (`createStudioUser` receives stale `admin: true`).

Repro: open dialog → fill username / initial password / enable admin → cancel → reopen → all three fields are still filled; submit after changing only the username sends the stale password and `admin: true`.

## Root cause / Fix

`onCancel` (web/src/pages/studio/UserManagement.tsx:513) closes the dialog without resetting the form, while the create-success path (`createUser`) and the reset-password dialog of the same file already call `createForm.resetFields()`. The fix adds `createForm.resetFields()` to the cancel path, mirroring those in-file precedents.

## Priority & scoring

PRIORITY 70 = impact 28 (a dismissed attempt silently produces an admin account with a credential the operator did not choose for it) + scope 11 (single dialog, core account-creation flow of the page) + reproducibility 18 (deterministic UI repro, covered by a regression test) + maintenance value 13 (aligns with the reset-on-cancel convention already used in this file and sibling create dialogs). FIX_CONFIDENCE 95: one-line handler change mirroring in-file precedents, red→green verified.

## Tests

- New regression `clears the create-user form after the dialog is dismissed` fills all three fields, cancels, reopens and asserts empty username/password and unchecked admin.
- Red on the unfixed code: `src/pages/studio/__tests__/UserManagement.test.tsx` → `Tests  1 failed | 6 passed (7)` with `× clears the create-user form after the dialog is dismissed`.
- Green with the fix: `Tests  7 passed (7)`.
- Full web suite `npx vitest run`: 982 tests, 1 failed — `ConsumerPage.test.tsx` ("shows group health diagnostics…"), a file this branch does not touch and a known load-fragile case under the parallel run; re-run in isolation: `Tests  31 passed (31)`.
- `npx tsc -b` clean; `npx eslint .` 0 errors (10 warnings, all in files this branch does not touch); `npx vite build` succeeds.

## Risk

Cancel now discards typed input by design, consistent with the create-success path and the reset-password dialog in the same file. No API, routing or state-manager changes; diff is one handler plus one test.

Head: 2343a152 (fix/studio-user-create-form-reset, 1 commit).
