### PR TITLE
feat: add Grafana dashboard dependency manifest

### DIFF
--- a/web/src/components/GrafanaDashboardList.tsx
+++ b/web/src/components/GrafanaDashboardList.tsx
@@ -18,7 +18,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, App, Button, Input, Modal, Select, Space, Table, Tag, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { ArrowClockwise, DownloadSimple, Eye } from '@phosphor-icons/react';
+import { ArrowClockwise, DownloadSimple, Eye, Graph } from '@phosphor-icons/react';
 import { useLang } from '../i18n/LangContext';
 import {
   getGrafanaDashboard,
@@ -28,6 +28,7 @@ import {
 } from '../services/grafanaService';
 import type { GrafanaDashboardInfo } from '../api/metrics';
 import { downloadBlob } from '../utils/download';
+import GrafanaDependencyDrawer from './GrafanaDependencyDrawer';
 
 const { Paragraph, Text } = Typography;
 
@@ -49,6 +50,7 @@ export const GrafanaDashboardList: React.FC = () => {
   const exportingAllRef = useRef(false);
   const [exportingUids, setExportingUids] = useState<Set<string>>(() => new Set());
   const [exportingAll, setExportingAll] = useState(false);
+  const [manifestOpen, setManifestOpen] = useState(false);
 
   const tagOptions = useMemo(
     () =>
@@ -242,6 +244,13 @@ export const GrafanaDashboardList: React.FC = () => {
         >
           {t('grafana.exportAll')}
         </Button>
+        <Button
+          icon={<Graph size={16} />}
+          disabled={loading || dashboards.length === 0}
+          onClick={() => setManifestOpen(true)}
+        >
+          {t('grafana.manifestAction')}
+        </Button>
       </Space>
 
       {loadError && (
@@ -298,6 +307,11 @@ export const GrafanaDashboardList: React.FC = () => {
           </Paragraph>
         )}
       </Modal>
+      <GrafanaDependencyDrawer
+        open={manifestOpen}
+        dashboards={dashboards}
+        onClose={() => setManifestOpen(false)}
+      />
     </div>
   );
 };

--- a/web/src/components/GrafanaDependencyDrawer.tsx
+++ b/web/src/components/GrafanaDependencyDrawer.tsx
@@ -1,0 +1,258 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. */
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Card,
+  Checkbox,
+  Col,
+  Drawer,
+  Flex,
+  Input,
+  Row,
+  Space,
+  Statistic,
+  Table,
+  Tag,
+  Typography,
+  message,
+} from 'antd';
+import { DownloadOutlined, ReloadOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import type { GrafanaDashboardInfo } from '../api/metrics';
+import { getGrafanaDashboard } from '../services/grafanaService';
+import { useLang } from '../i18n/LangContext';
+import { buildCsv, downloadCsv } from '../utils/download';
+import {
+  analyzeGrafanaDashboard,
+  buildGrafanaDependencyManifest,
+  filterGrafanaDependencyRows,
+  grafanaDependencyCsvRows,
+  type GrafanaDependencyRow,
+} from './grafanaDependencyManifest';
+
+interface Props {
+  open: boolean;
+  dashboards: GrafanaDashboardInfo[];
+  onClose: () => void;
+}
+
+const loadInBatches = async (dashboards: GrafanaDashboardInfo[], size = 4) => {
+  const rows: GrafanaDependencyRow[] = [];
+  for (let index = 0; index < dashboards.length; index += size) {
+    const batch = dashboards.slice(index, index + size);
+    rows.push(
+      ...(await Promise.all(
+        batch.map(async (info) =>
+          analyzeGrafanaDashboard(info, await getGrafanaDashboard(info.uid)),
+        ),
+      )),
+    );
+  }
+  return rows;
+};
+
+export const GrafanaDependencyDrawer = ({ open, dashboards, onClose }: Props) => {
+  const { t } = useLang();
+  const [rows, setRows] = useState<GrafanaDependencyRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [search, setSearch] = useState('');
+  const [issuesOnly, setIssuesOnly] = useState(false);
+  const manifest = useMemo(() => buildGrafanaDependencyManifest(rows), [rows]);
+  const filtered = useMemo(
+    () => filterGrafanaDependencyRows(manifest.rows, search, issuesOnly),
+    [issuesOnly, manifest.rows, search],
+  );
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      setRows(await loadInBatches(dashboards));
+      setLoaded(true);
+    } catch {
+      message.error(t('grafana.manifestLoadFailed'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const columns: ColumnsType<GrafanaDependencyRow> = [
+    {
+      title: t('grafana.title'),
+      dataIndex: 'title',
+      key: 'title',
+      fixed: 'left',
+      width: 210,
+      render: (title: string, row) => (
+        <Space direction="vertical" size={0}>
+          <Typography.Text strong>{title}</Typography.Text>
+          <Typography.Text code>{row.uid}</Typography.Text>
+        </Space>
+      ),
+    },
+    {
+      title: t('grafana.manifestSchema'),
+      dataIndex: 'schemaVersion',
+      key: 'schemaVersion',
+      width: 90,
+      render: (value: number | null) => value ?? '-',
+    },
+    { title: t('grafana.manifestPanels'), dataIndex: 'panelCount', key: 'panelCount', width: 90 },
+    {
+      title: t('grafana.manifestPanelTypes'),
+      key: 'panelTypes',
+      width: 200,
+      render: (_, row) => (
+        <Space size={[2, 2]} wrap>
+          {row.panelTypes.map((value) => (
+            <Tag key={value}>{value}</Tag>
+          ))}
+        </Space>
+      ),
+    },
+    {
+      title: t('grafana.manifestDataSources'),
+      key: 'dataSources',
+      width: 220,
+      render: (_, row) => row.dataSources.join(', ') || '-',
+    },
+    {
+      title: t('grafana.manifestVariables'),
+      key: 'variables',
+      width: 180,
+      render: (_, row) => row.variableNames.join(', ') || '-',
+    },
+    {
+      title: t('grafana.manifestTargets'),
+      dataIndex: 'targetCount',
+      key: 'targetCount',
+      width: 90,
+    },
+    {
+      title: t('grafana.manifestIssues'),
+      key: 'issues',
+      width: 220,
+      render: (_, row) =>
+        row.issues.length ? (
+          <Space size={[2, 2]} wrap>
+            {row.issues.map((issue) => (
+              <Tag color="orange" key={issue}>
+                {issue}
+              </Tag>
+            ))}
+          </Space>
+        ) : (
+          <Tag color="green">{t('grafana.manifestReady')}</Tag>
+        ),
+    },
+  ];
+
+  const exportRows = () => {
+    const data = grafanaDependencyCsvRows(filtered);
+    const csv = buildCsv(
+      [
+        { header: 'UID', value: (row) => row.uid },
+        { header: 'Title', value: (row) => row.title },
+        { header: 'Schema version', value: (row) => row.schemaVersion },
+        { header: 'Panels', value: (row) => row.panels },
+        { header: 'Panel types', value: (row) => row.panelTypes },
+        { header: 'Data sources', value: (row) => row.dataSources },
+        { header: 'Variables', value: (row) => row.variables },
+        { header: 'Variable types', value: (row) => row.variableTypes },
+        { header: 'Targets', value: (row) => row.targets },
+        { header: 'Transformations', value: (row) => row.transformations },
+        { header: 'Library panels', value: (row) => row.libraryPanels },
+        { header: 'Repeated panels', value: (row) => row.repeatedPanels },
+        { header: 'Alerts', value: (row) => row.alerts },
+        { header: 'Issues', value: (row) => row.issues },
+      ],
+      data,
+    );
+    downloadCsv(`rocketmq-grafana-dependencies-${new Date().toISOString().slice(0, 10)}.csv`, csv);
+  };
+
+  const cards = [
+    ['grafana.manifestDashboards', manifest.summary.dashboards],
+    ['grafana.manifestPanels', manifest.summary.panels],
+    ['grafana.manifestDataSources', manifest.summary.dataSources],
+    ['grafana.manifestIssues', manifest.summary.dashboardsWithIssues],
+  ] as const;
+
+  return (
+    <Drawer
+      title={t('grafana.manifestTitle')}
+      open={open}
+      onClose={onClose}
+      width={1080}
+      destroyOnHidden
+      extra={
+        <Space>
+          <Button icon={<DownloadOutlined />} disabled={!filtered.length} onClick={exportRows}>
+            {t('common.export')}
+          </Button>
+          <Button type="primary" icon={<ReloadOutlined />} loading={loading} onClick={load}>
+            {loaded ? t('common.refresh') : t('grafana.manifestLoad')}
+          </Button>
+        </Space>
+      }
+    >
+      <Alert
+        showIcon
+        type="info"
+        message={t('grafana.manifestDescription')}
+        style={{ marginBottom: 16 }}
+      />
+      {!loaded ? (
+        <Card>
+          <Flex vertical align="center" gap={12}>
+            <Typography.Text type="secondary">{t('grafana.manifestEmpty')}</Typography.Text>
+            <Button type="primary" loading={loading} onClick={load}>
+              {t('grafana.manifestLoad')}
+            </Button>
+          </Flex>
+        </Card>
+      ) : (
+        <>
+          <Row gutter={[12, 12]} style={{ marginBottom: 16 }}>
+            {cards.map(([key, value]) => (
+              <Col xs={12} lg={6} key={key}>
+                <Card size="small">
+                  <Statistic title={t(key)} value={value} />
+                </Card>
+              </Col>
+            ))}
+          </Row>
+          <Flex gap={16} wrap style={{ marginBottom: 16 }}>
+            <Input.Search
+              allowClear
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder={t('grafana.manifestSearch')}
+              style={{ width: 320 }}
+            />
+            <Checkbox
+              checked={issuesOnly}
+              onChange={(event) => setIssuesOnly(event.target.checked)}
+            >
+              {t('grafana.manifestIssuesOnly')}
+            </Checkbox>
+            <Typography.Text type="secondary">
+              {t('grafana.manifestFiltered', { visible: filtered.length, total: rows.length })}
+            </Typography.Text>
+          </Flex>
+          <Table
+            rowKey="uid"
+            size="small"
+            columns={columns}
+            dataSource={filtered}
+            scroll={{ x: 1300 }}
+            pagination={{ pageSize: 20 }}
+          />
+        </>
+      )}
+    </Drawer>
+  );
+};
+
+export default GrafanaDependencyDrawer;

--- a/web/src/components/__tests__/grafanaDependencyManifest.test.ts
+++ b/web/src/components/__tests__/grafanaDependencyManifest.test.ts
@@ -1,0 +1,179 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. */
+import { describe, expect, it } from 'vitest';
+import type { GrafanaDashboardInfo } from '../../api/metrics';
+import {
+  analyzeGrafanaDashboard,
+  buildGrafanaDependencyManifest,
+  filterGrafanaDependencyRows,
+  grafanaDependencyCsvRows,
+} from '../grafanaDependencyManifest';
+
+const info: GrafanaDashboardInfo = {
+  uid: 'rocketmq-overview',
+  title: 'RocketMQ Overview',
+  description: 'overview',
+  tags: ['rocketmq'],
+};
+
+describe('Grafana dependency manifest', () => {
+  it('recursively counts row and nested panels', () => {
+    const row = analyzeGrafanaDashboard(info, {
+      uid: info.uid,
+      title: info.title,
+      schemaVersion: 39,
+      panels: [
+        { type: 'row', panels: [{ type: 'timeseries' }, { type: 'stat' }] },
+        { type: 'table' },
+      ],
+    });
+    expect(row.panelCount).toBe(4);
+    expect(row.panelTypes).toEqual(['row', 'stat', 'table', 'timeseries']);
+  });
+
+  it('collects data sources from dashboard, panel, target, and variables', () => {
+    const row = analyzeGrafanaDashboard(info, {
+      uid: info.uid,
+      title: info.title,
+      schemaVersion: 39,
+      datasource: { uid: 'global-prometheus' },
+      panels: [
+        {
+          type: 'timeseries',
+          datasource: 'panel-prometheus',
+          targets: [{ datasource: { uid: 'target-prometheus' } }],
+        },
+      ],
+      templating: { list: [{ name: 'cluster', type: 'query', datasource: 'variable-prometheus' }] },
+    });
+    expect(row.dataSources).toEqual([
+      'global-prometheus',
+      'panel-prometheus',
+      'target-prometheus',
+      'variable-prometheus',
+    ]);
+    expect(row.variableNames).toEqual(['cluster']);
+  });
+
+  it('counts advanced panel dependencies', () => {
+    const row = analyzeGrafanaDashboard(info, {
+      uid: info.uid,
+      title: info.title,
+      schemaVersion: 39,
+      panels: [
+        {
+          type: 'timeseries',
+          targets: [{ refId: 'A' }, { refId: 'B' }],
+          transformations: [{ id: 'join' }, { id: 'rename' }],
+          libraryPanel: { uid: 'shared' },
+          repeat: 'broker',
+          alert: { name: 'alert' },
+        },
+      ],
+    });
+    expect(row).toMatchObject({
+      targetCount: 2,
+      transformationCount: 2,
+      libraryPanelCount: 1,
+      repeatedPanelCount: 1,
+      alertCount: 1,
+    });
+  });
+
+  it('reports structural portability notes', () => {
+    const row = analyzeGrafanaDashboard(info, {
+      panels: [{ type: 'timeseries', targets: [{ expr: 'up' }] }],
+      templating: { list: [{ type: 'query' }] },
+    });
+    expect(row.issues).toEqual([
+      'IMPLICIT_DATASOURCE',
+      'MISSING_SCHEMA_VERSION',
+      'MISSING_TITLE',
+      'MISSING_UID',
+      'UNNAMED_VARIABLE',
+    ]);
+  });
+
+  it('reports a metadata and model UID mismatch', () => {
+    const row = analyzeGrafanaDashboard(info, {
+      uid: 'different',
+      title: info.title,
+      schemaVersion: 39,
+      panels: [{ type: 'stat' }],
+    });
+    expect(row.issues).toEqual(['UID_MISMATCH']);
+  });
+
+  it('builds portfolio totals and sorts noted dashboards first', () => {
+    const ready = analyzeGrafanaDashboard(info, {
+      uid: info.uid,
+      title: info.title,
+      schemaVersion: 39,
+      panels: [{ type: 'stat' }],
+    });
+    const empty = analyzeGrafanaDashboard(
+      { ...info, uid: 'empty', title: 'Empty' },
+      {
+        uid: 'empty',
+        title: 'Empty',
+        schemaVersion: 39,
+        panels: [],
+      },
+    );
+    const manifest = buildGrafanaDependencyManifest([ready, empty]);
+    expect(manifest.rows[0].uid).toBe('empty');
+    expect(manifest.summary).toMatchObject({ dashboards: 2, panels: 1, dashboardsWithIssues: 1 });
+  });
+
+  it('deduplicates shared data sources in portfolio totals', () => {
+    const first = analyzeGrafanaDashboard(info, {
+      uid: info.uid,
+      title: info.title,
+      schemaVersion: 39,
+      datasource: 'prometheus',
+      panels: [{ type: 'stat' }],
+    });
+    const second = analyzeGrafanaDashboard(
+      { ...info, uid: 'two' },
+      {
+        uid: 'two',
+        title: 'Two',
+        schemaVersion: 39,
+        datasource: 'prometheus',
+        panels: [{ type: 'table' }],
+      },
+    );
+    expect(buildGrafanaDependencyManifest([first, second]).summary.dataSources).toBe(1);
+  });
+
+  it('filters across title, UID, data source, panel type, and variable', () => {
+    const row = analyzeGrafanaDashboard(info, {
+      uid: info.uid,
+      title: info.title,
+      schemaVersion: 39,
+      datasource: 'prometheus-prod',
+      panels: [{ type: 'heatmap' }],
+      templating: { list: [{ name: 'BrokerName', type: 'query' }] },
+    });
+    for (const term of ['overview', 'rocketmq-overview', 'PROMETHEUS', 'heatmap', 'brokername']) {
+      expect(filterGrafanaDependencyRows([row], term, false)).toHaveLength(1);
+    }
+    expect(filterGrafanaDependencyRows([row], '', true)).toHaveLength(0);
+  });
+
+  it('creates deterministic flat CSV rows', () => {
+    const row = analyzeGrafanaDashboard(info, {
+      uid: info.uid,
+      title: info.title,
+      schemaVersion: 39,
+      datasource: 'prometheus',
+      panels: [{ type: 'stat' }],
+    });
+    expect(grafanaDependencyCsvRows([row])[0]).toMatchObject({
+      uid: info.uid,
+      schemaVersion: 39,
+      panels: 1,
+      panelTypes: 'stat',
+      dataSources: 'prometheus',
+    });
+  });
+});

--- a/web/src/components/grafanaDependencyManifest.ts
+++ b/web/src/components/grafanaDependencyManifest.ts
@@ -1,0 +1,175 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. */
+import type { GrafanaDashboardInfo } from '../api/metrics';
+
+export interface GrafanaDependencyRow {
+  uid: string;
+  title: string;
+  schemaVersion: number | null;
+  panelCount: number;
+  panelTypes: string[];
+  dataSources: string[];
+  variableNames: string[];
+  variableTypes: string[];
+  targetCount: number;
+  transformationCount: number;
+  libraryPanelCount: number;
+  repeatedPanelCount: number;
+  alertCount: number;
+  issues: string[];
+}
+export interface GrafanaDependencyManifest {
+  rows: GrafanaDependencyRow[];
+  summary: {
+    dashboards: number;
+    panels: number;
+    targets: number;
+    dataSources: number;
+    variables: number;
+    libraryPanels: number;
+    dashboardsWithIssues: number;
+  };
+}
+const objectValue = (value: unknown): Record<string, unknown> | null =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+const stringValue = (value: unknown) =>
+  typeof value === 'string' && value.trim() ? value.trim() : null;
+const dataSourceName = (value: unknown): string | null => {
+  const direct = stringValue(value);
+  if (direct) return direct;
+  const object = objectValue(value);
+  return stringValue(object?.uid) || stringValue(object?.type);
+};
+const uniqueSorted = (values: Array<string | null>) =>
+  [...new Set(values.filter((value): value is string => Boolean(value)))].sort((a, b) =>
+    a.localeCompare(b),
+  );
+const flattenPanels = (model: Record<string, unknown>) => {
+  const result: Record<string, unknown>[] = [];
+  const visit = (candidate: unknown) => {
+    if (!Array.isArray(candidate)) return;
+    candidate.forEach((item) => {
+      const panel = objectValue(item);
+      if (!panel) return;
+      result.push(panel);
+      visit(panel.panels);
+    });
+  };
+  visit(model.panels);
+  return result;
+};
+
+/** 递归分析 Dashboard 模型；保留未知字段，且不修改原始 JSON。 */
+export const analyzeGrafanaDashboard = (
+  info: GrafanaDashboardInfo,
+  model: Record<string, unknown>,
+): GrafanaDependencyRow => {
+  const panels = flattenPanels(model);
+  const templating = objectValue(model.templating);
+  const variables = Array.isArray(templating?.list)
+    ? templating.list
+        .map(objectValue)
+        .filter((value): value is Record<string, unknown> => Boolean(value))
+    : [];
+  const targets = panels.flatMap((panel) =>
+    Array.isArray(panel.targets)
+      ? panel.targets
+          .map(objectValue)
+          .filter((value): value is Record<string, unknown> => Boolean(value))
+      : [],
+  );
+  const dataSources = uniqueSorted([
+    dataSourceName(model.datasource),
+    ...panels.map((panel) => dataSourceName(panel.datasource)),
+    ...targets.map((target) => dataSourceName(target.datasource)),
+    ...variables.map((variable) => dataSourceName(variable.datasource)),
+  ]);
+  const schemaVersion =
+    typeof model.schemaVersion === 'number' && Number.isFinite(model.schemaVersion)
+      ? model.schemaVersion
+      : null;
+  const modelUid = stringValue(model.uid);
+  const issues: string[] = [];
+  if (!modelUid) issues.push('MISSING_UID');
+  else if (modelUid !== info.uid) issues.push('UID_MISMATCH');
+  if (!stringValue(model.title)) issues.push('MISSING_TITLE');
+  if (schemaVersion === null) issues.push('MISSING_SCHEMA_VERSION');
+  if (panels.length === 0) issues.push('NO_PANELS');
+  if (dataSources.length === 0 && targets.length > 0) issues.push('IMPLICIT_DATASOURCE');
+  if (variables.some((variable) => !stringValue(variable.name))) issues.push('UNNAMED_VARIABLE');
+  return {
+    uid: info.uid,
+    title: info.title,
+    schemaVersion,
+    panelCount: panels.length,
+    panelTypes: uniqueSorted(panels.map((panel) => stringValue(panel.type))),
+    dataSources,
+    variableNames: uniqueSorted(variables.map((variable) => stringValue(variable.name))),
+    variableTypes: uniqueSorted(variables.map((variable) => stringValue(variable.type))),
+    targetCount: targets.length,
+    transformationCount: panels.reduce(
+      (count, panel) =>
+        count + (Array.isArray(panel.transformations) ? panel.transformations.length : 0),
+      0,
+    ),
+    libraryPanelCount: panels.filter((panel) => Boolean(objectValue(panel.libraryPanel))).length,
+    repeatedPanelCount: panels.filter((panel) => Boolean(stringValue(panel.repeat))).length,
+    alertCount: panels.filter((panel) => Boolean(objectValue(panel.alert))).length,
+    issues: uniqueSorted(issues),
+  };
+};
+
+export const buildGrafanaDependencyManifest = (
+  rows: GrafanaDependencyRow[],
+): GrafanaDependencyManifest => {
+  const sorted = [...rows].sort(
+    (a, b) => b.issues.length - a.issues.length || a.title.localeCompare(b.title),
+  );
+  return {
+    rows: sorted,
+    summary: {
+      dashboards: sorted.length,
+      panels: sorted.reduce((sum, row) => sum + row.panelCount, 0),
+      targets: sorted.reduce((sum, row) => sum + row.targetCount, 0),
+      dataSources: new Set(sorted.flatMap((row) => row.dataSources)).size,
+      variables: sorted.reduce((sum, row) => sum + row.variableNames.length, 0),
+      libraryPanels: sorted.reduce((sum, row) => sum + row.libraryPanelCount, 0),
+      dashboardsWithIssues: sorted.filter((row) => row.issues.length > 0).length,
+    },
+  };
+};
+export const filterGrafanaDependencyRows = (
+  rows: GrafanaDependencyRow[],
+  search: string,
+  issuesOnly: boolean,
+) => {
+  const keyword = search.trim().toLocaleLowerCase();
+  return rows
+    .filter((row) => !issuesOnly || row.issues.length > 0)
+    .filter(
+      (row) =>
+        !keyword ||
+        [row.uid, row.title, ...row.panelTypes, ...row.dataSources, ...row.variableNames]
+          .join('\n')
+          .toLocaleLowerCase()
+          .includes(keyword),
+    );
+};
+export const grafanaDependencyCsvRows = (rows: GrafanaDependencyRow[]) =>
+  rows.map((row) => ({
+    uid: row.uid,
+    title: row.title,
+    schemaVersion: row.schemaVersion ?? '',
+    panels: row.panelCount,
+    panelTypes: row.panelTypes.join('; '),
+    dataSources: row.dataSources.join('; '),
+    variables: row.variableNames.join('; '),
+    variableTypes: row.variableTypes.join('; '),
+    targets: row.targetCount,
+    transformations: row.transformationCount,
+    libraryPanels: row.libraryPanelCount,
+    repeatedPanels: row.repeatedPanelCount,
+    alerts: row.alertCount,
+    issues: row.issues.join('; '),
+  }));

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1852,6 +1852,42 @@ const translations: Record<string, Record<Lang, string>> = {
   'grafana.exportAll': { zh: '导出全部', en: 'Export all' },
   'grafana.exportAllDone': { zh: '全部看板已导出', en: 'All dashboards exported' },
   'grafana.exportAllFailed': { zh: '导出全部看板失败', en: 'Failed to export dashboards' },
+  'grafana.manifestAction': { zh: '依赖清单', en: 'Dependency manifest' },
+  'grafana.manifestTitle': {
+    zh: 'Grafana Dashboard 依赖清单',
+    en: 'Grafana dashboard dependency manifest',
+  },
+  'grafana.manifestDescription': {
+    zh: '按需读取 Dashboard JSON，汇总迁移与升级所需的面板、数据源、变量和高级功能依赖。',
+    en: 'Loads dashboard JSON on demand and inventories panels, data sources, variables, and advanced features needed for migration or upgrades.',
+  },
+  'grafana.manifestLoad': { zh: '加载依赖', en: 'Load dependencies' },
+  'grafana.manifestLoadFailed': {
+    zh: 'Dashboard 依赖加载失败',
+    en: 'Failed to load dashboard dependencies',
+  },
+  'grafana.manifestEmpty': {
+    zh: '尚未读取 Dashboard 内容。点击加载后将以每批 4 个的上限获取详情。',
+    en: 'Dashboard content has not been loaded. Details are fetched in batches of four.',
+  },
+  'grafana.manifestDashboards': { zh: 'Dashboard 数', en: 'Dashboards' },
+  'grafana.manifestPanels': { zh: '面板数', en: 'Panels' },
+  'grafana.manifestDataSources': { zh: '数据源引用', en: 'Data sources' },
+  'grafana.manifestVariables': { zh: '模板变量', en: 'Variables' },
+  'grafana.manifestTargets': { zh: '查询 Target', en: 'Query targets' },
+  'grafana.manifestSchema': { zh: 'Schema', en: 'Schema' },
+  'grafana.manifestPanelTypes': { zh: '面板类型', en: 'Panel types' },
+  'grafana.manifestIssues': { zh: '可移植性提示', en: 'Portability notes' },
+  'grafana.manifestReady': { zh: '结构完整', en: 'Structurally ready' },
+  'grafana.manifestSearch': {
+    zh: '搜索 Dashboard、数据源或变量',
+    en: 'Search dashboards, data sources, or variables',
+  },
+  'grafana.manifestIssuesOnly': { zh: '仅看有提示项', en: 'Notes only' },
+  'grafana.manifestFiltered': {
+    zh: '显示 {visible} / {total}',
+    en: 'Showing {visible} of {total}',
+  },
   // ─── Alert rule templates ───
   'alertAssets.title': { zh: '业务告警', en: 'Business Alerts' },
   'alertAssets.name': { zh: '名称', en: 'Name' },


### PR DESCRIPTION
<!-- Make sure the base branch is `master`: that is the RocketMQ Studio trunk. -->

### Which Issue(s) This PR Fixes

- Fixes #3197
- Replaces #3198, closed by the branch switch in #4379.

### Brief Description

This is a resubmission of #3198 against `master`, following the branch switch notice in #4379. The fork branch is unchanged; `master` is now the RocketMQ Studio trunk.

## Summary

- load dashboard models on demand in bounded batches of four
- recursively inventory nested panels, data sources, variables, targets, transformations, library panels, repeats, and alerts
- flag structural portability notes and summarize shared portfolio dependencies
- support cross-field search, notes-only filtering, and CSV export

### How Did You Test This Change?

## 原提交验证记录
- focused manifest and existing catalog suites: 20 tests passed
- `npm run lint` (0 errors; 10 pre-existing warnings)
- `npm run build` (8,040 modules transformed)
- scope audit: 663 additions, 1 deletion across 5 files

Fixes #3197

### Checklist

- [x] One coherent change; unrelated modifications are not bundled in
- [x] Commit subject follows Conventional Commits (`feat:` / `fix:` / `refactor:` / `chore:` / `docs:` / `perf:`)
- [x] Tests added or updated for non-trivial changes, test methods named `...Test`
- [x] New UI text has both Chinese and English entries under `web/src/i18n/`, or the change does not add UI text
- [x] Architecture constraints stay green (`mvn test` runs the ArchUnit checks), or the original verification scope is stated above
- [x] New source files carry the ASF license header, or no new source files were added
- [x] Documentation touched where behaviour changed (README / `docs/` / in-app help), or no documentation change was required
