### PR TITLE
fix(metadata): treat client-reported offline and broadcast groups as empty results

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -728,8 +728,20 @@ public class RocketMQMetadataProvider implements MetadataProvider {
             return brokerException.getResponseCode()
                     == org.apache.rocketmq.remoting.protocol.ResponseCode.CONSUMER_NOT_ONLINE;
         }
+        // rocketmq-tools grades these business states as MQClientException, so the typed code
+        // only survives in the message text: examineConsumerConnectionInfo throws
+        // CONSUMER_NOT_ONLINE for a group whose clients all disconnected, and
+        // examineConsumeStats throws BROADCAST_CONSUMPTION for a broadcast group with an
+        // empty offset table. Both mean "no live data", not a connectivity failure
+        // (same grading as RocketMQClientProvider.isGroupConnectionAbsent).
+        if (MqResponseCodes.hasResponseCode(e,
+                org.apache.rocketmq.remoting.protocol.ResponseCode.CONSUMER_NOT_ONLINE,
+                org.apache.rocketmq.remoting.protocol.ResponseCode.BROADCAST_CONSUMPTION)) {
+            return true;
+        }
         String message = e.getMessage();
-        return message != null && message.contains("not online");
+        return message != null && (message.contains("not online")
+                || message.contains("Not found the consumer group connection"));
     }
 
     // ── Helper methods ──────────────────────────────────────────────────

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
@@ -543,6 +543,21 @@ class RocketMQMetadataProviderTest {
     }
 
     @Test
+    void getGroupProgressShouldReturnEmptyForBroadcastGroupTest() throws Exception {
+        DefaultMQAdminExt admin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        // rocketmq-tools examineConsumeStats throws MQClientException(BROADCAST_CONSUMPTION)
+        // for a broadcast group with an empty offset table; the code only survives in the
+        // message text ("CODE: 213  DESC: ... the consumer is under the broadcast mode").
+        when(admin.examineConsumeStats("group-broadcast")).thenThrow(
+                new org.apache.rocketmq.client.exception.MQClientException(
+                        org.apache.rocketmq.remoting.protocol.ResponseCode.BROADCAST_CONSUMPTION,
+                        "Not found the consumer group consume stats, because return offset table is empty, "
+                                + "the consumer is under the broadcast mode"));
+
+        assertThat(newLiveProvider(admin).getGroupProgress(null, "group-broadcast")).isEmpty();
+    }
+
+    @Test
     void getGroupSubscriptionsSurfacesAdminFailure() throws Exception {
         DefaultMQAdminExt admin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
         when(admin.examineConsumerConnectionInfo("group-a"))
@@ -612,6 +627,20 @@ class RocketMQMetadataProviderTest {
                         "the consumer group[group-proxy] not online BROKER: 10.0.0.11:10911"));
 
         assertThat(newLiveProvider(admin).getGroupSubscriptions(null, "group-proxy")).isEmpty();
+    }
+
+    @Test
+    void getGroupSubscriptionsShouldReturnEmptyWhenClientReportsGroupOfflineTest() throws Exception {
+        DefaultMQAdminExt admin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        // rocketmq-tools examineConsumerConnectionInfo throws MQClientException(CONSUMER_NOT_ONLINE)
+        // when the broker returns an empty connection set; the typed code only survives in the
+        // message text ("CODE: 206  DESC: Not found the consumer group connection ...").
+        when(admin.examineConsumerConnectionInfo("group-offline")).thenThrow(
+                new org.apache.rocketmq.client.exception.MQClientException(
+                        org.apache.rocketmq.remoting.protocol.ResponseCode.CONSUMER_NOT_ONLINE,
+                        "Not found the consumer group connection"));
+
+        assertThat(newLiveProvider(admin).getGroupSubscriptions(null, "group-offline")).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Fixes #4258.

## Problem / Evidence

On the Apache vendor path, two ordinary group states make the consumer group detail drawer fail with HTTP 502 instead of showing empty live data:

- **Every client of the group disconnected** (consumer stopped, app restarted): the drawer's subscriptions call (`web/src/pages/instance/consumer.tsx:415` → `MetadataService.getGroupSubscriptions` → `RocketMQMetadataProvider.getGroupSubscriptions`) fails with **502 "Failed to get subscriptions for group X: CODE: 206  DESC: Not found the consumer group connection ..."**. rocketmq-tools 5.5.0 bytecode (`DefaultMQAdminExtImpl.examineConsumerConnectionInfo`) throws `MQClientException(206, "Not found the consumer group connection")` when the broker returns an empty connection set.
- **Broadcast-mode group**: the drawer's progress call (`consumer.tsx:435` → `getGroupProgress`) fails with **502 "Failed to get progress for group X: CODE: 213  DESC: Not found the consumer group consume stats, because return offset table is empty, the consumer is under the broadcast mode ..."**. Bytecode confirms tools throws `MQClientException(213, ...)` for that state.

Root cause: `RocketMQMetadataProvider.isGroupNotOnline` (RocketMQMetadataProvider.java:726-733 at 6c24d2ed) only matched `MQBrokerException(CONSUMER_NOT_ONLINE)` or a message containing `"not online"` — neither tool-thrown variant matches, so both fall through to `BusinessException(502, ...)`.

## Root cause / Fix

`isGroupNotOnline` now also consults `MqResponseCodes.hasResponseCode(e, CONSUMER_NOT_ONLINE, BROADCAST_CONSUMPTION)` and matches the `"Not found the consumer group connection"` message — the same grading `RocketMQClientProvider.isGroupConnectionAbsent` (merged for #4006) already applies on the clients page. The subscriptions path keeps its existing behavior for graded states (proxy fallback first, then an empty list); the progress path returns an empty list, exactly like its existing not-online branch.

## Priority & scoring

PRIORITY 74 = 影响 30（详情抽屉订阅/进度两个标签页对正常业务状态硬失败 502，无可用 workaround）+ 波及 13（Apache vendor 的消费组详情两个端点）+ 可复现 18（停掉消费者或使用广播消费即 100% 复现）+ 维护价值 13（#4006 已修孪生副本，谓词漂移应收敛）。FIX_CONFIDENCE 90：字节码级证实异常形态、同文件已有 not-online 分级语义、兄弟 provider 已有同款谓词。

## Tests

- New regressions (red on 6c24d2ed, actual output): `RocketMQMetadataProviderTest.getGroupSubscriptionsShouldReturnEmptyWhenClientReportsGroupOfflineTest` → `BusinessException: Failed to get subscriptions for group group-offline: CODE: 206  DESC: Not found the consumer group connection ...`; `getGroupProgressShouldReturnEmptyForBroadcastGroupTest` → `Failed to get progress for group group-broadcast: CODE: 213  DESC: ... the consumer is under the broadcast mode ...`. Both assert empty results and pass after the fix.
- Module suite: `mvn -o test -Dtest='RocketMQMetadataProviderTest,RocketMQAdminClientImplTest,RocketMQClientProviderTest,MetadataServiceTest'` → 151/151 passed.
- Full backend suite on this branch (`mvn -o test`): **2153 tests, 3 failures** = the pristine 6c24d2ed baseline set (AuthCorsIntegrationTest ×2 + the load-fragile `OpenAiCompatibleLlmGatewayTest.successfulAndFailedStreamsEmitOneTerminalSequence`, isolated-passing in prior rounds); 2153 = baseline 2151 + 2 new regressions. Zero new failures.

## Risk

Low: the predicate only widens the "no live data" grading; genuine connectivity failures (`IllegalStateException`, timeouts, topic routes unrelated to the group) still surface as 502 (covered by the existing `getGroupProgressSurfacesAdminFailure` / `getGroupSubscriptionsSurfacesAdminFailure` tests, still green). Cloud providers are untouched.
