### PR TITLE
fix(metrics): re-run the custom query when the dashboard instance changes

### DIFF
--- a/web/src/components/MetricsExplorer.tsx
+++ b/web/src/components/MetricsExplorer.tsx
@@ -844,6 +844,30 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
     appliedCustomPromql,
   ]);
 
+  // The dashboard keeps this explorer mounted and only swaps the instanceId prop. The
+  // reload effect re-runs the profile panels via loadAll, but nothing re-runs the custom
+  // query panel, so it would keep showing the previous instance's chart (or error) under
+  // the new instance. Re-run the committed custom query on the instance transition; when
+  // the selected data source drops out of the new instance's scope, the fallback effect
+  // above already re-runs both flows, so skip to avoid duplicating its request.
+  const lastInstanceIdRef = useRef(instanceId);
+  useEffect(() => {
+    if (lastInstanceIdRef.current === instanceId) return;
+    lastInstanceIdRef.current = instanceId;
+    if (!appliedCustomPromql) return;
+    if (dataSourceKey && !availableDataSources.some((source) => source.key === dataSourceKey)) {
+      return;
+    }
+    void runCustomQuery(appliedCustomPromql, selectedRange);
+  }, [
+    instanceId,
+    appliedCustomPromql,
+    runCustomQuery,
+    selectedRange,
+    dataSourceKey,
+    availableDataSources,
+  ]);
+
   const pendingAuthMode = pendingDataSource
     ? getDataSourceAuthMode(pendingDataSource.auth)
     : 'none';

--- a/web/src/components/__tests__/MetricsExplorer.test.tsx
+++ b/web/src/components/__tests__/MetricsExplorer.test.tsx
@@ -331,6 +331,41 @@ describe('MetricsExplorer', () => {
     expect(await screen.findAllByText('cluster=prod / node_id=broker-a')).not.toHaveLength(0);
   });
 
+  it('re-runs the committed custom query when the dashboard instance changes', async () => {
+    const user = userEvent.setup();
+    const view = renderWithProviders(<MetricsExplorer instanceId="instance-11" />);
+    await screen.findByRole('img', { name: 'Message In TPS time series' });
+
+    await user.type(screen.getByLabelText('自定义查询'), 'sum(rocketmq_topic_number)');
+    await user.click(screen.getByRole('button', { name: '查询' }));
+    await waitFor(() =>
+      expect(
+        vi
+          .mocked(queryMetrics)
+          .mock.calls.filter((call) => call[0].metric === 'sum(rocketmq_topic_number)'),
+      ).toHaveLength(1),
+    );
+
+    // The dashboard keeps the explorer mounted and only swaps the instanceId prop;
+    // the profile panels re-run via loadAll, so the custom panel must re-run too
+    // instead of keeping the previous instance's chart on screen.
+    view.rerender(
+      <App>
+        <LangProvider>
+          <MetricsExplorer instanceId="instance-22" />
+        </LangProvider>
+      </App>,
+    );
+
+    await waitFor(() =>
+      expect(
+        vi
+          .mocked(queryMetrics)
+          .mock.calls.filter((call) => call[0].metric === 'sum(rocketmq_topic_number)'),
+      ).toHaveLength(2),
+    );
+  });
+
   it('refreshes profile panels and the custom query independently', async () => {
     const user = userEvent.setup();
     renderWithProviders(<MetricsExplorer />);


### PR DESCRIPTION
Fixes #4264.

## Problem / Evidence

The home dashboard mounts one `MetricsExplorer` and only swaps the `instanceId` prop on an instance change (`web/src/pages/home/dashboard.tsx:408`, no `key`). The reload effect (MetricsExplorer.tsx:648-671, keyed on `loadAll`, which changes identity with `instanceId`) re-runs only the profile panels via `loadAll`. Nothing re-runs or clears the **custom query panel**: `runCustomQuery` fires solely from `activateDataSource`, the data-source-scope fallback effect, the refresh button and direct user actions - none of which trigger for an instance change with the default source. The effect cleanup only invalidates in-flight requests (`customRequestIdRef`); the `customPanel` state survives.

Regression test red on 6c24d2ed: run a custom query against `instance-11`, rerender with `instance-22` - the custom expression is never queried again (`queryMetrics` calls for it stay at 1), so the panel keeps rendering the previous instance's chart (or error) under the new instance until the user presses refresh.

## Root cause / Fix

Add a ref-guarded effect that re-runs the committed custom query (`appliedCustomPromql`) with the currently selected range when `instanceId` transitions. It deliberately skips the case where the selected data source drops out of the new instance's scope: the existing fallback effect (lines 822-845) already re-runs both `loadAll` and the custom query there, and skipping avoids duplicating its request. This mirrors the same-file pattern that fallback effect and the merged #3299 guards establish.

## Priority & scoring

PRIORITY 72 = 影响 28（监控面板在实例选择器已切换后仍展示旧实例的自定义查询结果，误导读数，需手动刷新恢复）+ 波及 12（仪表盘自定义查询面板一个面）+ 可复现 18（默认数据源下实例切换 100% 残留）+ 维护价值 14（#3299/#4189 同族治理，文件内已有同款重跑先例）。FIX_CONFIDENCE 85：修复镜像文件内 fallback effect 的既有语义，ref 守卫避免重复请求；与 #4189 的改动行不重叠。

## Tests

- New regression `MetricsExplorer > re-runs the committed custom query when the dashboard instance changes`: red on unfixed code (`Tests 1 failed | 25 passed`) - custom expression queried exactly once after the instance switch; green after the fix (`26 passed`), the second call for the custom expression is asserted.
- Module suite: `MetricsExplorer.test.tsx` **26/26 passed** (re-run after lint-staged reformat), including the pre-existing instance-switch fallback tests that pin the scope-drop path.
- Full web suite on this branch (`npx vitest run`): **982 tests, 980 passed, 2 failures** - both are pre-existing load-fragile cases, not touched by this change's behavior (`MetricsExplorer > restores profile, range, and source from query history`, an existing test that passes isolated in the 26/26 module run; `ConsumerPage > shows group health diagnostics...`, isolated **31/31**). A pristine `npx vitest run` in a clean worktree at 6c24d2ed measures **981 tests / 3 failures** (NotificationDeliveriesPage x1, MetricsExplorer x1, ConsumerPage x1 - the same fragile family; the per-run fragile set varies), so this branch's 982 = 981 pristine + 1 new regression, and my new test passes in the full run.
- `npx tsc -b` clean, `npx eslint` clean on both touched files, `npm run build` succeeds (`✓ built in 10.74s`).

## Risk

Low: the effect only fires on an actual `instanceId` transition (ref-guarded) and only when a custom query is committed. Two interactions are handled explicitly: the scope-drop path stays single-request (guard skips it), and on mount the ref equals the initial instance so no spurious run. If #4189 (range retention on instance switch) merges, the two compose - the custom query then re-runs with the retained range instead of the selected one; at this branch's base both use the selected range.

