### PR TITLE
fix(settings): build general settings saves from a fresh read

### DIFF
--- a/web/src/pages/settings/GeneralSettingsTab.tsx
+++ b/web/src/pages/settings/GeneralSettingsTab.tsx
@@ -99,13 +99,27 @@ export const GeneralSettingsTab = () => {
     };
   }, [message, notifyForm, securityForm, t]);
 
+  // Other tabs (AI assistant settings) write the same settings record while this tab stays
+  // mounted, so every save must be built from a fresh read instead of the mount-time snapshot.
+  const loadFreshSettings = async (fallback: GeneralSettings): Promise<GeneralSettings> => {
+    try {
+      const fresh = await getGeneralSettings();
+      setSettings(fresh);
+      return fresh;
+    } catch {
+      return fallback;
+    }
+  };
+
   const persistPreference = async (patch: Partial<GeneralSettings>) => {
     if (!settings) return;
     const next = { ...settings, ...patch };
     setSettings(next);
     setSavingPreference(true);
     try {
-      await saveGeneralSettings(buildPayload(next));
+      const base = await loadFreshSettings(settings);
+      await saveGeneralSettings(buildPayload({ ...base, ...patch }));
+      setSettings({ ...base, ...patch });
       message.success(t('settings.saveSuccess'));
     } catch {
       message.error(t('settings.saveFailed'));
@@ -117,10 +131,11 @@ export const GeneralSettingsTab = () => {
   const mergeAndSave = async (patch: Partial<GeneralSettings>) => {
     if (!settings) return false;
     try {
-      await saveGeneralSettings(buildPayload({ ...settings, ...patch }));
+      const base = await loadFreshSettings(settings);
+      await saveGeneralSettings(buildPayload({ ...base, ...patch }));
       const statePatch = { ...patch };
       delete statePatch.clearDingtalkSigningSecret;
-      setSettings({ ...settings, ...statePatch });
+      setSettings({ ...base, ...statePatch });
       return true;
     } catch {
       message.error(t('settings.saveFailed'));

--- a/web/src/pages/settings/__tests__/GeneralSettingsTab.test.tsx
+++ b/web/src/pages/settings/__tests__/GeneralSettingsTab.test.tsx
@@ -149,6 +149,55 @@ describe('GeneralSettingsTab', () => {
       ),
     );
     expect(localStorage.getItem('rocketmq-studio-theme')).toBe('dark');
+    // The fresh read that guards unmanaged fields must not revert the visible preference.
+    await waitFor(() =>
+      expect(screen.getByText('深色').closest('.ant-segmented-item')).toHaveClass(
+        'ant-segmented-item-selected',
+      ),
+    );
+  });
+
+  it('saves llm fields from a fresh read instead of the mount-time snapshot', async () => {
+    const baseSettings = {
+      theme: 'system',
+      compact: false,
+      desktopNotify: false,
+      notifySound: false,
+      sessionTimeout: 30,
+      requireLogin: true,
+      apiKeyConfigured: false,
+    };
+    vi.mocked(getGeneralSettings)
+      .mockResolvedValueOnce({
+        ...baseSettings,
+        llmProvider: 'openai',
+        model: 'gpt-test',
+        baseUrl: 'https://openai.example/v1',
+      })
+      .mockResolvedValue({
+        ...baseSettings,
+        llmProvider: 'deepseek',
+        model: 'deepseek-chat',
+        baseUrl: 'https://deepseek.example/v1',
+      });
+    vi.mocked(saveGeneralSettings).mockResolvedValue();
+    renderTab();
+
+    const saveButtons = await screen.findAllByRole('button', { name: '保存设置' });
+    await waitFor(() => expect(saveButtons[0]).toBeEnabled());
+    // The AI assistant tab saved a different provider while this tab stayed mounted;
+    // submitting the security form must not resurrect the stale provider.
+    fireEvent.submit(saveButtons[0].closest('form')!);
+
+    await waitFor(() => expect(saveGeneralSettings).toHaveBeenCalledTimes(1));
+    expect(saveGeneralSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        llmProvider: 'deepseek',
+        model: 'deepseek-chat',
+        baseUrl: 'https://deepseek.example/v1',
+        sessionTimeout: 30,
+      }),
+    );
   });
 
   it('can explicitly clear a configured DingTalk signing secret', async () => {


### PR DESCRIPTION
Fixes #4250.

## Problem / Evidence

`GeneralSettingsTab` fetches the general settings once on mount and builds every save payload from that snapshot, including the `llmProvider`/`model`/`baseUrl` fields the tab never renders or edits. The AI assistant tab writes the same persisted record through `/llm/config` while the general tab stays mounted (antd Tabs keep visited panes alive), so every general save posts the mount-time LLM values back and silently reverts the AI configuration.

Repro: open `/settings` (snapshot: `llmProvider=openai`) → AI tab, switch provider/model/base URL, save → back on the general tab (still mounted), change the session timeout, save → `POST /api/settings/general/save` carries the stale `llmProvider`/`model`/`baseUrl` and overwrites the row.

## Root cause / Fix

The tab must not send fields it does not manage from its own snapshot. `persistPreference` and `mergeAndSave` now re-read the persisted settings (`loadFreshSettings`) before building each payload, so unmanaged fields are sent as currently stored; on a fresh-read failure the previous snapshot is used as fallback (baseline behavior). After a preference save succeeds, local state is synced to the fresh base plus the saved patch so the theme/compact controls keep showing the saved value. `loadFreshSettings` takes the current snapshot as its fallback parameter, which also keeps the `Promise<GeneralSettings>` contract type-clean.

## Priority & scoring

PRIORITY 74 = impact 30 (any general save silently reverts the AI provider/model/base URL — persisted data loss; the AI chat then calls the wrong provider or billing model with a possibly mismatched key, no error shown) + scope 14 (every save path on the tab: security form, notification form, theme, compact, three notification-test buttons) + reproducibility 18 (deterministic 4-step repro, covered by a regression test) + maintenance value 12 (fresh-read convention; #2863's server-side null-backfill cannot address stale non-null client values, as recorded in #4250). FIX_CONFIDENCE 88: mechanism verified red→green, fallback preserves baseline behavior on read failure.

## Tests

- New regression `saves llm fields from a fresh read instead of the mount-time snapshot` mocks a mount-time `openai` snapshot and a fresh-read `deepseek` record, submits the security form and asserts the save payload carries the fresh `deepseek` values.
- Red on the unfixed code: `src/pages/settings/__tests__/GeneralSettingsTab.test.tsx` → `Tests  1 failed | 6 passed (7)` with `× saves llm fields from a fresh read instead of the mount-time snapshot` (`expected "vi.fn()" to be called with arguments: [ObjectContaining{…}]` — payload carried the stale `openai` values).
- The existing theme test additionally asserts the 深色 option stays selected after the save completes; this assertion fails when the post-save state sync is omitted (`Expected the element to have class: ant-segmented-item-selected`), so the visible-preference behavior is pinned.
- Green with the fix: `Tests  7 passed (7)` (re-run after the final commit, including lint-staged reformatting).
- Full web suite `npx vitest run`: 982 tests, 2 failed — `ClusterPage.test.tsx` and `ConsumerPage.test.tsx`, files this branch does not touch and known load-fragile cases under the parallel run; re-run in isolation: ClusterPage `Tests  25 passed (25)`, ConsumerPage `Tests  31 passed (31)`.
- `npx tsc -b` clean; `npm run build` (tsc -b + vite build) succeeds; `npx eslint .` 0 errors (10 warnings, all in files this branch does not touch).

## Risk

One extra GET before each save (settings-page frequency makes this negligible); on a fresh-read failure the save still proceeds from the previous snapshot, matching today's behavior. State after a successful preference save now reflects server truth plus the patch. No API or type changes beyond this component and its test.

Head: ea4ea0a1 (fix/settings-general-save-stale-llm-rollback, 1 commit).
