### PR TITLE
fix(studio): export users against the committed search term

### DIFF
--- a/web/src/pages/studio/UserManagement.tsx
+++ b/web/src/pages/studio/UserManagement.tsx
@@ -265,7 +265,9 @@ const UserManagementPage = () => {
     setUserExporting(true);
     try {
       const exportedUsers = await exportStudioUsers({
-        search: search.trim() || undefined,
+        // The table only ever shows the debounced (committed) search; exporting the live
+        // input would produce a CSV for a query the user never saw displayed.
+        search: debouncedSearch || undefined,
         admin: roleFilter === undefined ? undefined : roleFilter === 'admin',
         enabled: statusFilter === undefined ? undefined : statusFilter === 'enabled',
       });
@@ -279,7 +281,7 @@ const UserManagementPage = () => {
       message.error('导出用户列表失败，请稍后重试');
     }
     setUserExporting(false);
-  }, [admin, roleFilter, search, statusFilter]);
+  }, [admin, debouncedSearch, roleFilter, statusFilter]);
   // Declared widths total 1116px, which stays inside the usable content width of a normal
   // 1440px viewport (220px Sider plus page and Card padding), so the table does not show a
   // horizontal scrollbar by default. Columns whose text can be longer than that truncate with

--- a/web/src/pages/studio/__tests__/UserManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/UserManagement.test.tsx
@@ -184,6 +184,42 @@ describe('UserManagementPage', () => {
     expect(exportedCsv).toContain('"2"');
   });
 
+  it('exports users matching the committed search, not live input', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    renderPage();
+    await screen.findByText('operator');
+
+    await user.type(screen.getByPlaceholderText('搜索用户名'), 'alpha');
+    await waitFor(() =>
+      expect(listStudioUsers).toHaveBeenLastCalledWith(
+        expect.objectContaining({ search: 'alpha' }),
+      ),
+    );
+
+    // Refine the input and export within the same synchronous block so the 300 ms
+    // debounce cannot commit the new term in between: the CSV must match the query
+    // the displayed table was loaded with, not the uncommitted live input.
+    const searchInput = screen.getByPlaceholderText('搜索用户名');
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: 'alpha-beta' } });
+      fireEvent.click(screen.getByRole('button', { name: '导出' }));
+    });
+
+    await waitFor(() =>
+      expect(downloadStudioUsers).toHaveBeenCalledWith({
+        search: 'alpha',
+        admin: undefined,
+        enabled: undefined,
+      }),
+    );
+    expect(downloadStudioUsers).not.toHaveBeenCalledWith({
+      search: 'alpha-beta',
+      admin: undefined,
+      enabled: undefined,
+    });
+    expect(downloadCsv).toHaveBeenCalledTimes(1);
+  });
+
   it('renders active session metadata and revokes sessions after confirmation', async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     renderPage();


### PR DESCRIPTION
Fixes #4262.

## Problem / Evidence

The studio user inventory loads its table from a debounced (committed) search (`listStudioUsers` receives `search: debouncedSearch || undefined`, UserManagement.tsx:134), but the "导出" (export) button rebuilt its query from the **live** input value (`search: search.trim() || undefined`, UserManagement.tsx:268, with the live `search` in its dependency array at line 282). Typing a refinement and clicking export within the 300 ms debounce window - or while the matching refetch is still in flight - downloaded a CSV for a search the displayed table never showed.

Regression test red on 6c24d2ed: after the debounce settles on `alpha`, refining the input to `alpha-beta` and exporting synchronously makes the export API receive `search: "alpha-beta"` while the table still shows the `alpha` results. Sibling pages already do this correctly: `ops/audit.tsx` exports from `debouncedSearchText`, `settings/CloudCredentialTab.tsx` and `settings/DataSourceTab.tsx` from their `debouncedSearch`.

## Root cause / Fix

`handleExportUsers` now sends `search: debouncedSearch || undefined` - the committed value the visible table was loaded with - and reads `debouncedSearch` (instead of `search`) in its dependency array. This is the export-side twin of the committed-query semantics established by #4005 for the message page pagination.

## Priority & scoring

PRIORITY 70 = 影响 26（导出物是本页的审计/清单工件，内容与用户所见列表不一致且静默发生）+ 波及 11（仅本页导出按钮）+ 可复现 18（防抖窗口内"输入→导出"是常规操作序列，确定性复现）+ 维护价值 15（#4005 既有语义的导出孪生，三个兄弟页已正确，一致性收敛）。FIX_CONFIDENCE 95：单值替换 + 依赖数组同步，行为由兄弟页与既有测试共同锚定。

## Tests

- New regression `UserManagementPage > exports users matching the committed search, not live input` is deterministic: after the committed search is awaited, the refinement and the export click run inside one synchronous `act` block so the 300 ms debounce cannot commit in between (a first draft that raced the real 300 ms timer proved load-fragile under the full suite and was rewritten before commit). Red on unfixed code (`Tests run: 7, 1 failed` - export received `alpha-beta`) and green after the fix (`7 passed`), verified by stashing the fix.
- Module suite: `UserManagement.test.tsx` **7/7 passed** (re-run after the lint-staged reformat).
- Full web suite on this branch (`npx vitest run`): **982 tests, 979 passed, 3 failures** - all in untouched files from the known load-fragile family (`MetricsExplorer.test.tsx` ×1, `ConsumerPage.test.tsx` ×2); both files pass isolated (**25/25** and **31/31**). My test passes in the full run.
- `tsc -b` clean, `eslint` clean on both touched files, `npm run build` succeeds (built in 9.67s).

## Risk

Low: one-value change scoped to the export handler; filtering semantics (`admin`/`enabled`) untouched. Users who typed a new term and waited for the table to refresh see identical behavior; only the stale-window export changes, from "unseen query" to "displayed query".
