### PR TITLE
feat(message): recall pending delayed messages by receipt handle

### DIFF
--- a/docs/delayed-message-recall.md
+++ b/docs/delayed-message-recall.md
@@ -1,0 +1,54 @@
+# 定时消息撤回
+
+消息查询页提供 `Recall delayed message` 入口，使用原生产者发送回执中的撤回句柄请求 Broker 撤回待投递定时消息。
+入口仅对真实 Apache 实例启用。启用登录校验时，检查句柄与撤回接口均需要管理员权限。
+
+## 操作流程
+
+1. 在消息查询页选中原发送使用的 Apache 实例，点击 `Recall delayed message`。
+2. 输入原 Topic 和生产者发送回执中的 `recallHandle`，点击 `Inspect handle`。
+3. 核对解码后的 Topic、Broker、原消息 ID 和句柄时间。
+4. 点击 `Confirm recall` 提交。成功时展示 Broker 返回的消息 ID 和接收提示。
+5. 如需确认业务结果，结合原生产应用和消息轨迹检查；不要仅根据接口成功判断消息从未被投递。
+
+检查阶段仅解析实例与句柄，不打开生产者连接、不写入撤回标记。
+修改 Topic 或句柄会清除已检查的目标，必须重新检查后确认。
+提交期间锁定表单和关闭按钮，完成后显示结果；失败不会自动重试。
+切换实例会卸载旧窗口，迟到响应不会写入新实例窗口。
+
+## 句柄与限制
+
+仅消息 ID 无法执行撤回。句柄由原始发送回执提供，不能从普通消息查询结果重建。
+原生 SDK 的 v1 句柄包含 Topic、Broker 名称、时间和消息 ID，Studio 直接复用 SDK 解码器。
+Topic 必须与句柄一致。句柄时间保持 SDK 的值，可能包含 Broker 为时间取整补偿的 1 毫秒。
+本地不根据时钟推断句柄仍然有效；最终时效检查由 Broker 完成。
+
+功能要求 Broker 支持定时消息撤回并允许该操作。旧延迟等级消息和已投递消息不能通过本功能撤销。
+过期、Topic 不存在、Broker 角色或权限拒绝等错误直接显示，不切换到其他实例或 Broker 重试。
+Broker 接收的是定时删除标记，SDK 成功回执不等于对最终投递状态的独立证明。
+网络超时后结果可能不确定，重新提交前应核对生产应用与轨迹状态。
+
+## 接口与审计
+
+```http
+POST /api/messages/recall/preview
+POST /api/messages/recall
+Content-Type: application/json
+
+{"instanceId":"instance-a","topic":"orders","recallHandle":"<producer-receipt-handle>"}
+```
+
+检查接口返回目标信息；撤回接口返回 `messageId` 和 `acceptedAt`。
+执行路径复用实例绑定的 Producer 池。SDK 异常保留现有 502 映射，中断状态会恢复。
+审计操作名为 `RECALL_DELAY_MESSAGE`，记录实例、Topic、Broker、消息 ID、时间及操作结果；不记录完整句柄。
+审计存储失败不会把 Broker 已接受的操作改报为失败。
+
+## 兼容性与验证
+
+无新增依赖、数据库字段或配置。无迁移，直接部署；回滚提交可移除入口和接口。
+回滚代码不能恢复已经被 Broker 接收的撤回操作，恢复业务任务需由原生产应用明确重新发送。
+本地测试覆盖真实实例解析／客户端池到模拟 SDK 的链路、HTTP 校验、权限、审计和前端确认流程。
+浏览器验证使用受控本地接口响应，不向真实 Broker 写入消息。真实集群 E2E、压力、容量与混沌尚未执行。
+
+语义依据：RocketMQ 5.5.0 的 [RecallMessageProcessor](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/RecallMessageProcessor.java)
+与 [RecallMessageHandle](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/common/src/main/java/org/apache/rocketmq/common/producer/RecallMessageHandle.java)。最后核对日期：2026-09-08。

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/DelayMessageRecallController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/DelayMessageRecallController.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import org.apache.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/messages/recall")
+@RequiredArgsConstructor
+public class DelayMessageRecallController {
+    private final DelayMessageRecallService service;
+
+    @PostMapping("/preview")
+    public Result<RecallMessagePreview> preview(@Valid @RequestBody RecallMessageDTO request) {
+        return Result.ok(service.preview(request));
+    }
+
+    @PostMapping
+    public Result<RecallMessageReceipt> recall(@Valid @RequestBody RecallMessageDTO request) {
+        return Result.ok(service.recall(request));
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/DelayMessageRecallService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/DelayMessageRecallService.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.rocketmq.common.producer.RecallMessageHandle;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DelayMessageRecallService {
+    private final RuntimeAdminClientResolver resolver;
+    private final OperationAuditService auditService;
+
+    public RecallMessagePreview preview(RecallMessageDTO request) {
+        resolver.resolveEndpoint(request.instanceId());
+        return decode(request);
+    }
+
+    public RecallMessageReceipt recall(RecallMessageDTO request) {
+        RecallMessagePreview target = decode(request);
+        return resolver.executeProducer(request.instanceId(), producer -> {
+            String messageId;
+            try {
+                messageId = producer.recallMessage(target.topic(), request.recallHandle().trim());
+                if (messageId == null || messageId.isBlank()) {
+                    throw new BusinessException(502, "Broker returned no recall receipt");
+                }
+            } catch (Exception failure) {
+                if (failure instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+                record(request.instanceId(), target, "FAILED", failure.getMessage());
+                throw failure;
+            }
+            // Keep the observational audit outside the broker operation's failure boundary.
+            record(request.instanceId(), target, "SUCCESS", null);
+            return new RecallMessageReceipt(messageId, System.currentTimeMillis());
+        });
+    }
+
+    private RecallMessagePreview decode(RecallMessageDTO request) {
+        try {
+            var handle = (RecallMessageHandle.HandleV1) RecallMessageHandle.decodeHandle(request.recallHandle().trim());
+            if (!request.topic().trim().equals(handle.getTopic())) {
+                throw new BusinessException(400, "Topic does not match the recall handle");
+            }
+            long timestamp = Long.parseLong(handle.getTimestampStr());
+            if (timestamp <= 0 || handle.getBrokerName().isBlank() || handle.getMessageId().isBlank()) {
+                throw new BusinessException(400, "Recall handle has invalid target fields");
+            }
+            return new RecallMessagePreview(handle.getTopic(), handle.getBrokerName(), handle.getMessageId(), timestamp);
+        } catch (DecoderException | NumberFormatException | IndexOutOfBoundsException failure) {
+            throw new BusinessException(400, "Recall handle is invalid");
+        }
+    }
+
+    private void record(String instanceId, RecallMessagePreview target, String result, String error) {
+        auditService.record("RECALL_DELAY_MESSAGE", "MESSAGE", target.messageId(), instanceId,
+                "topic=" + target.topic() + ", broker=" + target.brokerName()
+                        + ", deliveryTimestamp=" + target.deliveryTimestamp(),
+                result, error);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/RecallMessageDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/RecallMessageDTO.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RecallMessageDTO(@NotBlank String instanceId, @NotBlank String topic, @NotBlank String recallHandle) {
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/RecallMessagePreview.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/RecallMessagePreview.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+/** A decoded handle describes the target; it does not prove that the message is still pending. */
+public record RecallMessagePreview(String topic, String brokerName, String messageId, long deliveryTimestamp) {
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/RecallMessageReceipt.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/RecallMessageReceipt.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+/** The broker accepted the recall marker; delivery is not queried or independently confirmed. */
+public record RecallMessageReceipt(String messageId, long acceptedAt) {
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
@@ -42,6 +42,20 @@ import static org.mockito.Mockito.when;
 
 class AuthInterceptorTest {
 
+    @ParameterizedTest
+    @ValueSource(strings = {"/api/messages/recall", "/api/messages/recall/preview"})
+    void delayedMessageRecallRequiresAdmin(String path) throws Exception {
+        TestSession reader = login(false);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        assertThat(reader.interceptor().preHandle(authenticatedRequest("POST", path, reader.token()),
+                response, new Object())).isFalse();
+        assertThat(response.getStatus()).isEqualTo(403);
+
+        TestSession admin = login(true);
+        assertThat(admin.interceptor().preHandle(authenticatedRequest("POST", path, admin.token()),
+                new MockHttpServletResponse(), new Object())).isTrue();
+    }
+
     @Test
     void shouldResolveAuthenticatedUserOnlyOncePerRequest() throws Exception {
         AuthProperties properties = new AuthProperties();

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/DelayMessageRecallTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/DelayMessageRecallTest.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.common.producer.RecallMessageHandle;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminProperties;
+import org.apache.rocketmq.studio.cluster.broker.MqClientPool;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.exception.GlobalExceptionHandler;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.studio.persistence.entity.RmqOperationAudit;
+import org.apache.rocketmq.studio.persistence.mapper.RmqOperationAuditMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedConstruction;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+class DelayMessageRecallTest {
+    private static final String HANDLE = RecallMessageHandle.HandleV1.buildHandle(
+            "orders", "broker-a", "1888825600000", "original-message");
+    private final InstanceRepository instances = mock(InstanceRepository.class);
+    private final RmqOperationAuditMapper audits = mock(RmqOperationAuditMapper.class);
+    private final MqClientPool pool = new MqClientPool();
+    private final ObjectMapper json = new ObjectMapper();
+    private MockedConstruction<DefaultMQProducer> producers;
+    private DelayMessageRecallService service;
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() {
+        producers = mockConstruction(DefaultMQProducer.class);
+        when(instances.findByIdentifier("instance-a")).thenReturn(Optional.of(InstanceVO.builder()
+                .name("instance-a").vendor(InstanceVendor.APACHE).endpoint("selected:9876").build()));
+        var resolver = new RuntimeAdminClientResolver(instances, mock(MqAdminExtFactory.class),
+                new MqAdminProperties(), pool);
+        service = new DelayMessageRecallService(resolver, new OperationAuditService(audits));
+        mvc = MockMvcBuilders.standaloneSetup(new DelayMessageRecallController(service))
+                .setControllerAdvice(new GlobalExceptionHandler()).build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        Thread.interrupted();
+        pool.shutdown();
+        producers.close();
+    }
+
+    @Test
+    void previewDecodesOriginalReceiptWithoutOpeningProducerOrAuditingMutation() throws Exception {
+        mvc.perform(post("/api/messages/recall/preview").contentType(MediaType.APPLICATION_JSON)
+                        .content(json.writeValueAsBytes(request("orders", HANDLE))))
+                .andExpect(jsonPath("$.data.topic").value("orders"))
+                .andExpect(jsonPath("$.data.brokerName").value("broker-a"))
+                .andExpect(jsonPath("$.data.messageId").value("original-message"))
+                .andExpect(jsonPath("$.data.deliveryTimestamp").value(1888825600000L));
+        assertThat(producers.constructed()).isEmpty();
+        verifyNoInteractions(audits);
+    }
+
+    @Test
+    void recallUsesSelectedEndpointAndAuditsAcceptedMessageWithoutHandle() throws Exception {
+        var producer = producer();
+        when(producer.recallMessage("orders", HANDLE)).thenReturn("original-message");
+        mvc.perform(post("/api/messages/recall").contentType(MediaType.APPLICATION_JSON)
+                        .content(json.writeValueAsBytes(request(" orders ", " " + HANDLE + " "))))
+                .andExpect(jsonPath("$.data.messageId").value("original-message"))
+                .andExpect(jsonPath("$.data.acceptedAt").isNumber());
+        verify(producer).setNamesrvAddr("selected:9876");
+        verify(producer).recallMessage("orders", HANDLE);
+        var record = audit();
+        assertThat(record.getOperation()).isEqualTo("RECALL_DELAY_MESSAGE");
+        assertThat(record.getResult()).isEqualTo("SUCCESS");
+        assertThat(record.getResourceName()).isEqualTo("original-message");
+        assertThat(record.getClusterId()).isEqualTo("instance-a");
+        assertThat(record.getDetail()).contains("topic=orders", "broker=broker-a").doesNotContain(HANDLE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"not-a-handle", "%%%%", "djIgYSBiIDEgYw==", "IA=="})
+    void invalidHandleFailsBeforeProducerCreation(String handle) {
+        assertThatThrownBy(() -> service.recall(request("orders", handle)))
+                .isInstanceOf(BusinessException.class).hasMessageContaining("invalid");
+        assertThat(producers.constructed()).isEmpty();
+        verifyNoInteractions(audits);
+    }
+
+    @Test
+    void topicMismatchCannotRedirectTheRecall() {
+        assertThatThrownBy(() -> service.recall(request("other-topic", HANDLE)))
+                .hasMessageContaining("does not match");
+        assertThat(producers.constructed()).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"unknown", "-1", "0", "9223372036854775808"})
+    void malformedTimestampIsRejectedWithoutApplyingALocalClockDeadline(String timestamp) {
+        String handle = RecallMessageHandle.HandleV1.buildHandle("orders", "broker-a", timestamp, "original-message");
+        assertThatThrownBy(() -> service.preview(request("orders", handle))).isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    void malformedTargetFieldsAreRejected() {
+        String handle = RecallMessageHandle.HandleV1.buildHandle("orders", "", "1888825600000", "original-message");
+        assertThatThrownBy(() -> service.recall(request("orders", handle))).hasMessageContaining("invalid target");
+    }
+
+    @Test
+    void brokerRejectionKeepsFailureAndRecordsItOnce() throws Exception {
+        when(producer().recallMessage("orders", HANDLE))
+                .thenThrow(new MQBrokerException(ResponseCode.ILLEGAL_OPERATION, "timestamp invalid"));
+        mvc.perform(post("/api/messages/recall").contentType(MediaType.APPLICATION_JSON)
+                        .content(json.writeValueAsBytes(request("orders", HANDLE))))
+                .andExpect(jsonPath("$.code").value(502))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("timestamp invalid")));
+        assertThat(audit().getResult()).isEqualTo("FAILED");
+    }
+
+    @Test
+    void missingReceiptIsNotReportedAsAccepted() throws Exception {
+        producer();
+        assertThatThrownBy(() -> service.recall(request("orders", HANDLE))).hasMessageContaining("no recall receipt");
+        assertThat(audit().getResult()).isEqualTo("FAILED");
+    }
+
+    @Test
+    void auditStorageFailureDoesNotConvertAcceptanceIntoRetryableFailure() throws Exception {
+        when(producer().recallMessage("orders", HANDLE)).thenReturn("original-message");
+        when(audits.insert(any(RmqOperationAudit.class))).thenThrow(new IllegalStateException("storage unavailable"));
+        assertThat(service.recall(request("orders", HANDLE)).messageId()).isEqualTo("original-message");
+        verify(producer()).recallMessage("orders", HANDLE);
+    }
+
+    @Test
+    void interruptionIsPreservedAndAudited() throws Exception {
+        var producer = producer();
+        doThrow(new InterruptedException("cancelled")).when(producer).recallMessage(anyString(), anyString());
+        assertThatThrownBy(() -> service.recall(request("orders", HANDLE))).hasMessageContaining("cancelled");
+        assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        assertThat(audit().getResult()).isEqualTo("FAILED");
+    }
+
+    @Test
+    void cloudInstanceCannotFallBackToDefaultApacheEndpoint() {
+        when(instances.findByIdentifier("instance-a")).thenReturn(Optional.of(InstanceVO.builder()
+                .name("instance-a").vendor(InstanceVendor.ALIYUN).endpoint("cloud").build()));
+        assertThatThrownBy(() -> service.preview(request("orders", HANDLE))).hasMessageContaining("only supports Apache");
+        assertThatThrownBy(() -> service.recall(request("orders", HANDLE))).hasMessageContaining("only supports Apache");
+        assertThat(producers.constructed()).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"instanceId\":\"instance-a\",\"topic\":\"orders\",\"recallHandle\":\" \"}"})
+    void requiredHttpFieldsAreValidated(String body) throws Exception {
+        mvc.perform(post("/api/messages/recall").contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(jsonPath("$.code").value(400));
+        assertThat(producers.constructed()).isEmpty();
+    }
+
+    private DefaultMQProducer producer() {
+        pool.withProducer("selected:9876", null, null, client -> client);
+        return producers.constructed().getFirst();
+    }
+
+    private RecallMessageDTO request(String topic, String handle) {
+        return new RecallMessageDTO("instance-a", topic, handle);
+    }
+
+    private RmqOperationAudit audit() {
+        var capture = ArgumentCaptor.forClass(RmqOperationAudit.class);
+        verify(audits).insert(capture.capture());
+        return capture.getValue();
+    }
+}

--- a/web/src/api/messageRecall.test.ts
+++ b/web/src/api/messageRecall.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, describe, expect, it } from 'vitest';
+import client from './client';
+import { previewMessageRecall, recallDelayMessage } from './messageRecall';
+
+const mock = new MockAdapter(client);
+const request = { instanceId: 'instance-a', topic: 'orders', recallHandle: 'producer-handle' };
+afterEach(() => mock.reset());
+
+describe('message recall contract', () => {
+  it('keeps handle inspection separate from the recall mutation', async () => {
+    const target = {
+      topic: 'orders',
+      brokerName: 'broker-a',
+      messageId: 'original-id',
+      deliveryTimestamp: 1888825600000,
+    };
+    mock.onPost('/messages/recall/preview').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual(request);
+      return [200, { code: 200, data: target }];
+    });
+    expect(await previewMessageRecall(request)).toEqual(target);
+    expect(mock.history.post.map((config) => config.url)).toEqual(['/messages/recall/preview']);
+  });
+
+  it('submits an explicit recall and returns the broker receipt', async () => {
+    const receipt = { messageId: 'original-id', acceptedAt: 1788825600000 };
+    mock.onPost('/messages/recall').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual(request);
+      return [200, { code: 200, data: receipt }];
+    });
+    expect(await recallDelayMessage(request)).toEqual(receipt);
+    expect(mock.history.post).toHaveLength(1);
+  });
+});

--- a/web/src/api/messageRecall.ts
+++ b/web/src/api/messageRecall.ts
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import client from './client';
+
+export interface RecallRequest {
+  instanceId: string;
+  topic: string;
+  recallHandle: string;
+}
+
+export interface RecallTarget {
+  topic: string;
+  brokerName: string;
+  messageId: string;
+  deliveryTimestamp: number;
+}
+
+export interface RecallReceipt {
+  messageId: string;
+  acceptedAt: number;
+}
+
+export async function previewMessageRecall(request: RecallRequest) {
+  const response = await client.post<{ data: RecallTarget }>('/messages/recall/preview', request);
+  return response.data.data;
+}
+
+export async function recallDelayMessage(request: RecallRequest) {
+  const response = await client.post<{ data: RecallReceipt }>('/messages/recall', request);
+  return response.data.data;
+}

--- a/web/src/components/DelayMessageRecallDialog.tsx
+++ b/web/src/components/DelayMessageRecallDialog.tsx
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Alert, Button, Descriptions, Form, Input, Modal, Space, Typography } from 'antd';
+import {
+  previewMessageRecall,
+  recallDelayMessage,
+  type RecallRequest,
+  type RecallTarget,
+  type RecallReceipt,
+} from '../api/messageRecall';
+
+interface Props {
+  instanceId: string;
+  initialTopic?: string;
+  onClose: () => void;
+}
+
+export default function DelayMessageRecallDialog({ instanceId, initialTopic, onClose }: Props) {
+  const [form] = Form.useForm<{ topic: string; recallHandle: string }>();
+  const [target, setTarget] = useState<{ request: RecallRequest; detail: RecallTarget } | null>(
+    null,
+  );
+  const [receipt, setReceipt] = useState<RecallReceipt | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<'preview' | 'recall' | null>(null);
+  const busyRef = useRef(false);
+  const activeRef = useRef(true);
+  const generationRef = useRef(0);
+  useEffect(() => {
+    activeRef.current = true;
+    return () => {
+      activeRef.current = false;
+      generationRef.current += 1;
+    };
+  }, []);
+
+  const preview = async () => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    const generation = ++generationRef.current;
+    try {
+      const values = await form.validateFields();
+      if (!activeRef.current || generation !== generationRef.current) return;
+      const request = {
+        instanceId,
+        topic: values.topic.trim(),
+        recallHandle: values.recallHandle.trim(),
+      };
+      setBusy('preview');
+      setError(null);
+      setReceipt(null);
+      setTarget(null);
+      const detail = await previewMessageRecall(request);
+      if (activeRef.current && generation === generationRef.current) setTarget({ request, detail });
+    } catch (failure) {
+      if (activeRef.current && generation === generationRef.current && failure instanceof Error)
+        setError(failure.message);
+    } finally {
+      busyRef.current = false;
+      if (activeRef.current) setBusy(null);
+    }
+  };
+
+  const recall = async () => {
+    if (busyRef.current || !target || receipt) return;
+    busyRef.current = true;
+    setBusy('recall');
+    setError(null);
+    try {
+      const result = await recallDelayMessage(target.request);
+      if (activeRef.current) setReceipt(result);
+    } catch (failure) {
+      if (activeRef.current)
+        setError(failure instanceof Error ? failure.message : 'Recall request failed');
+    } finally {
+      busyRef.current = false;
+      if (activeRef.current) setBusy(null);
+    }
+  };
+
+  return (
+    <Modal
+      open
+      title="Recall a delayed message"
+      width={720}
+      styles={{ body: { maxHeight: '65vh', overflowY: 'auto', paddingRight: 8 } }}
+      onCancel={onClose}
+      closable={busy !== 'recall'}
+      maskClosable={busy !== 'recall'}
+      keyboard={busy !== 'recall'}
+      footer={
+        <Space>
+          <Button disabled={busy === 'recall'} onClick={onClose}>
+            Close
+          </Button>
+          <Button
+            loading={busy === 'preview'}
+            disabled={busy === 'recall'}
+            onClick={() => void preview()}
+          >
+            Inspect handle
+          </Button>
+          <Button
+            danger
+            type="primary"
+            disabled={!target || !!receipt || busy === 'preview'}
+            loading={busy === 'recall'}
+            onClick={() => void recall()}
+          >
+            Confirm recall
+          </Button>
+        </Space>
+      }
+    >
+      <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+        <Alert
+          showIcon
+          type="warning"
+          message="Recall applies only to pending timer messages"
+          description="Paste the recall handle returned by the original producer send receipt. A message ID alone cannot recall a message. Broker acceptance does not undo a message already delivered."
+        />
+        <Typography.Text>Instance: {instanceId}</Typography.Text>
+        <Form
+          form={form}
+          layout="vertical"
+          initialValues={{ topic: initialTopic }}
+          disabled={busy !== null}
+          onValuesChange={() => {
+            generationRef.current += 1;
+            setTarget(null);
+            setReceipt(null);
+            setError(null);
+          }}
+        >
+          <Form.Item
+            label="Topic"
+            name="topic"
+            rules={[{ required: true, whitespace: true, message: 'Topic is required' }]}
+          >
+            <Input />
+          </Form.Item>
+          <Form.Item
+            label="Recall handle"
+            name="recallHandle"
+            rules={[{ required: true, whitespace: true, message: 'Recall handle is required' }]}
+          >
+            <Input.TextArea rows={3} autoComplete="off" />
+          </Form.Item>
+        </Form>
+        {target && (
+          <Descriptions bordered size="small" column={1}>
+            <Descriptions.Item label="Target Topic">{target.detail.topic}</Descriptions.Item>
+            <Descriptions.Item label="Broker">{target.detail.brokerName}</Descriptions.Item>
+            <Descriptions.Item label="Original message ID">
+              {target.detail.messageId}
+            </Descriptions.Item>
+            <Descriptions.Item label="Handle delivery time">
+              {new Date(target.detail.deliveryTimestamp).toLocaleString()}
+            </Descriptions.Item>
+          </Descriptions>
+        )}
+        {error && <Alert type="error" showIcon message={error} />}
+        {receipt && (
+          <Alert
+            type="success"
+            showIcon
+            message="Broker accepted the recall request"
+            description={
+              <Space direction="vertical">
+                <Typography.Text copyable>{receipt.messageId}</Typography.Text>
+                <Typography.Text>
+                  Acceptance does not independently confirm cancellation. Check the message trace or
+                  the producing application if delivery status is uncertain.
+                </Typography.Text>
+              </Space>
+            }
+          />
+        )}
+      </Space>
+    </Modal>
+  );
+}

--- a/web/src/components/__tests__/DelayMessageRecallDialog.test.tsx
+++ b/web/src/components/__tests__/DelayMessageRecallDialog.test.tsx
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, fireEvent, render as renderComponent, screen, waitFor } from '@testing-library/react';
+import { ConfigProvider } from 'antd';
+import type { ReactElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import DelayMessageRecallDialog from '../DelayMessageRecallDialog';
+import {
+  previewMessageRecall,
+  recallDelayMessage,
+  type RecallTarget,
+  type RecallReceipt,
+} from '../../api/messageRecall';
+
+vi.mock('../../api/messageRecall', () => ({
+  previewMessageRecall: vi.fn(),
+  recallDelayMessage: vi.fn(),
+}));
+
+const target: RecallTarget = {
+  topic: 'orders',
+  brokerName: 'broker-a',
+  messageId: 'original-message',
+  deliveryTimestamp: 1888825600000,
+};
+const receipt: RecallReceipt = { messageId: 'original-message', acceptedAt: 1788825600000 };
+
+const render = (element: ReactElement) =>
+  renderComponent(element, {
+    wrapper: ({ children }) => (
+      <ConfigProvider theme={{ token: { motion: false } }}>{children}</ConfigProvider>
+    ),
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(previewMessageRecall).mockResolvedValue(target);
+  vi.mocked(recallDelayMessage).mockResolvedValue(receipt);
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockReturnValue({
+      matches: false,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  });
+});
+
+const open = () =>
+  render(
+    <DelayMessageRecallDialog instanceId="instance-a" initialTopic="orders" onClose={vi.fn()} />,
+  );
+
+async function inspect() {
+  fireEvent.change(screen.getByLabelText('Recall handle'), {
+    target: { value: ' original-handle ' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Inspect handle' }));
+  await screen.findByText('original-message');
+}
+
+describe('DelayMessageRecallDialog', () => {
+  it('requires inspection and then submits the exact inspected target after confirmation', async () => {
+    open();
+    expect(screen.getByRole('button', { name: 'Confirm recall' })).toBeDisabled();
+    await inspect();
+    expect(previewMessageRecall).toHaveBeenCalledWith({
+      instanceId: 'instance-a',
+      topic: 'orders',
+      recallHandle: 'original-handle',
+    });
+    await waitFor(() => expect(screen.getByText('broker-a')).toBeVisible());
+    expect(recallDelayMessage).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm recall' }));
+    await waitFor(() =>
+      expect(screen.getByText('Broker accepted the recall request')).toBeVisible(),
+    );
+    expect(recallDelayMessage).toHaveBeenCalledWith({
+      instanceId: 'instance-a',
+      topic: 'orders',
+      recallHandle: 'original-handle',
+    });
+    expect(screen.getByRole('button', { name: 'Confirm recall' })).toBeDisabled();
+  });
+
+  it('rejects empty form fields without invoking either endpoint', async () => {
+    open();
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect handle' }));
+    await waitFor(() => expect(screen.getByText('Recall handle is required')).toBeVisible());
+    expect(previewMessageRecall).not.toHaveBeenCalled();
+    expect(recallDelayMessage).not.toHaveBeenCalled();
+  });
+
+  it('invalidates the confirmation whenever the handle or topic changes', async () => {
+    open();
+    await inspect();
+    fireEvent.change(screen.getByLabelText('Topic'), { target: { value: 'other-topic' } });
+    expect(screen.queryByText('original-message')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm recall' })).toBeDisabled();
+  });
+
+  it('shows a malformed handle error and keeps recall disabled', async () => {
+    vi.mocked(previewMessageRecall).mockRejectedValue(new Error('Recall handle is invalid'));
+    open();
+    fireEvent.change(screen.getByLabelText('Recall handle'), { target: { value: 'bad' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect handle' }));
+    await waitFor(() => expect(screen.getByText('Recall handle is invalid')).toBeVisible());
+    expect(screen.getByRole('button', { name: 'Confirm recall' })).toBeDisabled();
+  });
+
+  it('keeps broker rejection visible and does not manufacture a success receipt', async () => {
+    vi.mocked(recallDelayMessage).mockRejectedValue(new Error('recall failed, timestamp invalid'));
+    open();
+    await inspect();
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm recall' }));
+    await waitFor(() => expect(screen.getByText('recall failed, timestamp invalid')).toBeVisible());
+    expect(screen.queryByText('Broker accepted the recall request')).not.toBeInTheDocument();
+  });
+
+  it('submits only once and keeps the dialog locked while recall is pending', async () => {
+    let finish!: (value: RecallReceipt) => void;
+    vi.mocked(recallDelayMessage).mockReturnValue(
+      new Promise((resolve) => {
+        finish = resolve;
+      }),
+    );
+    open();
+    await inspect();
+    const button = screen.getByRole('button', { name: 'Confirm recall' });
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(recallDelayMessage).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText('Topic')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Close' })).toBeDisabled();
+    await act(async () => finish(receipt));
+    await waitFor(() =>
+      expect(screen.getByText('Broker accepted the recall request')).toBeVisible(),
+    );
+  });
+
+  it('ignores a late inspection after the dialog has closed', async () => {
+    let finish!: (value: RecallTarget) => void;
+    vi.mocked(previewMessageRecall).mockReturnValue(
+      new Promise((resolve) => {
+        finish = resolve;
+      }),
+    );
+    const { unmount } = open();
+    fireEvent.change(screen.getByLabelText('Recall handle'), {
+      target: { value: 'original-handle' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect handle' }));
+    await waitFor(() => expect(previewMessageRecall).toHaveBeenCalledTimes(1));
+    unmount();
+    await act(async () => finish(target));
+    expect(screen.queryByText('original-message')).not.toBeInTheDocument();
+    expect(recallDelayMessage).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -53,6 +53,9 @@ import type { Dayjs } from 'dayjs';
 import PageHeader from '../../components/PageHeader';
 import { InstanceSelect } from '../../components/InstanceSelect';
 import MessageQueryHistoryDrawer from '../../components/MessageQueryHistoryDrawer';
+import DelayMessageRecallDialog from '../../components/DelayMessageRecallDialog';
+import { supportsApacheRuntime } from '../../api/instance';
+import { isMockMode } from '../../services/dataMode';
 import {
   useQueueBrowser,
   QueueBrowserControls,
@@ -316,13 +319,15 @@ const TraceDiagnosticsPanel = ({ diagnostics }: { diagnostics: MessageTraceDiagn
    MessagePage
    ═══════════════════════════════════════════ */
 type InstanceFilterProps = {
+  recallSupported: boolean;
   selectedInstanceId: string | undefined;
   selectInstance: (instanceId: string) => void;
   instanceOptions: { value: string; label: string }[];
 };
 
 const MessagePage = () => {
-  const { selectedInstanceId, selectInstance, instanceOptions } = useInstanceFilter();
+  const { selectedInstanceId, selectedInstance, selectInstance, instanceOptions } =
+    useInstanceFilter();
   // Keying the content by the selected instance makes React remount it whenever the instance
   // changes — whether from this page's own <Select> or from the shared filter/route elsewhere —
   // so query results, the detail modal and in-flight request ownership all reset cleanly.
@@ -332,6 +337,9 @@ const MessagePage = () => {
       selectedInstanceId={selectedInstanceId}
       selectInstance={selectInstance}
       instanceOptions={instanceOptions}
+      recallSupported={
+        !!selectedInstance && supportsApacheRuntime(selectedInstance) && !isMockMode()
+      }
     />
   );
 };
@@ -340,6 +348,7 @@ const MessagePage = () => {
    MessagePageContent
    ═══════════════════════════════════════════ */
 const MessagePageContent = ({
+  recallSupported,
   selectedInstanceId,
   selectInstance,
   instanceOptions,
@@ -380,6 +389,7 @@ const MessagePageContent = ({
     };
   }, [loadTopicOptions]);
   const [queryMode, setQueryMode] = useState<QueryMode>('topic');
+  const [recallOpen, setRecallOpen] = useState(false);
   const queueBrowser = useQueueBrowser(selectedInstanceId);
   const [selectedTopic, setSelectedTopic] = useState<string | undefined>();
   const [dateRange, setDateRange] = useState<[Dayjs, Dayjs]>(getDefaultRange);
@@ -1017,7 +1027,22 @@ const MessagePageContent = ({
      ═══════════════════════════════════════════ */
   return (
     <div style={{ padding: 24 }}>
-      <PageHeader title={t('message.title')} subtitle="按 Topic、Key 或 Message ID 检索消息" />
+      <PageHeader
+        title={t('message.title')}
+        subtitle="按 Topic、Key 或 Message ID 检索消息"
+        extra={
+          <Button disabled={!recallSupported} onClick={() => setRecallOpen(true)}>
+            Recall delayed message
+          </Button>
+        }
+      />
+      {recallOpen && selectedInstanceId && recallSupported && (
+        <DelayMessageRecallDialog
+          instanceId={selectedInstanceId}
+          initialTopic={selectedTopic}
+          onClose={() => setRecallOpen(false)}
+        />
+      )}
 
       {/* ── Query Form ── */}
       <Card style={{ marginBottom: 16 }}>


### PR DESCRIPTION
<!-- Make sure the base branch is `master`: that is the RocketMQ Studio trunk. -->

### Which Issue(s) This PR Fixes

- Fixes #4427
- Replaces #4107, closed by the branch switch in #4379.

### Brief Description

This is a resubmission of #4107 against `master`, following the branch switch notice in #4379. The fork branch is unchanged; `master` is now the RocketMQ Studio trunk.

## 变更目的

消息查询页增加定时消息撤回入口。管理员提供原生产者回执中的 `recallHandle`，检查目标 Topic、Broker、消息 ID 和句柄时间，再显式确认撤回；结果显示 Broker 接收回执。

已有 #1930 展示撤回轨迹事件，#2576 修复轨迹失败状态，均没有执行撤回操作。本项已检索历史 Issue/PR 的标题正文及在线 `recall` 结果。

## 实现范围

- 新增 `POST /api/messages/recall/preview` 和 `POST /api/messages/recall`；沿用现有管理员权限规则并增加对应权限测试。
- 使用 SDK 的 `RecallMessageHandle` 解码器，校验请求 Topic 与句柄目标一致，显示原始目标；检查阶段只解析实例与句柄，不创建 Producer 或写入标记。
- 通过所选 Apache 实例的 Producer 池调用 `recallMessage`，不回落到默认实例；空回执不报成功，异常与中断保留现有处理语义。
- 记录 `RECALL_DELAY_MESSAGE` 成功／失败审计，包含目标字段且不记录完整句柄；审计存储失败不改变已接受操作的返回结果。
- 增加检查、确认、目标变更失效、提交锁定、迟到响应隔离和成功消息 ID 展示；Mock／云实例禁用入口。
- 新增中文操作、协议与回滚边界说明，无新增依赖或持久化模型。

官方 [RecallMessageProcessor](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/RecallMessageProcessor.java) 通过写入定时删除标记处理撤回。因此界面只报告“Broker accepted the recall request”，不宣称撤回了已经投递的消息，也不将成功响应视为对最终投递状态的独立证明。

### How Did You Test This Change?

## 本地验证

基线 `d6dee7d7ccfcf4886f02466ec51452a6928b2cc8`，Java 21、Node 24.18.0，2026-09-08。

```bash
cd server
mvn -B -ntp -Dtest=DelayMessageRecallTest,RuntimeAdminClientResolverTest,AuthInterceptorTest,OperationAuditServiceTest verify
cd ../web
npx vitest run src/api/messageRecall.test.ts src/components/__tests__/DelayMessageRecallDialog.test.tsx src/pages/instance/__tests__/MessagePage.test.tsx src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
npm run build
```

- 后端 73 个测试通过，包含 19 个新增撤回场景与 2 个新增权限场景；HTTP 到真实实例解析／客户端池链路只模拟 SDK 连接，未连接真实 Broker。
- 新增服务 JaCoCo 行覆盖率 28/28（100%）、分支 12/14，Controller 两个入口覆盖；Checkstyle、打包通过。
- 前端 38 个测试通过，TypeScript、Vite、修改文件 ESLint 通过。
- 本地 Playwright 验证入口、检查与确认发送相同的实例／Topic／句柄、显示接受回执并禁用再次确认；每次涉及提交的浏览器脚本都先拦截所有非 GET，只对两个精确本地接口返回受控结果，无真实撤回操作。
- `git diff --check` 通过；13 个文件，972 行新增、2 行删除，合计 974 行。

原样上游基线已有 3 个全量后端失败（AuthCorsIntegrationTest 两项、AliyunInstanceProviderTest 一项）与依赖漏洞。本 PR 无新增依赖，相关验证无新增失败，不将增量验证表述为项目级全量验收。真实集群 E2E、性能、压力、容量及混沌验证未执行。

Broker 必须支持并允许定时消息撤回。旧延迟等级消息与已投递消息不能据此撤销；Broker 保留最终时间与权限判断。超时可能产生不确定结果，页面不自动重试。

无迁移，直接部署；回滚该提交可移除接口与入口，但不能撤销 Broker 已接收的撤回操作。提交含 `[skip ci]`，验证在本地执行。

### Checklist

- [x] One coherent change; unrelated modifications are not bundled in
- [x] Commit subject follows Conventional Commits (`feat:` / `fix:` / `refactor:` / `chore:` / `docs:` / `perf:`)
- [x] Tests added or updated for non-trivial changes, test methods named `...Test`
- [x] New UI text has both Chinese and English entries under `web/src/i18n/`, or the change does not add UI text
- [x] Architecture constraints stay green (`mvn test` runs the ArchUnit checks), or the original verification scope is stated above
- [x] New source files carry the ASF license header, or no new source files were added
- [x] Documentation touched where behaviour changed (README / `docs/` / in-app help), or no documentation change was required
