### PR TITLE
feat(broker): inspect native HA replication state

### DIFF
--- a/docs/broker-ha-diagnostics.md
+++ b/docs/broker-ha-diagnostics.md
@@ -1,0 +1,46 @@
+# Broker 主从复制状态
+
+Broker 集群页的 `HA status` 按钮读取所选 Apache 实例中一个 Broker 名称的全部登记副本。
+诊断用于排查主从复制落后、连接缺失和传输停滞；操作不会切换主从或修改 Broker 配置。
+Mock 模式下按钮禁用，避免将模拟列表与真实诊断混合。
+
+## 查询与解释
+
+1. 选择 Apache 实例，在 Broker 列表点击 `HA status`。
+2. 查看每个 Broker ID 的地址、实际报告的主从角色、日志偏移和查询结果。
+3. 展开主节点查看从节点确认偏移、差距、传输位置、每秒速率以及 Broker 报告的同步状态。
+4. 展开从节点查看上游地址、本地日志位置、主节点刷盘位置、最后读写时间与传输速率。
+5. 点击 `Refresh snapshot` 手动重新采样；关闭窗口会取消浏览器请求并丢弃迟到响应。
+
+偏移和差距单位为字节，不是消息条数。响应使用十进制字符串，浏览器不会将其转换为浮点数。
+`inSync` 和同步副本数来自 Broker；页面没有另行推算阈值。
+未报告的读写时间显示 `Not reported`，不将零时间戳显示成 1970 年。
+副本从 NameServer 返回的 Broker 地址表选取，接口不接受任意 Broker 地址。
+
+## 接口
+
+```http
+GET /api/brokers/ha?instanceId=instance-a&brokerName=broker-a
+```
+
+返回 `brokerName`、采样完成时间 `sampledAt`、完整性 `complete` 和节点数组 `nodes`。
+节点按 Broker ID 排序；角色使用实时响应，不按 Broker ID 推断。
+不支持 HA 查询、连接失败、权限不足或空响应会记录在该节点的 `error`，其他节点仍继续查询。
+找不到 Broker 返回业务错误 404；实例解析、凭据及厂商约束沿用现有运行时解析器。
+
+## 边界与兼容性
+
+各副本依次采样，不构成原子快照。查询成本为一次拓扑 RPC 加每个登记副本一次 HA RPC，
+延迟由现有管理客户端的 RPC 超时和副本数共同决定。没有新增后台轮询或重试任务。
+浏览器取消不保证已发出的 Broker RPC 立刻终止。服务端线程中断时停止继续探测并保留中断标志。
+HA 服务支持取决于 Broker 版本和部署模式；不支持时明确显示错误，不回填健康状态。
+这些数据不足以证明可安全故障切换，也不替代 Controller 的同步状态集合。
+
+本功能没有新增依赖或持久化字段。无迁移，直接部署；回滚该提交即可移除入口与接口。
+
+## 验证依据
+
+协议字段对应 RocketMQ 5.5.0 的 [HARuntimeInfo](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/HARuntimeInfo.java)，
+解释参考官方 [haStatus 命令](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/tools/src/main/java/org/apache/rocketmq/tools/command/ha/HAStatusSubCommand.java)。核对日期：2026-09-08。
+本地测试覆盖 HTTP 到服务映射、主从分支、部分失败、精度、中断、实例参数和前端请求生命周期。
+真实 RocketMQ 集群 E2E、性能、压力、容量及混沌测试尚未执行；浏览器交互使用本地受控响应。

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerHaController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerHaController.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import org.apache.rocketmq.studio.common.domain.Result;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/brokers/ha")
+@RequiredArgsConstructor
+public class BrokerHaController {
+    private final BrokerHaService service;
+
+    @GetMapping
+    public Result<BrokerHaSnapshot> inspect(@RequestParam String instanceId, @RequestParam String brokerName) {
+        return Result.ok(service.inspect(instanceId, brokerName));
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerHaService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerHaService.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import org.apache.rocketmq.remoting.protocol.body.HARuntimeInfo;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BrokerHaService {
+    private final RuntimeAdminClientResolver resolver;
+
+    public BrokerHaSnapshot inspect(String instanceId, String brokerName) {
+        if (brokerName == null || brokerName.isBlank()) {
+            throw new BusinessException(400, "brokerName is required");
+        }
+        String name = brokerName.trim();
+        return resolver.execute(instanceId, admin -> {
+            var cluster = admin.examineBrokerClusterInfo();
+            var broker = cluster.getBrokerAddrTable().get(name);
+            if (broker == null || broker.getBrokerAddrs().isEmpty()) {
+                throw new BusinessException(404, "Broker has no registered replicas: " + name);
+            }
+            List<BrokerHaSnapshot.Node> nodes = new ArrayList<>();
+            // Query only addresses advertised by this instance's NameServer.
+            for (var entry : broker.getBrokerAddrs().entrySet().stream()
+                    .sorted(java.util.Map.Entry.comparingByKey()).toList()) {
+                String id = entry.getKey().toString();
+                String address = entry.getValue();
+                try {
+                    var info = admin.getBrokerHAStatus(address);
+                    if (info == null) {
+                        throw new BusinessException(502, "Broker returned no HA runtime data");
+                    }
+                    nodes.add(map(id, address, info));
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    throw interrupted;
+                } catch (Exception failure) {
+                    nodes.add(new BrokerHaSnapshot.Node(id, address, failure.getMessage() == null
+                            ? failure.getClass().getSimpleName() : failure.getMessage(),
+                            null, null, null, List.of(), null));
+                }
+            }
+            return new BrokerHaSnapshot(name, System.currentTimeMillis(),
+                    nodes.stream().allMatch(node -> node.error() == null), List.copyOf(nodes));
+        });
+    }
+
+    private BrokerHaSnapshot.Node map(String id, String address, HARuntimeInfo info) {
+        if (info.isMaster()) {
+            var connections = info.getHaConnectionInfo().stream().map(connection ->
+                    new BrokerHaSnapshot.Connection(connection.getAddr(), connection.isInSync(),
+                            Long.toString(connection.getSlaveAckOffset()), Long.toString(connection.getDiff()),
+                            Long.toString(connection.getTransferFromWhere()),
+                            Long.toString(connection.getTransferredByteInSecond()))).toList();
+            return new BrokerHaSnapshot.Node(id, address, null, true,
+                    Long.toString(info.getMasterCommitLogMaxOffset()), info.getInSyncSlaveNums(), connections, null);
+        }
+        var client = info.getHaClientRuntimeInfo();
+        if (client == null) {
+            throw new BusinessException(502, "Replica returned no HA client data");
+        }
+        var replica = new BrokerHaSnapshot.Replica(client.getMasterAddr(), Long.toString(client.getMaxOffset()),
+                Long.toString(client.getMasterFlushOffset()), Long.toString(client.getTransferredByteInSecond()),
+                client.getLastReadTimestamp(), client.getLastWriteTimestamp());
+        return new BrokerHaSnapshot.Node(id, address, null, false, replica.maxOffset(), null, List.of(), replica);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerHaSnapshot.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerHaSnapshot.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import java.util.List;
+
+/** Physical log offsets are decimal strings to preserve precision in browsers. */
+public record BrokerHaSnapshot(String brokerName, long sampledAt, boolean complete, List<Node> nodes) {
+    public record Node(String brokerId, String address, String error, Boolean master,
+                       String maxOffset, Integer inSyncSlaveCount, List<Connection> connections, Replica replica) {
+    }
+
+    public record Connection(String address, boolean inSync, String ackOffset, String differenceBytes,
+                             String transferOffset, String bytesPerSecond) {
+    }
+
+    public record Replica(String masterAddress, String maxOffset, String masterFlushOffset,
+                          String bytesPerSecond, long lastReadTimestamp, long lastWriteTimestamp) {
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/BrokerHaTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/BrokerHaTest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.body.HARuntimeInfo;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.common.exception.GlobalExceptionHandler;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class BrokerHaTest {
+    private final RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+    private final MQAdminExt admin = mock(MQAdminExt.class);
+    private final BrokerHaService service = new BrokerHaService(resolver);
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        doAnswer(call -> call.<MqAdminExtFactory.AdminAction<?>>getArgument(1).apply(admin))
+                .when(resolver).execute(anyString(), any());
+        var cluster = new ClusterInfo();
+        cluster.setBrokerAddrTable(new HashMap<>(Map.of("broker-a",
+                new BrokerData("cluster-a", "broker-a", new HashMap<>(Map.of(
+                        0L, "master:10911", 1L, "replica:10911"))))));
+        when(admin.examineBrokerClusterInfo()).thenReturn(cluster);
+        mvc = MockMvcBuilders.standaloneSetup(new BrokerHaController(service))
+                .setControllerAdvice(new GlobalExceptionHandler()).build();
+    }
+
+    @Test
+    void httpSnapshotPreservesPhysicalOffsetsAndBothRoles() throws Exception {
+        var master = new HARuntimeInfo();
+        master.setMaster(true);
+        master.setMasterCommitLogMaxOffset(9007199254740993L);
+        master.setInSyncSlaveNums(1);
+        var connection = new HARuntimeInfo.HAConnectionRuntimeInfo();
+        connection.setAddr("replica:10912");
+        connection.setInSync(true);
+        connection.setSlaveAckOffset(9007199254740000L);
+        connection.setDiff(993);
+        connection.setTransferFromWhere(9007199254740001L);
+        connection.setTransferredByteInSecond(1024);
+        master.setHaConnectionInfo(List.of(connection));
+        when(admin.getBrokerHAStatus("master:10911")).thenReturn(master);
+        var slave = replica();
+        when(admin.getBrokerHAStatus("replica:10911")).thenReturn(slave);
+
+        mvc.perform(get("/api/brokers/ha").param("instanceId", "instance-a").param("brokerName", " broker-a "))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.complete").value(true))
+                .andExpect(jsonPath("$.data.nodes[0].brokerId").value("0"))
+                .andExpect(jsonPath("$.data.nodes[0].master").value(true))
+                .andExpect(jsonPath("$.data.nodes[0].maxOffset").value("9007199254740993"))
+                .andExpect(jsonPath("$.data.nodes[0].connections[0].differenceBytes").value("993"))
+                .andExpect(jsonPath("$.data.nodes[0].connections[0].transferOffset").value("9007199254740001"))
+                .andExpect(jsonPath("$.data.nodes[0].connections[0].bytesPerSecond").value("1024"))
+                .andExpect(jsonPath("$.data.nodes[1].master").value(false))
+                .andExpect(jsonPath("$.data.nodes[1].replica.masterAddress").value("master:10912"))
+                .andExpect(jsonPath("$.data.nodes[1].replica.masterFlushOffset").value("200"))
+                .andExpect(jsonPath("$.data.nodes[1].replica.lastReadTimestamp").value(1000));
+        verify(resolver).execute(org.mockito.ArgumentMatchers.eq("instance-a"), any());
+    }
+
+    @Test
+    void failingMasterDoesNotHideReachableReplica() throws Exception {
+        when(admin.getBrokerHAStatus("master:10911")).thenThrow(new IllegalStateException("unsupported HA service"));
+        when(admin.getBrokerHAStatus("replica:10911")).thenReturn(replica());
+        var result = service.inspect("instance-a", "broker-a");
+        assertThat(result.complete()).isFalse();
+        assertThat(result.nodes().getFirst().error()).isEqualTo("unsupported HA service");
+        assertThat(result.nodes().getFirst().master()).isNull();
+        assertThat(result.nodes().getLast().replica().maxOffset()).isEqualTo("300");
+    }
+
+    @Test
+    void absentRuntimeDataIsUnavailableRatherThanHealthyZero() throws Exception {
+        var incomplete = new HARuntimeInfo();
+        incomplete.setHaClientRuntimeInfo(null);
+        when(admin.getBrokerHAStatus("replica:10911")).thenReturn(incomplete);
+        var result = service.inspect("instance-a", "broker-a");
+        assertThat(result.complete()).isFalse();
+        assertThat(result.nodes()).allSatisfy(node -> assertThat(node.error()).contains("no HA"));
+    }
+
+    @Test
+    void emptyExceptionMessageStillProducesFailedNode() throws Exception {
+        when(admin.getBrokerHAStatus(anyString())).thenThrow(new IllegalStateException());
+        assertThat(service.inspect("instance-a", "broker-a").nodes())
+                .allSatisfy(node -> assertThat(node.error()).isEqualTo("IllegalStateException"));
+    }
+
+    @Test
+    void noConnectionsIsValidMasterObservation() throws Exception {
+        var master = new HARuntimeInfo();
+        master.setMaster(true);
+        when(admin.getBrokerHAStatus(anyString())).thenReturn(master);
+        var result = service.inspect("instance-a", "broker-a");
+        assertThat(result.complete()).isTrue();
+        assertThat(result.nodes()).allSatisfy(node -> {
+            assertThat(node.connections()).isEmpty();
+            assertThat(node.inSyncSlaveCount()).isZero();
+        });
+    }
+
+    @Test
+    void interruptionStopsRemainingProbesAndRestoresFlag() throws Exception {
+        when(admin.getBrokerHAStatus("master:10911")).thenThrow(new InterruptedException("cancelled"));
+        try {
+            assertThatThrownBy(() -> service.inspect("instance-a", "broker-a"))
+                    .isInstanceOf(InterruptedException.class);
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+            verify(admin, never()).getBrokerHAStatus("replica:10911");
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void brokerOutsideSelectedInstanceCannotSupplyAnAddress() throws Exception {
+        mvc.perform(get("/api/brokers/ha").param("instanceId", "instance-a").param("brokerName", "other:10911"))
+                .andExpect(jsonPath("$.code").value(404));
+        verify(admin, never()).getBrokerHAStatus(anyString());
+    }
+
+    @Test
+    void missingParametersAndBlankBrokerAreRejected() throws Exception {
+        mvc.perform(get("/api/brokers/ha").param("instanceId", "instance-a"))
+                .andExpect(status().isBadRequest());
+        mvc.perform(get("/api/brokers/ha").param("brokerName", "broker-a"))
+                .andExpect(status().isBadRequest());
+        mvc.perform(get("/api/brokers/ha").param("instanceId", "instance-a").param("brokerName", " "))
+                .andExpect(jsonPath("$.code").value(400));
+        assertThatThrownBy(() -> service.inspect("instance-a", null)).hasMessageContaining("brokerName");
+    }
+
+    @Test
+    void brokerWithNoRegisteredReplicasIsNotACompleteSnapshot() throws Exception {
+        var cluster = admin.examineBrokerClusterInfo();
+        cluster.getBrokerAddrTable().get("broker-a").setBrokerAddrs(new HashMap<>());
+        assertThatThrownBy(() -> service.inspect("instance-a", "broker-a"))
+                .hasMessageContaining("no registered replicas");
+    }
+
+    private HARuntimeInfo replica() {
+        var info = new HARuntimeInfo();
+        var client = info.getHaClientRuntimeInfo();
+        client.setMasterAddr("master:10912");
+        client.setMaxOffset(300);
+        client.setMasterFlushOffset(200);
+        client.setTransferredByteInSecond(2048);
+        client.setLastReadTimestamp(1000);
+        client.setLastWriteTimestamp(2000);
+        return info;
+    }
+}

--- a/web/src/api/brokerHa.test.ts
+++ b/web/src/api/brokerHa.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, describe, expect, it } from 'vitest';
+import client from './client';
+import { inspectBrokerHa } from './brokerHa';
+
+const mock = new MockAdapter(client);
+afterEach(() => mock.reset());
+
+describe('HA API contract', () => {
+  it('sends the selected instance and broker as query parameters and preserves the envelope', async () => {
+    const snapshot = { brokerName: 'broker/a', sampledAt: 10, complete: true, nodes: [] };
+    const signal = new AbortController().signal;
+    mock.onGet('/brokers/ha').reply((request) => {
+      expect(request.params).toEqual({ instanceId: 'instance-a', brokerName: 'broker/a' });
+      expect(request.signal).toBe(signal);
+      return [200, { code: 200, data: snapshot }];
+    });
+    expect(await inspectBrokerHa('instance-a', 'broker/a', signal)).toEqual(snapshot);
+    expect(mock.history.post).toHaveLength(0);
+  });
+
+  it('honors cancellation before sending the request', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(inspectBrokerHa('instance-a', 'broker-a', controller.signal)).rejects.toThrow();
+    expect(mock.history.get).toHaveLength(0);
+  });
+});

--- a/web/src/api/brokerHa.ts
+++ b/web/src/api/brokerHa.ts
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import client from './client';
+
+export interface HaConnection {
+  address: string;
+  inSync: boolean;
+  ackOffset: string;
+  differenceBytes: string;
+  transferOffset: string;
+  bytesPerSecond: string;
+}
+
+export interface HaNode {
+  brokerId: string;
+  address: string;
+  error: string | null;
+  master: boolean | null;
+  maxOffset: string | null;
+  inSyncSlaveCount: number | null;
+  connections: HaConnection[];
+  replica: {
+    masterAddress: string | null;
+    maxOffset: string;
+    masterFlushOffset: string;
+    bytesPerSecond: string;
+    lastReadTimestamp: number;
+    lastWriteTimestamp: number;
+  } | null;
+}
+
+export interface BrokerHaSnapshot {
+  brokerName: string;
+  sampledAt: number;
+  complete: boolean;
+  nodes: HaNode[];
+}
+
+export async function inspectBrokerHa(instanceId: string, brokerName: string, signal: AbortSignal) {
+  const response = await client.get<{ data: BrokerHaSnapshot }>('/brokers/ha', {
+    params: { instanceId, brokerName },
+    signal,
+  });
+  return response.data.data;
+}

--- a/web/src/components/BrokerHaDialog.tsx
+++ b/web/src/components/BrokerHaDialog.tsx
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+import { Alert, Button, Descriptions, Modal, Space, Spin, Table, Tag, Typography } from 'antd';
+import {
+  inspectBrokerHa,
+  type BrokerHaSnapshot,
+  type HaConnection,
+  type HaNode,
+} from '../api/brokerHa';
+
+interface Props {
+  instanceId: string;
+  brokerName: string;
+  onClose: () => void;
+}
+
+const timestamp = (value: number) =>
+  value > 0 ? new Date(value).toLocaleString() : 'Not reported';
+
+function NodeDetails({ node }: { node: HaNode }) {
+  if (node.error) return <Alert type="error" showIcon message={node.error} />;
+  if (node.master)
+    return (
+      <Table<HaConnection>
+        size="small"
+        pagination={false}
+        dataSource={node.connections}
+        rowKey={(row) => row.address}
+        scroll={{ x: 880 }}
+        locale={{ emptyText: 'No connected replicas reported by this master' }}
+        columns={[
+          { title: 'Replica address', dataIndex: 'address' },
+          {
+            title: 'In sync',
+            dataIndex: 'inSync',
+            render: (value: boolean) => (value ? 'Yes' : 'No'),
+          },
+          { title: 'Acknowledged offset', dataIndex: 'ackOffset' },
+          { title: 'Difference (bytes)', dataIndex: 'differenceBytes' },
+          { title: 'Transfer offset', dataIndex: 'transferOffset' },
+          { title: 'Transfer (bytes/s)', dataIndex: 'bytesPerSecond' },
+        ]}
+      />
+    );
+  const replica = node.replica;
+  if (!replica) return null;
+  return (
+    <Descriptions bordered size="small" column={2}>
+      <Descriptions.Item label="Master address">
+        {replica.masterAddress || 'Not reported'}
+      </Descriptions.Item>
+      <Descriptions.Item label="Replica max offset">{replica.maxOffset}</Descriptions.Item>
+      <Descriptions.Item label="Master flush offset">{replica.masterFlushOffset}</Descriptions.Item>
+      <Descriptions.Item label="Transfer (bytes/s)">{replica.bytesPerSecond}</Descriptions.Item>
+      <Descriptions.Item label="Last read">
+        {timestamp(replica.lastReadTimestamp)}
+      </Descriptions.Item>
+      <Descriptions.Item label="Last write">
+        {timestamp(replica.lastWriteTimestamp)}
+      </Descriptions.Item>
+    </Descriptions>
+  );
+}
+
+export default function BrokerHaDialog({ instanceId, brokerName, onClose }: Props) {
+  const [snapshot, setSnapshot] = useState<BrokerHaSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [revision, setRevision] = useState(0);
+  useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+    void Promise.resolve()
+      .then(() => {
+        if (!active) return;
+        setLoading(true);
+        setSnapshot(null);
+        setError(null);
+        return inspectBrokerHa(instanceId, brokerName, controller.signal);
+      })
+      .then((result) => {
+        if (active && result) setSnapshot(result);
+      })
+      .catch((failure: unknown) => {
+        if (active) setError(failure instanceof Error ? failure.message : 'HA query failed');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [instanceId, brokerName, revision]);
+
+  return (
+    <Modal
+      open
+      title={`Replication status: ${brokerName}`}
+      onCancel={onClose}
+      width={1100}
+      footer={
+        <Space>
+          <Button loading={loading} onClick={() => setRevision((value) => value + 1)}>
+            Refresh snapshot
+          </Button>
+          <Button onClick={onClose}>Close</Button>
+        </Space>
+      }
+    >
+      <Space direction="vertical" style={{ width: '100%' }} size="middle">
+        <Alert
+          type="info"
+          showIcon
+          message="Physical log replication snapshot"
+          description="Offsets and differences are bytes, not message counts. Nodes are sampled sequentially. This view does not establish failover readiness."
+        />
+        {error && <Alert type="error" showIcon message={error} />}
+        <Spin spinning={loading}>
+          {snapshot && (
+            <Space direction="vertical" style={{ width: '100%' }}>
+              <Typography.Text>Sample completed: {timestamp(snapshot.sampledAt)}</Typography.Text>
+              {!snapshot.complete && (
+                <Alert
+                  type="warning"
+                  showIcon
+                  message="Partial snapshot: some replicas could not report HA state. Expand failed rows for details."
+                />
+              )}
+              <Table<HaNode>
+                size="small"
+                pagination={false}
+                dataSource={snapshot.nodes}
+                rowKey="brokerId"
+                scroll={{ x: 780 }}
+                expandable={{ expandedRowRender: (node) => <NodeDetails node={node} /> }}
+                columns={[
+                  { title: 'Broker ID', dataIndex: 'brokerId' },
+                  { title: 'Address', dataIndex: 'address' },
+                  {
+                    title: 'Reported role',
+                    render: (_, node) =>
+                      node.master === null ? 'Unavailable' : node.master ? 'Master' : 'Replica',
+                  },
+                  {
+                    title: 'Max log offset (bytes)',
+                    dataIndex: 'maxOffset',
+                    render: (value) => value ?? '-',
+                  },
+                  {
+                    title: 'In-sync replicas',
+                    dataIndex: 'inSyncSlaveCount',
+                    render: (value) => value ?? '-',
+                  },
+                  {
+                    title: 'Query',
+                    render: (_, node) => (
+                      <Tag color={node.error ? 'error' : 'success'}>
+                        {node.error ? 'Failed' : 'Available'}
+                      </Tag>
+                    ),
+                  },
+                ]}
+              />
+            </Space>
+          )}
+        </Spin>
+      </Space>
+    </Modal>
+  );
+}

--- a/web/src/components/__tests__/BrokerHaDialog.test.tsx
+++ b/web/src/components/__tests__/BrokerHaDialog.test.tsx
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, fireEvent, render as renderComponent, screen, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { ConfigProvider } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BrokerHaDialog from '../BrokerHaDialog';
+import { inspectBrokerHa, type BrokerHaSnapshot } from '../../api/brokerHa';
+
+vi.mock('../../api/brokerHa', () => ({ inspectBrokerHa: vi.fn() }));
+
+// jsdom does not dispatch CSS animation completion events.
+const render = (element: ReactElement) =>
+  renderComponent(element, {
+    wrapper: ({ children }) => (
+      <ConfigProvider theme={{ token: { motion: false } }}>{children}</ConfigProvider>
+    ),
+  });
+
+const fixture: BrokerHaSnapshot = {
+  brokerName: 'broker-a',
+  sampledAt: 1788825600000,
+  complete: true,
+  nodes: [
+    {
+      brokerId: '0',
+      address: 'master:10911',
+      error: null,
+      master: true,
+      maxOffset: '9007199254740993',
+      inSyncSlaveCount: 0,
+      connections: [
+        {
+          address: 'replica:10912',
+          inSync: false,
+          ackOffset: '9007199254740000',
+          differenceBytes: '993',
+          transferOffset: '9007199254740001',
+          bytesPerSecond: '1024',
+        },
+      ],
+      replica: null,
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockReturnValue({
+      matches: false,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  });
+  vi.mocked(inspectBrokerHa).mockResolvedValue(structuredClone(fixture));
+});
+
+describe('BrokerHaDialog', () => {
+  it('keeps byte offsets exact and expands master connection details', async () => {
+    render(<BrokerHaDialog instanceId="instance-a" brokerName="broker-a" onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('9007199254740993')).toBeVisible());
+    fireEvent.click(screen.getByRole('button', { name: 'Expand row' }));
+    await waitFor(() => expect(screen.getByText('9007199254740001')).toBeVisible());
+    expect(screen.getByText('993')).toBeVisible();
+    expect(screen.getByText('No')).toBeVisible();
+    expect(inspectBrokerHa).toHaveBeenCalledWith('instance-a', 'broker-a', expect.any(AbortSignal));
+  });
+
+  it('shows partial errors without labeling an unavailable node as a replica', async () => {
+    vi.mocked(inspectBrokerHa).mockResolvedValue({
+      ...fixture,
+      complete: false,
+      nodes: [
+        { ...fixture.nodes[0], master: null, maxOffset: null, error: 'HA service unsupported' },
+      ],
+    });
+    render(<BrokerHaDialog instanceId="instance-a" brokerName="broker-a" onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText(/Partial snapshot/)).toBeVisible());
+    expect(screen.getByText('Unavailable')).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: 'Expand row' }));
+    await waitFor(() => expect(screen.getByText('HA service unsupported')).toBeVisible());
+  });
+
+  it('displays replica progress and distinguishes unreported timestamps', async () => {
+    vi.mocked(inspectBrokerHa).mockResolvedValue({
+      ...fixture,
+      nodes: [
+        {
+          ...fixture.nodes[0],
+          master: false,
+          connections: [],
+          inSyncSlaveCount: null,
+          replica: {
+            masterAddress: 'master:10912',
+            maxOffset: '123',
+            masterFlushOffset: '100',
+            bytesPerSecond: '2048',
+            lastReadTimestamp: 0,
+            lastWriteTimestamp: 1788825600000,
+          },
+        },
+      ],
+    });
+    render(<BrokerHaDialog instanceId="instance-a" brokerName="broker-a" onClose={vi.fn()} />);
+    await screen.findByText('Replica');
+    fireEvent.click(screen.getByRole('button', { name: 'Expand row' }));
+    await waitFor(() => expect(screen.getByText('master:10912')).toBeVisible());
+    expect(screen.getByText('Not reported')).toBeVisible();
+    expect(screen.getByText('2048')).toBeVisible();
+  });
+
+  it('retries failed requests and prevents concurrent refreshes', async () => {
+    vi.mocked(inspectBrokerHa).mockRejectedValueOnce(new Error('Instance unavailable'));
+    render(<BrokerHaDialog instanceId="instance-a" brokerName="broker-a" onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('Instance unavailable')).toBeVisible());
+    fireEvent.click(screen.getByRole('button', { name: /Refresh snapshot/ }));
+    await waitFor(() => expect(screen.getByText('9007199254740993')).toBeVisible());
+    expect(screen.queryByText('Instance unavailable')).not.toBeInTheDocument();
+    expect(inspectBrokerHa).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts a closed dialog request and ignores its late result', async () => {
+    let resolve!: (value: BrokerHaSnapshot) => void;
+    vi.mocked(inspectBrokerHa).mockReturnValue(
+      new Promise((done) => {
+        resolve = done;
+      }),
+    );
+    const { unmount } = render(
+      <BrokerHaDialog instanceId="instance-a" brokerName="broker-a" onClose={vi.fn()} />,
+    );
+    await waitFor(() => expect(inspectBrokerHa).toHaveBeenCalledTimes(1));
+    const signal = vi.mocked(inspectBrokerHa).mock.calls[0][2];
+    unmount();
+    expect(signal.aborted).toBe(true);
+    await act(async () => resolve(fixture));
+    expect(screen.queryByText('9007199254740993')).not.toBeInTheDocument();
+  });
+
+  it('does not let an old instance replace the new instance snapshot', async () => {
+    let resolve!: (value: BrokerHaSnapshot) => void;
+    vi.mocked(inspectBrokerHa).mockReturnValueOnce(
+      new Promise((done) => {
+        resolve = done;
+      }),
+    );
+    const { rerender } = render(
+      <BrokerHaDialog instanceId="instance-a" brokerName="broker-a" onClose={vi.fn()} />,
+    );
+    await waitFor(() => expect(inspectBrokerHa).toHaveBeenCalledTimes(1));
+    const signal = vi.mocked(inspectBrokerHa).mock.calls[0][2];
+    rerender(<BrokerHaDialog instanceId="instance-b" brokerName="broker-b" onClose={vi.fn()} />);
+    await screen.findByText('9007199254740993');
+    await act(async () => resolve({ ...fixture, nodes: [] }));
+    expect(signal.aborted).toBe(true);
+    await waitFor(() => expect(screen.getByText('9007199254740993')).toBeVisible());
+  });
+
+  it('close invokes the owner and does not issue any mutation', async () => {
+    const close = vi.fn();
+    render(<BrokerHaDialog instanceId="instance-a" brokerName="broker-a" onClose={close} />);
+    await waitFor(() => expect(inspectBrokerHa).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Close' })[1]);
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -31,6 +31,7 @@ import type { ClusterInfo } from '../../api/cluster';
 import { supportsApacheRuntime, type Instance } from '../../api/instance';
 import { listInstances } from '../../services/instanceService';
 import { useVisiblePolling } from '../../hooks/useVisiblePolling';
+import BrokerHaDialog from '../../components/BrokerHaDialog';
 import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 
 // ─── Types ──────────────────────────────────────────────────────
@@ -190,6 +191,7 @@ const BrokerClusterPage = () => {
   const [proxyData, setProxyData] = useState<ProxyRecord[]>([]);
   const [instances, setInstances] = useState<Instance[]>([]);
   const [selectedInstanceId, setSelectedInstanceId] = useState<string | undefined>(undefined);
+  const [haTarget, setHaTarget] = useState<{ instanceId: string; brokerName: string } | null>(null);
   const mountedRef = useRef(true);
   const loadRequestId = useRef(0);
   const { t } = useLang();
@@ -325,6 +327,25 @@ const BrokerClusterPage = () => {
     (activeTab === 'broker' && brokerData.length === 0);
 
   const brokerColumns = [
+    {
+      title: 'Replication',
+      key: 'replication',
+      render: (_: unknown, record: BrokerRecord) => (
+        <Button
+          size="small"
+          disabled={!selectedInstanceId || isMockMode()}
+          onClick={() =>
+            selectedInstanceId &&
+            setHaTarget({
+              instanceId: selectedInstanceId,
+              brokerName: record.brokerName,
+            })
+          }
+        >
+          HA status
+        </Button>
+      ),
+    },
     {
       title: t('brokerCluster.k8sCluster'),
       dataIndex: 'k8sCluster',
@@ -521,7 +542,10 @@ const BrokerClusterPage = () => {
           <Select
             aria-label="选择实例"
             value={selectedInstanceId}
-            onChange={setSelectedInstanceId}
+            onChange={(value) => {
+              setHaTarget(null);
+              setSelectedInstanceId(value);
+            }}
             placeholder="选择实例"
             style={{ minWidth: 180 }}
             options={instances.map((instance) => ({ value: instance.name, label: instance.name }))}
@@ -614,6 +638,14 @@ const BrokerClusterPage = () => {
           />
         </Card>
       </Spin>
+      {haTarget && haTarget.instanceId === selectedInstanceId && (
+        <BrokerHaDialog
+          key={haTarget.instanceId + haTarget.brokerName}
+          instanceId={haTarget.instanceId}
+          brokerName={haTarget.brokerName}
+          onClose={() => setHaTarget(null)}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
<!-- Make sure the base branch is `master`: that is the RocketMQ Studio trunk. -->

### Which Issue(s) This PR Fixes

- Fixes #4425
- Replaces #4106, closed by the branch switch in #4379.

### Brief Description

This is a resubmission of #4106 against `master`, following the branch switch notice in #4379. The fork branch is unchanged; `master` is now the RocketMQ Studio trunk.

## 变更目的

在 Broker 集群页增加按需查询的主从复制诊断。运维人员可以从现有 Broker 行查看全部登记副本的实时角色、日志偏移、主节点确认差距和传输速率，展开从节点查看上游地址及最后读写时间。

## 实现范围

- 新增只读 `GET /api/brokers/ha?instanceId=...&brokerName=...`，复用所选 Apache 实例的运行时客户端与凭据。
- 从该实例的 NameServer 地址表选择全部副本并按 Broker ID 排序；接口不接受任意目标地址。
- 调用原生 `getBrokerHAStatus`，角色以响应为准；偏移、差距和速率使用十进制字符串保留 64 位整数精度。
- 单个节点不支持查询、超时或失败时返回节点错误和 `complete=false`，保留其他节点的诊断结果；线程中断停止后续查询。
- 增加列表入口、主从明细、手动刷新、部分结果提示及关闭／切换实例后的请求取消和过期响应隔离。
- 新增中文操作和兼容性说明，无新增依赖与持久化字段。

核对全部 Issue/PR 标题正文和在线 `HA replication` 检索后，相关 #658 是复制告警规则，没有提供原生 HA 状态查询与副本明细。协议字段和单位依据官方 [HARuntimeInfo](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/HARuntimeInfo.java) 与 [haStatus 命令](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/tools/src/main/java/org/apache/rocketmq/tools/command/ha/HAStatusSubCommand.java)。

### How Did You Test This Change?

## 本地验证

基线 `d6dee7d7ccfcf4886f02466ec51452a6928b2cc8`，Java 21、Node 24.18.0，2026-09-08。

```bash
cd server
mvn -B -ntp -Dtest=BrokerHaTest,RuntimeAdminClientResolverTest,ClusterControllerTest verify
cd ../web
npx vitest run src/api/brokerHa.test.ts src/components/__tests__/BrokerHaDialog.test.tsx src/pages/studio/__tests__/BrokerCluster.test.tsx
npm run build
```

- 后端 52 个测试通过，含 9 个新增 HTTP／服务组合场景；Checkstyle、打包通过。
- 新增服务 JaCoCo 行覆盖率 43/43、分支覆盖率 20/20；新增 Controller 与响应记录类均覆盖。
- 前端 24 个测试通过；TypeScript、Vite 构建及修改文件 ESLint 通过。
- Playwright 在真实本地页面使用受控 GET 响应，验证列表入口、复制连接展开、`9007199254740993` 偏移精度与部分失败；1100px 弹窗没有自身横向溢出。测试使用 ConfigProvider 关闭 jsdom 不完成的 CSS 动画，生产动画保持正常。
- `git diff --check` 通过；10 个文件，904 行新增、1 行删除，合计 905 行。

原样上游基线已有 3 个全量后端失败（AuthCorsIntegrationTest 两项、AliyunInstanceProviderTest 一项）和依赖漏洞。本 PR 无新增依赖、相关验证无新增失败；不把增量验证称为项目级全量验收。真实集群 E2E、性能、压力、容量及混沌测试未执行。

副本依次采样，延迟受现有 RPC 超时和登记副本数影响，不是原子快照。浏览器取消不保证已经开始的 Broker RPC 立即终止。HA 服务支持由 Broker 版本与模式决定，不能依据本快照断言故障切换安全。

无迁移，直接部署；回滚该独立提交即可移除功能。提交含 `[skip ci]`，验证在本地执行。

### Checklist

- [x] One coherent change; unrelated modifications are not bundled in
- [x] Commit subject follows Conventional Commits (`feat:` / `fix:` / `refactor:` / `chore:` / `docs:` / `perf:`)
- [x] Tests added or updated for non-trivial changes, test methods named `...Test`
- [x] New UI text has both Chinese and English entries under `web/src/i18n/`, or the change does not add UI text
- [x] Architecture constraints stay green (`mvn test` runs the ArchUnit checks), or the original verification scope is stated above
- [x] New source files carry the ASF license header, or no new source files were added
- [x] Documentation touched where behaviour changed (README / `docs/` / in-app help), or no documentation change was required
