### PR TITLE
fix(alerts): reset the silence form when the maintenance dialog is dismissed

### DIFF
--- a/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
@@ -547,6 +547,49 @@ describe('SystemAlertsPage', () => {
     });
   });
 
+  it('resets the silence form after the dialog is dismissed without creating', async () => {
+    vi.mocked(listAlertSilencesPage).mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      size: 10,
+    });
+    vi.mocked(createAlertSilence).mockResolvedValue({
+      id: 11,
+      domain: 'BUSINESS',
+      startsAt: '2026-08-12T01:00',
+      endsAt: '2026-08-12T02:00',
+      createdBy: 'admin',
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole('button', { name: '维护窗口' }));
+    await user.type(screen.getByLabelText('规则 ID'), '42');
+    await user.type(screen.getByLabelText('标签范围'), 'brokerName=broker-a');
+    fireEvent.change(screen.getByLabelText('开始时间'), { target: { value: '2026-08-11T01:00' } });
+    fireEvent.change(screen.getByLabelText('结束时间'), { target: { value: '2026-08-11T02:00' } });
+
+    await user.click(await screen.findByRole('button', { name: 'Cancel' }));
+    await user.click(await screen.findByRole('button', { name: '维护窗口' }));
+
+    expect(await screen.findByLabelText('规则 ID')).toHaveValue('');
+    expect(screen.getByLabelText('标签范围')).toHaveValue('');
+
+    fireEvent.change(screen.getByLabelText('开始时间'), { target: { value: '2026-08-12T01:00' } });
+    fireEvent.change(screen.getByLabelText('结束时间'), { target: { value: '2026-08-12T02:00' } });
+    await user.click(screen.getByRole('button', { name: /创\s*建/ }));
+
+    await waitFor(() => {
+      expect(createAlertSilence).toHaveBeenLastCalledWith(
+        expect.not.objectContaining({ ruleId: 42 }),
+      );
+    });
+    const payload = vi.mocked(createAlertSilence).mock.lastCall?.[0] as Record<string, unknown>;
+    expect(payload.ruleId).toBeUndefined();
+    expect(payload.labels).toBeUndefined();
+  });
+
   it('loads maintenance windows by page and backs up after deleting the last page item', async () => {
     vi.mocked(listAlertSilencesPage)
       .mockResolvedValueOnce({

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -828,7 +828,10 @@ const SystemAlertsPage = () => {
       <Modal
         title={t('sysAlerts.maintenanceWindows')}
         open={silencesVisible}
-        onCancel={() => setSilencesVisible(false)}
+        onCancel={() => {
+          setSilencesVisible(false);
+          silenceForm.resetFields();
+        }}
         onOk={() => void createSilence()}
         okText={t('sysAlerts.create')}
         okButtonProps={{ style: { display: canManageSilences ? undefined : 'none' } }}


### PR DESCRIPTION
Fixes #4251.

## Problem / Evidence

The maintenance windows dialog on `/ops/system-alerts` keeps its create form mounted across open/close cycles and the cancel path only calls `setSilencesVisible(false)`. Values typed into a dismissed attempt (rule ID, label scope, recurrence, times) survive the cancel and pre-fill the next open. Creating a silence after a cancelled attempt then sends the stale scope: the request carries the previous attempt's `ruleId` and `labels` even though the operator only changed the window times.

Repro: open dialog → rule ID `42`, labels `brokerName=broker-a`, times → cancel → reopen → fields still filled → change only the times → create → `createAlertSilence` is called with the stale `ruleId: 42` and `labels` from the cancelled attempt.

## Root cause / Fix

`onCancel` (web/src/pages/ops/systemAlerts.tsx:831) closes the dialog without resetting the form, while the create-success path (`createSilence`) already calls `silenceForm.resetFields()`. The fix adds `silenceForm.resetFields()` to the cancel path, mirroring the create-success path and the reset-on-cancel convention used by the other create dialogs in the codebase.

## Priority & scoring

PRIORITY 70 = impact 27 (the silence is created on the wrong scope, so the alert notifications the window was meant to suppress keep firing; a residual DAILY/WEEKLY recurrence also creates an unintended recurring silence) + scope 11 (single create dialog) + reproducibility 18 (deterministic UI repro, covered by a regression test) + maintenance value 14 (same reset-on-cancel convention as the sibling dialogs; fixes the residue class recorded in #4251). FIX_CONFIDENCE 95: one-line handler change mirroring in-file precedents, red→green verified.

## Tests

- New regression `resets the silence form after the dialog is dismissed without creating` fills rule ID / label scope / times, cancels, reopens, asserts empty fields and asserts `createAlertSilence` is called without the stale `ruleId`/`labels`.
- Red on the unfixed code: `src/pages/ops/__tests__/SystemAlertsPage.test.tsx` → `Tests  1 failed | 14 passed (15)` with `× resets the silence form after the dialog is dismissed without creating`.
- Green with the fix: `Tests  15 passed (15)`.
- Full web suite `npx vitest run`: 982 tests, 1 failed — `ConsumerPage.test.tsx`, a file this branch does not touch and a known load-fragile case under the parallel run; re-run in isolation: `Tests  31 passed (31)`.
- `npx tsc -b` clean; `npx eslint .` 0 errors (the `systemAlerts.tsx` warning at line 227 is a pre-existing `react-hooks/exhaustive-deps` notice, untouched by this change); `npx vite build` succeeds.

## Risk

Cancel now discards typed input by design, consistent with the create-success path. No API or state changes; diff is one handler plus one test.

Head: 33771da6 (fix/alert-silence-form-residue, 1 commit).
