### PR TITLE
fix(group): grade never-connected and broadcast groups as offline states

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -34,6 +34,7 @@ import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfi
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.MqClientPool;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.util.MqResponseCodes;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
@@ -236,7 +237,16 @@ public class RocketMQAdminClientImpl implements AdminClient {
                 && brokerException.getResponseCode() == ResponseCode.CONSUMER_NOT_ONLINE) {
             return true;
         }
+        // rocketmq-tools locates a group through the %RETRY%<group> topic route before any
+        // broker call, so a group that never connected fails with TOPIC_NOT_EXIST for that
+        // retry topic, and a broadcast group with an empty offset table fails with
+        // BROADCAST_CONSUMPTION. Both mean "no live data", not a lookup failure.
         String message = exception.getMessage();
+        if (MqResponseCodes.hasResponseCode(exception, ResponseCode.BROADCAST_CONSUMPTION)
+                || MqResponseCodes.hasResponseCode(exception, ResponseCode.TOPIC_NOT_EXIST)
+                        && message != null && message.contains("%RETRY%")) {
+            return true;
+        }
         return message != null && (message.contains("not online") || message.contains("CODE: 206"));
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
@@ -176,6 +176,21 @@ class RocketMQAdminClientImplTest {
     }
 
     @Test
+    void getConsumerGroupReturnsOfflineDetailForGroupWithoutRetryRouteTest() throws Exception {
+        // rocketmq-tools examineConsumerConnectionInfo locates the group through the
+        // %RETRY%<group> route, so a group created but never connected fails with
+        // TOPIC_NOT_EXIST for that retry topic before any broker is contacted.
+        when(adminExt.examineConsumerConnectionInfo("orders")).thenThrow(
+                new MQClientException(ResponseCode.TOPIC_NOT_EXIST,
+                        "No topic route info in name server for the topic: %RETRY%orders"));
+
+        ConsumerGroupVO group = adminClient.getConsumerGroup(null, "orders");
+
+        assertThat(group.getName()).isEqualTo("orders");
+        assertThat(group.getOnlineInstances()).isZero();
+    }
+
+    @Test
     void getConsumerGroupFillsProxySideConnectionsWhenBrokerReportsOfflineTest() throws Exception {
         when(adminExt.examineConsumerConnectionInfo("orders"))
                 .thenThrow(new MQClientException(
@@ -420,6 +435,45 @@ class RocketMQAdminClientImplTest {
         assertThat(preview.isAllowReset()).isFalse();
         assertThat(preview.getQueueCount()).isZero();
         assertThat(preview.getWarnings()).containsExactly("No consume offset data found for topic orders");
+        verify(adminExt, never()).resetOffsetByTimestamp(anyString(), anyString(), anyString(),
+                anyLong(), anyBoolean());
+    }
+
+    @Test
+    void previewResetOffsetShouldReturnEmptyPreviewForGroupWithoutRetryRouteTest() throws Exception {
+        when(adminExt.examineConsumeStats("cg-orders")).thenThrow(
+                new MQClientException(ResponseCode.TOPIC_NOT_EXIST,
+                        "No topic route info in name server for the topic: %RETRY%cg-orders"));
+
+        ResetConsumerOffsetPreviewVO preview = adminClient.previewResetOffset(
+                null, "cg-orders", 1784246400000L, "orders");
+
+        assertThat(preview.isComplete()).isFalse();
+        assertThat(preview.isAllowReset()).isFalse();
+        assertThat(preview.getQueueCount()).isZero();
+        assertThat(preview.getWarnings())
+                .containsExactly("Consumer group is not online and no consume offset data is available");
+        verify(adminExt, never()).resetOffsetByTimestamp(anyString(), anyString(), anyString(),
+                anyLong(), anyBoolean());
+    }
+
+    @Test
+    void previewResetOffsetShouldReturnEmptyPreviewForBroadcastGroupTest() throws Exception {
+        // rocketmq-tools examineConsumeStats grades a broadcast group's empty offset table as
+        // MQClientException(BROADCAST_CONSUMPTION); the code only survives in the message text.
+        when(adminExt.examineConsumeStats("cg-orders")).thenThrow(
+                new MQClientException(ResponseCode.BROADCAST_CONSUMPTION,
+                        "Not found the consumer group consume stats, because return offset table is empty, "
+                                + "the consumer is under the broadcast mode"));
+
+        ResetConsumerOffsetPreviewVO preview = adminClient.previewResetOffset(
+                null, "cg-orders", 1784246400000L, "orders");
+
+        assertThat(preview.isComplete()).isFalse();
+        assertThat(preview.isAllowReset()).isFalse();
+        assertThat(preview.getQueueCount()).isZero();
+        assertThat(preview.getWarnings())
+                .containsExactly("Consumer group is not online and no consume offset data is available");
         verify(adminExt, never()).resetOffsetByTimestamp(anyString(), anyString(), anyString(),
                 anyLong(), anyBoolean());
     }


### PR DESCRIPTION
Fixes #4260.

## Problem / Evidence

On the Apache vendor path, `RocketMQAdminClientImpl` treats two ordinary group states as hard failures:

- **Group created but never connected** (no clients yet, so `%RETRY%<group>` has no route): the group detail endpoint (`MetadataService.getConsumerGroup` → `RocketMQAdminClientImpl.getConsumerGroup`) returns **502 "Failed to get consumer group: CODE: 17  DESC: No topic route info in name server for the topic: %RETRY%<group> ..."**. Creating a consumer group in Studio and immediately opening its detail hits this 100% of the time.
- **Reset-offset preview for that group, or for a broadcast-mode group**: returns **500 "Failed to preview reset offset: CODE: 17/213  DESC: ..."** — blocking the preview-first reset flow.

Bytecode basis (rocketmq-tools 5.5.0): `examineConsumerConnectionInfo`/`examineConsumeStats` locate the group through `MixAll.getRetryTopic(group)` via `examineTopicRouteInfo` → `MQClientAPIImpl.getTopicRouteInfoFromNameServer`, which throws `MQClientException(TOPIC_NOT_EXIST=17, nameserver remark "No topic route info in name server for the topic: ...")`; a broadcast group's empty offset table throws `MQClientException(BROADCAST_CONSUMPTION=213, "... the consumer is under the broadcast mode")`.

Root cause: `isConsumerNotOnline` (RocketMQAdminClientImpl.java:234-241 at 6c24d2ed) only matched `MQBrokerException(CONSUMER_NOT_ONLINE)` or messages containing `"not online"` / `"CODE: 206"` — neither variant matches.

## Root cause / Fix

`isConsumerNotOnline` now also grades `BROADCAST_CONSUMPTION` and a `TOPIC_NOT_EXIST` whose message names the group's `%RETRY%` topic (via `MqResponseCodes.hasResponseCode`) as not-online states. `getConsumerGroup` then keeps its existing offline semantics (proxy fallback, then zero defaults); `doPreviewResetOffset` returns its existing empty "not online" preview.

## Priority & scoring

PRIORITY 74 = 影响 30（Studio 内创建消费组后立即打开详情 100% 得 502；重置位点预览对未连接/广播组 500，阻断 preview-first 流程）+ 波及 13（消费组详情与重置预览两个端点）+ 可复现 18（新建组即触发，确定性）+ 维护价值 13（#4006 孪生家族第三处漂移副本，ensureRetryTopicExists javadoc 已自证该失败模式）。FIX_CONFIDENCE 88：字节码级证实异常形态与消息文本，同文件已有 not-online 分级语义。

## Tests

- New regressions (red on 6c24d2ed, actual output): `getConsumerGroupReturnsOfflineDetailForGroupWithoutRetryRouteTest` → `Failed to get consumer group: CODE: 17  DESC: No topic route info in name server for the topic: %RETRY%orders`; `previewResetOffsetShouldReturnEmptyPreviewForGroupWithoutRetryRouteTest` → `Failed to preview reset offset: CODE: 17  DESC: ... %RETRY%cg-orders`; `previewResetOffsetShouldReturnEmptyPreviewForBroadcastGroupTest` → `Failed to preview reset offset: CODE: 213  DESC: ... the consumer is under the broadcast mode`. Summary `Tests run: 49, Failures: 0, Errors: 3`; all three assert the offline/empty shapes and pass after the fix.
- Module suite: `RocketMQAdminClientImplTest` 49/49, `RocketMQMetadataProviderTest` 40/40, `RocketMQClientProviderTest` 27/27, `MetadataServiceTest` 36/36 = **152/152**.
- Full backend suite on this branch (`mvn -o test`): **2154 tests, 3 failures** = the pristine 6c24d2ed baseline set (AuthCorsIntegrationTest ×2 + load-fragile `OpenAiCompatibleLlmGatewayTest.successfulAndFailedStreamsEmitOneTerminalSequence`); 2154 = baseline 2151 + 3 new regressions. Zero new failures.

## Risk

Low: the predicate only widens the not-online grading; the `%RETRY%` message guard keeps unrelated TOPIC_NOT_EXIST failures (e.g. a reset target topic without a route, surfaced through other calls) outside the grading. Genuine broker failures still throw (existing admin-failure tests stay green). The empty preview's reason string says "not online" for broadcast groups too — the shown state (no offset data) is correct; the wording is kept minimal.
