### PR TITLE
fix(ai): address the message tools by instance identifier

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MessageQueryToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MessageQueryToolHandler.java
@@ -45,7 +45,7 @@ public class MessageQueryToolHandler implements ToolHandler {
 
     @Override
     public Object execute(Map<String, Object> input) {
-        String instanceId = (String) input.get("cluster");
+        String instanceId = (String) input.get("instance");
         String topic = (String) input.get("topic");
         String msgId = (String) input.get("msgId");
         String tag = (String) input.get("tag");

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandler.java
@@ -44,7 +44,7 @@ public class MessageTraceToolHandler implements ToolHandler {
 
     @Override
     public Object execute(Map<String, Object> input) {
-        String instanceId = (String) input.get("cluster");
+        String instanceId = (String) input.get("instance");
         String msgId = (String) input.get("msgId");
         String topic = (String) input.get("topic");
         TraceRecordVO trace = messageService.getMessageTrace(instanceId, msgId, topic);

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/ToolCatalog.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/ToolCatalog.java
@@ -139,8 +139,12 @@ public class ToolCatalog {
         if (CLUSTER_LIST_TOOL.equals(definition.name())) {
             return;
         }
+        // Every remote tool must declare the entity it is addressed by: metadata tools are
+        // cluster-addressed, runtime tools (message query/trace) are instance-addressed.
         Object required = definition.inputSchema().get("required");
-        if (!(required instanceof List<?> requiredFields) || !requiredFields.contains("cluster")) {
+        boolean declaresTargetField = required instanceof List<?> requiredFields
+                && (requiredFields.contains("cluster") || requiredFields.contains("instance"));
+        if (!declaresTargetField) {
             throw new IllegalStateException(
                     "Remote tool must require cluster: " + definition.name());
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayService.java
@@ -78,7 +78,7 @@ public class ToolGatewayService {
 
         return catalog.list().stream()
                 .filter(definition -> discoveryCapabilities.clusterCapabilitiesResolved()
-                        || !requiresCluster(definition))
+                        || !requiresTargetContext(definition))
                 .filter(definition -> discoveryCapabilities.capabilities().containsAll(
                         definition.requiredCapabilities()))
                 .filter(this::isVisibleToCurrentUser)
@@ -220,9 +220,16 @@ public class ToolGatewayService {
         return Collections.unmodifiableMap(compiled);
     }
 
-    private static boolean requiresCluster(ToolDefinition definition) {
+    /**
+     * Whether the tool is addressed through a target entity declared in its required input
+     * fields: metadata tools through {@code cluster}, runtime tools (message query/trace)
+     * through {@code instance}. Such tools are only discoverable once that target's context
+     * resolves.
+     */
+    private static boolean requiresTargetContext(ToolDefinition definition) {
         Object required = definition.inputSchema().get("required");
-        return required instanceof List<?> fields && fields.contains("cluster");
+        return required instanceof List<?> fields
+                && (fields.contains("cluster") || fields.contains("instance"));
     }
 
     private boolean isVisibleToCurrentUser(ToolDefinition definition) {

--- a/server/src/main/resources/tool-catalog/rmq-tools.yaml
+++ b/server/src/main/resources/tool-catalog/rmq-tools.yaml
@@ -358,12 +358,13 @@ tools:
     inputSchema:
       type: object
       required:
-        - cluster
+        - instance
       additionalProperties: false
       properties:
-        cluster:
+        instance:
           type: string
           minLength: 1
+          description: The RocketMQ instance identifier (unique name or numeric id) that the query targets.
         topic:
           type: string
         msgId:
@@ -420,13 +421,14 @@ tools:
     inputSchema:
       type: object
       required:
-        - cluster
+        - instance
         - msgId
       additionalProperties: false
       properties:
-        cluster:
+        instance:
           type: string
           minLength: 1
+          description: The RocketMQ instance identifier (unique name or numeric id) that owns the traced message.
         msgId:
           type: string
           minLength: 1

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageQueryToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageQueryToolHandlerTest.java
@@ -60,7 +60,7 @@ class MessageQueryToolHandlerTest {
         when(messageService.queryMessages(eq("instance-a"), eq("TopicA"), any(), any(), any(), any(), any()))
                 .thenReturn(List.of(message));
 
-        Object result = handler.execute(Map.of("cluster", "instance-a", "topic", "TopicA"));
+        Object result = handler.execute(Map.of("instance", "instance-a", "topic", "TopicA"));
 
         assertThat(result).isInstanceOf(List.class);
         List<?> rows = (List<?>) result;
@@ -79,7 +79,7 @@ class MessageQueryToolHandlerTest {
         when(messageService.queryMessages(any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(List.of());
 
-        handler.execute(Map.of("cluster", "instance-a", "topic", "TopicA",
+        handler.execute(Map.of("instance", "instance-a", "topic", "TopicA",
                 "startTime", 1000L, "endTime", 2000L));
 
         verify(messageService)
@@ -93,7 +93,7 @@ class MessageQueryToolHandlerTest {
 
         org.assertj.core.api.Assertions.assertThatThrownBy(
                         () -> handler.execute(Map.of(
-                                "cluster", "instance-a", "topic", "TopicA", "startTime", overflow)))
+                                "instance", "instance-a", "topic", "TopicA", "startTime", overflow)))
                 .isInstanceOf(org.apache.rocketmq.studio.common.exception.BusinessException.class)
                 .hasMessageContaining("epoch-milliseconds");
     }
@@ -102,7 +102,7 @@ class MessageQueryToolHandlerTest {
     void executeShouldRejectNonFiniteTimestampInsteadOfWrapping() {
         org.assertj.core.api.Assertions.assertThatThrownBy(
                         () -> handler.execute(Map.of(
-                                "cluster", "instance-a", "topic", "TopicA",
+                                "instance", "instance-a", "topic", "TopicA",
                                 "startTime", Double.POSITIVE_INFINITY)))
                 .isInstanceOf(org.apache.rocketmq.studio.common.exception.BusinessException.class)
                 .hasMessageContaining("epoch-milliseconds");
@@ -112,7 +112,7 @@ class MessageQueryToolHandlerTest {
     void executeShouldRejectNonNumericTimestamp() {
         org.assertj.core.api.Assertions.assertThatThrownBy(
                         () -> handler.execute(Map.of(
-                                "cluster", "instance-a", "topic", "TopicA",
+                                "instance", "instance-a", "topic", "TopicA",
                                 "startTime", "not-a-number")))
                 .isInstanceOf(org.apache.rocketmq.studio.common.exception.BusinessException.class)
                 .hasMessageContaining("epoch-milliseconds");
@@ -123,7 +123,7 @@ class MessageQueryToolHandlerTest {
         when(messageService.queryMessages(any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(List.of());
 
-        handler.execute(Map.of("cluster", "instance-a", "topic", "TopicA",
+        handler.execute(Map.of("instance", "instance-a", "topic", "TopicA",
                 "startTime", java.math.BigInteger.valueOf(123456789L)));
 
         verify(messageService)

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandlerTest.java
@@ -65,7 +65,7 @@ class MessageTraceToolHandlerTest {
                 .thenReturn(trace);
 
         Object result = handler.execute(Map.of(
-                "cluster", "instance-a", "msgId", "msg-1", "topic", "TopicA"));
+                "instance", "instance-a", "msgId", "msg-1", "topic", "TopicA"));
 
         assertThat(result).isInstanceOf(Map.class);
         Map<?, ?> row = (Map<?, ?>) result;

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolCatalogTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolCatalogTest.java
@@ -86,6 +86,22 @@ class ToolCatalogTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void messageToolInputsAreInstanceAddressed() {
+        for (String name : List.of("rmq.message.query", "rmq.message.trace")) {
+            ToolDefinition tool = ToolCatalog.load(canonicalCatalog(), canonicalSchema())
+                    .find(name)
+                    .orElseThrow();
+            List<String> required = (List<String>) tool.inputSchema().get("required");
+            assertThat(required).contains("instance").doesNotContain("cluster");
+            Map<String, Object> properties =
+                    (Map<String, Object>) tool.inputSchema().get("properties");
+            Map<String, Object> instance = (Map<String, Object>) properties.get("instance");
+            assertThat((String) instance.get("description")).contains("instance");
+        }
+    }
+
+    @Test
     void rejectsIncompatibleMinimumClientMajorVersion() {
         Resource incompatible = utf8Resource("""
                 version: 2.0.0

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
@@ -32,6 +32,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.message.MessageService;
+import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
 import org.apache.rocketmq.studio.instance.topic.MetadataService;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
 import org.apache.rocketmq.studio.ops.ai.AiToolVO;
@@ -616,10 +617,34 @@ class ToolGatewayServiceTest {
         AuthenticatedUserContext.setUser(2L, "reader", false);
 
         assertThatThrownBy(() -> gateway.execute(
-                "rmq.message.query", Map.of("cluster", "cluster-v5")))
+                "rmq.message.query", Map.of("instance", "cluster-v5")))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Admin permission required");
         verifyNoInteractions(messageService);
+    }
+
+    @Test
+    void messageQueryToolTargetsTheInstanceNamedByItsInput() {
+        when(messageService.queryMessages(
+                "inst-1", "TopicA", null, null, null, null, null)).thenReturn(List.of());
+
+        gateway.execute(
+                "rmq.message.query", Map.of("instance", "inst-1", "topic", "TopicA"));
+
+        verify(messageService).queryMessages("inst-1", "TopicA", null, null, null, null, null);
+    }
+
+    @Test
+    void messageTraceToolTargetsTheInstanceNamedByItsInput() {
+        when(messageService.getMessageTrace("inst-1", "msg-1", null))
+                .thenReturn(TraceRecordVO.builder()
+                        .nodes(List.of())
+                        .consumerStatus(List.of())
+                        .build());
+
+        gateway.execute("rmq.message.trace", Map.of("instance", "inst-1", "msgId", "msg-1"));
+
+        verify(messageService).getMessageTrace("inst-1", "msg-1", null);
     }
 
     @Test

--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -456,6 +456,32 @@ describe('AiPage tool runner', () => {
     expect(within(dialog).getByTestId('tool-result')).toHaveTextContent('"GRPC"');
   });
 
+  it('does not prefill the selected cluster id into instance-addressed tools', async () => {
+    vi.mocked(listTools).mockResolvedValue([
+      {
+        name: 'rmq.message.query',
+        description: 'Query messages in a RocketMQ instance.',
+        parameters: {
+          type: 'object',
+          required: ['instance'],
+          properties: { instance: { type: 'string' }, topic: { type: 'string' } },
+        },
+        riskLevel: 'L1',
+        permission: 'message:read',
+      },
+    ]);
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: '工具' }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'AI 工具' });
+    await waitFor(() => expect(listTools).toHaveBeenCalledWith('cluster-a'));
+
+    const input = within(dialog).getByRole('textbox', { name: '工具参数 JSON' });
+    expect(input).toHaveValue('{\n  "instance": ""\n}');
+  });
+
   it('ignores an older tool catalog after the cluster changes', async () => {
     const oldTools = [{ name: 'rmq.old', description: 'old', parameters: {} }];
     const latestTools = [{ name: 'rmq.latest', description: 'latest', parameters: {} }];


### PR DESCRIPTION
Fixes #4256.

## Problem / Evidence

`rmq.message.query` and `rmq.message.trace` read their `cluster` input into the instance-id slot (`MessageQueryToolHandler.java:48`, `MessageTraceToolHandler.java:47`) and pass it to `MessageService`, which resolves a registered instance via `providerRegistry.byInstanceId` → `RuntimeAdminClientResolver.resolveInstance` → `instanceRepository.findByIdentifier` (unique instance name or numeric id). The consumers of these tools supply a cluster id instead:

- the AI page's tool dialog prefills every field named `cluster` with the selected cluster id (`buildToolInputTemplate` ← `listClusters()` → `cluster.id`);
- no tool output exposes an instance id, so the model cannot know one either;
- the catalog declares no description for the field, and `requiredCapabilities: []` skips the gateway's capability check, so the wrong value flows straight to the handler.

Result: opening the AI tool dialog for `rmq.message.query` prefills `"cluster": "<clusterId>"` and every run fails with `404 Instance not found: <clusterId>` — the same failure mode commit 206314b9 (#4115) recorded and fixed for the two list tools, whose cluster-scoped branches the message tools do not have.

## Root cause / Fix

The two runtime tools were the only tools whose required input names a different entity than the field name implies. This change gives them an honest contract:

- `rmq-tools.yaml`: the two tools' required input is renamed `cluster` → `instance`, with a description naming the expected identifier (unique name or numeric id).
- both handlers read `instance`.
- `ToolCatalog.validateClusterConvention` now accepts `cluster` or `instance` as the declared target field, so the "every remote tool declares what it is addressed by" invariant keeps holding for instance-addressed runtime tools; `ToolGatewayService.requiresCluster` (renamed `requiresTargetContext`) applies the same rule so discovery keeps hiding the message tools until a cluster context resolves.
- the AI page needs no code change: a required field no longer named `cluster` simply stops receiving the cluster id; a test pins that.

## Priority & scoring

PRIORITY 72 = impact 27 (both message tools unusable from the manual tool dialog — every run fails with a misleading 404 — and the catalog contract actively misleads chat runs) + scope 12 (two handlers, their catalog entries, one validation predicate) + reproducibility 18 (deterministic UI repro, covered by regression tests at catalog, gateway and UI-template layers) + maintenance value 15 (aligns the tool framework with its own runtime tools; unblocks the message-tool improvement line around #4148). FIX_CONFIDENCE 85: deterministic behavior, verified red→green at three layers; the residual chat-mode limitation (the model must ask the operator for the instance identifier when unknown) is inherent to the deployment model and stated in the Risk section for the maintainer to weigh.

## Tests

- New `ToolCatalogTest.messageToolInputsAreInstanceAddressed` asserts the two tools require `instance` (not `cluster`) and describe it.
- New `ToolGatewayServiceTest.messageQueryToolTargetsTheInstanceNamedByItsInput` / `messageTraceToolTargetsTheInstanceNamedByItsInput` execute both tools through the real gateway with an `instance` input and verify `MessageService` delegation.
- Red on the unfixed code: `Tests run: 43, Failures: 2, Errors: 2` — (a) new `ToolCatalogTest.messageToolInputsAreInstanceAddressed` failed (the canonical catalog still requires `cluster`); (b) the two new gateway contract tests errored with `BusinessException: Tool input validation failed for rmq.message.query: [: required property 'cluster' not found, : property 'instance' is not defined…]`; (c) the existing reader-permission test, re-keyed to `instance` as part of the contract sync, failed under the baseline schema's validation error instead of reaching the permission check.
- Green after the change: `ToolCatalogTest` 7/7, `ToolGatewayServiceTest` 36/36, `MessageQueryToolHandlerTest` 6/6, `MessageTraceToolHandlerTest` 1/1 (re-run after the final commit: `Tests run: 50, Failures: 0`).
- Full server suite `mvn -o test`: 2154 tests, 2 failures = the standing baseline set (`AuthCorsIntegrationTest` ×2), i.e. 2151 baseline + 3 new tests with zero new failures.
- Web: new `AiPage` test pins that an instance-addressed tool's template is `{"instance": ""}` — never the selected cluster id (`AiPage.test.tsx` 18/18). Full `npx vitest run`: 982 tests, 3 failures all in untouched files (`ClusterPage` ×1, `ConsumerPage` ×2 — known load-fragile under the parallel suite); both files re-run in isolation: 56/56 pass. `npx tsc -b` clean, `npx eslint .` 0 errors, `npx vite build` succeeds.

## Risk

The input contract of the two tools changes (old `cluster`-keyed payloads are rejected by input validation with an explicit error instead of failing later with a misleading 404 — no working consumer can be affected since the old path never succeeded). The framework's target-field invariant is relaxed to accept `instance`; `ToolGatewayService.enforceCapabilities` still reads the `cluster` field for capability checks, which remains unreachable for these tools (`requiredCapabilities: []`) but is flagged here as a coupling to revisit if capabilities are ever required of the message tools. In chat mode the model must obtain the instance identifier from the operator when unknown; the field description now states what is expected.

Head: 4f78b5ab (fix/ai-message-tool-instance-input, 1 commit).

