### PR TITLE
feat: inspect broker timer configuration and runtime

### DIFF
--- a/docs/broker-timer-diagnostics.md
+++ b/docs/broker-timer-diagnostics.md
@@ -1,0 +1,54 @@
+# Broker 定时服务诊断
+
+最后验证日期：2026-09-08。适用于所选 Apache 实例中登记了主节点的 Broker。
+
+## 使用
+
+进入集群管理的 Broker 列表，选择实例，在目标行点击 `Timer status`。
+面板展示主节点地址、采样时间、定时配置和运行指标；点击 `Refresh snapshot` 手动重取。
+关闭面板或切换实例会取消浏览器请求并忽略迟到结果，不增加后台轮询。
+Mock 模式不提供此查询，云实例沿用页面原有的 Apache 实例筛选。
+
+配置包括时间轮开关、入队与出队暂停、RocksDB 定时引擎与扫描暂停、撤回开关、
+时间精度和最大延迟。页面保留 Broker 返回的原值，鼠标悬停标签可查看原配置名。
+这些配置用于解释当前观测，不提供配置修改或定时引擎切换。
+
+## 指标含义
+
+| Broker 字段 | 展示单位与含义 |
+| --- | --- |
+| `timerReadBehind` | 秒，定时出队进度落后时间；不是毫秒，也不是消费组延迟 |
+| `timerOffsetBehind` | 队列位置数，定时入队进度差 |
+| `timerCongestNum` | 时间轮待处理条目，包含尚未到期的消息，不能直接解释为超期消息数 |
+| `timerEnqueueTps` | 消息/秒，定时入队速率 |
+| `timerDequeueTps` | 消息/秒，定时出队速率 |
+
+计数通过 JSON 字符串传递，保留超过 JavaScript 安全整数范围的精度。
+未返回的字段显示 `Not reported`，不回填为零。关闭时间轮时，Broker 仍可能返回零指标；
+面板明确提示关闭状态，不根据这些零值给出健康结论。RocksDB 引擎切换期间需结合各暂停配置判断。
+
+## 接口与边界
+
+`GET /api/brokers/timer?instanceId=...&brokerName=...` 使用现有认证和实例管理客户端，
+通过该实例的 NameServer 查询 Broker，只读取主节点 ID 0，不接受任意地址或回退到从节点。
+名称不存在返回 404；未登记主节点返回 409。
+
+配置与运行指标是两次独立 RPC，并非原子快照。单个 RPC 失败时返回对应来源的错误，
+另一个来源仍可查看；两个来源均失败时也会显示失败原因，不伪造可用数据。
+版本不支持的字段保持缺失。仅返回列出的定时字段，不将全部 Broker 配置转发给浏览器。
+中断会终止后续探测并恢复线程中断标记。
+
+字段语义依据 RocketMQ 5.5.0 官方
+[TimerMessageStore](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java)
+与 [AdminBrokerProcessor](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java)。
+其他版本或引擎应结合相应 Broker 实现解释，不将本面板视为自动告警或健康检查。
+
+## 验证与回滚
+
+后端：`mvn -B -ntp -Dtest=BrokerTimerTest,RuntimeAdminClientResolverTest,ClusterControllerTest verify`。
+前端：运行 `brokerTimer.test.ts`、`BrokerTimerDialog.test.tsx` 和 `BrokerCluster.test.tsx`，
+并执行修改文件 ESLint 与 `npm run build`。浏览器使用本地受控响应验证真实列表入口和面板。
+真实集群 E2E、性能、压力、容量和混沌验证未执行。
+
+无新增依赖、配置、数据库字段或 Broker 写入。无迁移，直接部署；
+回滚代码即可移除接口和入口，不涉及数据回滚。

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerTimerController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerTimerController.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.Result;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class BrokerTimerController {
+    private final BrokerTimerService service;
+
+    @GetMapping("/api/brokers/timer")
+    public Result<BrokerTimerSnapshot> inspect(@RequestParam String instanceId, @RequestParam String brokerName) {
+        return Result.ok(service.inspect(instanceId, brokerName));
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerTimerService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerTimerService.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class BrokerTimerService {
+    private static final List<String> CONFIG_KEYS = List.of("timerWheelEnable", "timerStopEnqueue",
+            "timerStopDequeue", "timerRocksDBEnable", "timerRocksDBStopScan", "recallMessageEnable",
+            "timerPrecisionMs", "timerMaxDelaySec");
+    private static final List<String> RUNTIME_KEYS = List.of("timerReadBehind", "timerOffsetBehind",
+            "timerCongestNum", "timerEnqueueTps", "timerDequeueTps");
+    private final RuntimeAdminClientResolver resolver;
+
+    public BrokerTimerSnapshot inspect(String instanceId, String brokerName) {
+        if (brokerName == null || brokerName.isBlank()) {
+            throw new BusinessException(400, "brokerName is required");
+        }
+        String name = brokerName.trim();
+        return resolver.execute(instanceId, admin -> {
+            var cluster = admin.examineBrokerClusterInfo();
+            var broker = cluster.getBrokerAddrTable().get(name);
+            if (broker == null) {
+                throw new BusinessException(404, "Broker is not registered: " + name);
+            }
+            // Timer progress belongs to the registered master, not an arbitrary reachable replica.
+            String address = broker.getBrokerAddrs().get(MixAll.MASTER_ID);
+            if (address == null || address.isBlank()) {
+                throw new BusinessException(409, "Broker has no registered master: " + name);
+            }
+            var configuration = read(() -> {
+                var properties = admin.getBrokerConfig(address);
+                if (properties == null) {
+                    throw new BusinessException(502, "Broker returned no configuration");
+                }
+                Map<String, String> values = new LinkedHashMap<>();
+                for (String key : CONFIG_KEYS) {
+                    String value = properties.getProperty(key);
+                    if (value != null) {
+                        values.put(key, value);
+                    }
+                }
+                return values;
+            });
+            var runtime = read(() -> {
+                var stats = admin.fetchBrokerRuntimeStats(address);
+                if (stats == null || stats.getTable() == null) {
+                    throw new BusinessException(502, "Broker returned no runtime statistics");
+                }
+                Map<String, String> values = new LinkedHashMap<>();
+                for (String key : RUNTIME_KEYS) {
+                    String value = stats.getTable().get(key);
+                    if (value != null) {
+                        values.put(key, value);
+                    }
+                }
+                return values;
+            });
+            return new BrokerTimerSnapshot(name, address, System.currentTimeMillis(), configuration, runtime);
+        });
+    }
+
+    private BrokerTimerSnapshot.Section read(Probe probe) throws InterruptedException {
+        try {
+            return new BrokerTimerSnapshot.Section(Map.copyOf(probe.read()), null);
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw interrupted;
+        } catch (Exception failure) {
+            return new BrokerTimerSnapshot.Section(Map.of(), failure.getMessage() == null
+                    ? failure.getClass().getSimpleName() : failure.getMessage());
+        }
+    }
+
+    @FunctionalInterface
+    private interface Probe {
+        Map<String, String> read() throws Exception;
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerTimerSnapshot.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerTimerSnapshot.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import java.util.Map;
+
+public record BrokerTimerSnapshot(String brokerName, String address, long sampledAt,
+                                  Section configuration, Section runtime) {
+    public record Section(Map<String, String> values, String error) {
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/BrokerTimerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/BrokerTimerTest.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.body.KVTable;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.common.exception.GlobalExceptionHandler;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class BrokerTimerTest {
+    private final RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+    private final MQAdminExt admin = mock(MQAdminExt.class);
+    private final BrokerTimerService service = new BrokerTimerService(resolver);
+    private final ClusterInfo cluster = new ClusterInfo();
+    private final Properties configuration = new Properties();
+    private final KVTable runtime = new KVTable();
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        doAnswer(call -> call.<MqAdminExtFactory.AdminAction<?>>getArgument(1).apply(admin))
+                .when(resolver).execute(anyString(), any());
+        cluster.setBrokerAddrTable(new HashMap<>(Map.of("broker-a",
+                new BrokerData("cluster-a", "broker-a", new HashMap<>(Map.of(
+                        0L, "master:10911", 1L, "replica:10911"))))));
+        configuration.setProperty("timerWheelEnable", "true");
+        configuration.setProperty("timerStopEnqueue", "false");
+        configuration.setProperty("timerPrecisionMs", "1000");
+        configuration.setProperty("timerMaxDelaySec", "604800");
+        runtime.setTable(new HashMap<>(Map.of("timerReadBehind", "7",
+                "timerOffsetBehind", "9007199254740993", "timerCongestNum", "9007199254740995",
+                "timerEnqueueTps", "1.5", "timerDequeueTps", "0.5")));
+        when(admin.examineBrokerClusterInfo()).thenReturn(cluster);
+        when(admin.getBrokerConfig("master:10911")).thenReturn(configuration);
+        when(admin.fetchBrokerRuntimeStats("master:10911")).thenReturn(runtime);
+        mvc = MockMvcBuilders.standaloneSetup(new BrokerTimerController(service))
+                .setControllerAdvice(new GlobalExceptionHandler()).build();
+    }
+
+    @Test
+    void httpSnapshotUsesRegisteredMasterAndPreservesExactValues() throws Exception {
+        configuration.setProperty("accessKey", "must-not-be-exported");
+        configuration.setProperty("storePathRootDir", "/private/broker");
+        runtime.getTable().put("unrelatedRuntimeField", "private-value");
+        mvc.perform(get("/api/brokers/timer").param("instanceId", "instance-a")
+                        .param("brokerName", " broker-a "))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.address").value("master:10911"))
+                .andExpect(jsonPath("$.data.brokerName").value("broker-a"))
+                .andExpect(jsonPath("$.data.sampledAt").isNumber())
+                .andExpect(jsonPath("$.data.configuration.values.timerPrecisionMs").value("1000"))
+                .andExpect(jsonPath("$.data.runtime.values.timerReadBehind").value("7"))
+                .andExpect(jsonPath("$.data.runtime.values.timerOffsetBehind").value("9007199254740993"))
+                .andExpect(jsonPath("$.data.runtime.values.timerCongestNum").value("9007199254740995"))
+                .andExpect(jsonPath("$.data.runtime.values.timerEnqueueTps").value("1.5"))
+                .andExpect(jsonPath("$.data.configuration.values.accessKey").doesNotExist())
+                .andExpect(jsonPath("$.data.configuration.values.storePathRootDir").doesNotExist())
+                .andExpect(jsonPath("$.data.runtime.values.unrelatedRuntimeField").doesNotExist());
+        verify(resolver).execute(eq("instance-a"), any());
+        verify(admin, never()).getBrokerConfig("replica:10911");
+        verify(admin, never()).fetchBrokerRuntimeStats("replica:10911");
+    }
+
+    @Test
+    void disabledTimerWithZeroMetricsRemainsDisabled() {
+        configuration.setProperty("timerWheelEnable", "false");
+        runtime.getTable().replaceAll((key, value) -> "0");
+        var result = service.inspect("instance-a", "broker-a");
+        assertThat(result.configuration().values()).containsEntry("timerWheelEnable", "false");
+        assertThat(result.runtime().values()).containsEntry("timerReadBehind", "0");
+    }
+
+    @Test
+    void unsupportedFieldsAreAbsentRatherThanInventedDefaults() {
+        configuration.clear();
+        runtime.getTable().clear();
+        var result = service.inspect("instance-a", "broker-a");
+        assertThat(result.configuration().values()).isEmpty();
+        assertThat(result.runtime().values()).isEmpty();
+        assertThat(result.runtime().error()).isNull();
+    }
+
+    @Test
+    void failedConfigurationDoesNotHideRuntime() throws Exception {
+        when(admin.getBrokerConfig("master:10911")).thenThrow(new IllegalStateException("Config denied"));
+        var result = service.inspect("instance-a", "broker-a");
+        assertThat(result.configuration().error()).isEqualTo("Config denied");
+        assertThat(result.configuration().values()).isEmpty();
+        assertThat(result.runtime().values()).containsEntry("timerReadBehind", "7");
+    }
+
+    @Test
+    void failedRuntimeDoesNotHideConfiguration() throws Exception {
+        when(admin.fetchBrokerRuntimeStats("master:10911")).thenThrow(new IllegalStateException("Runtime denied"));
+        var result = service.inspect("instance-a", "broker-a");
+        assertThat(result.runtime().error()).isEqualTo("Runtime denied");
+        assertThat(result.configuration().values()).containsEntry("timerWheelEnable", "true");
+    }
+
+    @Test
+    void nullPayloadsProduceSourceErrors() throws Exception {
+        when(admin.getBrokerConfig("master:10911")).thenReturn(null);
+        when(admin.fetchBrokerRuntimeStats("master:10911")).thenReturn(null);
+        var result = service.inspect("instance-a", "broker-a");
+        assertThat(result.configuration().error()).contains("no configuration");
+        assertThat(result.runtime().error()).contains("no runtime statistics");
+    }
+
+    @Test
+    void nullRuntimeTableProducesSourceError() {
+        runtime.setTable(null);
+        assertThat(service.inspect("instance-a", "broker-a").runtime().error()).contains("no runtime statistics");
+    }
+
+    @Test
+    void exceptionWithoutMessageStillMarksSourceUnavailable() throws Exception {
+        when(admin.getBrokerConfig("master:10911")).thenThrow(new IllegalStateException());
+        assertThat(service.inspect("instance-a", "broker-a").configuration().error()).isEqualTo("IllegalStateException");
+    }
+
+    @Test
+    void interruptedConfigurationStopsTheNextProbe() throws Exception {
+        when(admin.getBrokerConfig("master:10911")).thenThrow(new InterruptedException("cancelled"));
+        try {
+            assertThatThrownBy(() -> service.inspect("instance-a", "broker-a")).isInstanceOf(InterruptedException.class);
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+            verify(admin, never()).fetchBrokerRuntimeStats(anyString());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void unknownBrokerCannotSupplyAnArbitraryAddress() throws Exception {
+        mvc.perform(get("/api/brokers/timer").param("instanceId", "instance-a")
+                        .param("brokerName", "outside:10911"))
+                .andExpect(status().isNotFound());
+        verify(admin, never()).getBrokerConfig(anyString());
+    }
+
+    @Test
+    void absentMasterDoesNotFallBackToReplica() throws Exception {
+        cluster.getBrokerAddrTable().get("broker-a").getBrokerAddrs().remove(0L);
+        mvc.perform(get("/api/brokers/timer").param("instanceId", "instance-a").param("brokerName", "broker-a"))
+                .andExpect(status().isConflict());
+        verify(admin, never()).fetchBrokerRuntimeStats(anyString());
+    }
+
+    @Test
+    void blankMasterAddressIsUnavailable() {
+        cluster.getBrokerAddrTable().get("broker-a").getBrokerAddrs().put(0L, " ");
+        assertThatThrownBy(() -> service.inspect("instance-a", "broker-a")).hasMessageContaining("no registered master");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = " ")
+    void blankBrokerIsRejectedBeforeResolvingInstance(String brokerName) {
+        assertThatThrownBy(() -> service.inspect("instance-a", brokerName)).hasMessage("brokerName is required");
+        verifyNoInteractions(resolver);
+    }
+
+    @Test
+    void httpRequiresInstanceAndBrokerParameters() throws Exception {
+        mvc.perform(get("/api/brokers/timer").param("brokerName", "broker-a")).andExpect(status().isBadRequest());
+        mvc.perform(get("/api/brokers/timer").param("instanceId", "instance-a")).andExpect(status().isBadRequest());
+        verifyNoInteractions(resolver);
+    }
+}

--- a/web/src/api/brokerTimer.test.ts
+++ b/web/src/api/brokerTimer.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, expect, it } from 'vitest';
+import client from './client';
+import { inspectBrokerTimer } from './brokerTimer';
+
+const mock = new MockAdapter(client);
+afterEach(() => mock.reset());
+
+it('passes instance, broker and cancellation without converting 64-bit counters', async () => {
+  const payload = { runtime: { values: { timerOffsetBehind: '9007199254740993' }, error: null } };
+  mock.onGet('/brokers/timer').reply(200, { code: 200, data: payload });
+  const controller = new AbortController();
+  expect(await inspectBrokerTimer('instance-a', 'broker/a', controller.signal)).toEqual(payload);
+  expect(mock.history.get[0].params).toEqual({ instanceId: 'instance-a', brokerName: 'broker/a' });
+  expect(mock.history.get[0].signal).toBe(controller.signal);
+  expect(mock.history.post).toHaveLength(0);
+});
+
+it('honors a cancelled inspection', async () => {
+  const controller = new AbortController();
+  controller.abort();
+  await expect(inspectBrokerTimer('instance-a', 'broker-a', controller.signal)).rejects.toThrow();
+  expect(mock.history.get).toHaveLength(0);
+});

--- a/web/src/api/brokerTimer.ts
+++ b/web/src/api/brokerTimer.ts
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import client from './client';
+
+export interface TimerSection {
+  values: Record<string, string>;
+  error: string | null;
+}
+
+export interface BrokerTimerSnapshot {
+  brokerName: string;
+  address: string;
+  sampledAt: number;
+  configuration: TimerSection;
+  runtime: TimerSection;
+}
+
+export async function inspectBrokerTimer(
+  instanceId: string,
+  brokerName: string,
+  signal: AbortSignal,
+) {
+  const response = await client.get<{ data: BrokerTimerSnapshot }>('/brokers/timer', {
+    params: { instanceId, brokerName },
+    signal,
+  });
+  return response.data.data;
+}

--- a/web/src/components/BrokerTimerDialog.tsx
+++ b/web/src/components/BrokerTimerDialog.tsx
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+import { Alert, Button, Descriptions, Modal, Space, Spin, Typography } from 'antd';
+import {
+  inspectBrokerTimer,
+  type BrokerTimerSnapshot,
+  type TimerSection,
+} from '../api/brokerTimer';
+
+const configurationFields = [
+  ['timerWheelEnable', 'Timer wheel enabled'],
+  ['timerStopEnqueue', 'Enqueue paused'],
+  ['timerStopDequeue', 'Dequeue paused'],
+  ['timerRocksDBEnable', 'RocksDB timer enabled'],
+  ['timerRocksDBStopScan', 'RocksDB scan paused'],
+  ['recallMessageEnable', 'Recall enabled'],
+  ['timerPrecisionMs', 'Precision (ms)'],
+  ['timerMaxDelaySec', 'Maximum delay (seconds)'],
+];
+
+const runtimeFields = [
+  ['timerReadBehind', 'Dequeue behind (seconds)'],
+  ['timerOffsetBehind', 'Enqueue behind (queue positions)'],
+  ['timerCongestNum', 'Timer wheel pending entries'],
+  ['timerEnqueueTps', 'Enqueue rate (messages/s)'],
+  ['timerDequeueTps', 'Dequeue rate (messages/s)'],
+];
+
+function Section({
+  title,
+  data,
+  fields,
+}: {
+  title: string;
+  data: TimerSection;
+  fields: string[][];
+}) {
+  return (
+    <section aria-label={title}>
+      <Typography.Title level={5}>{title}</Typography.Title>
+      {data.error && <Alert type="warning" showIcon message={data.error} />}
+      <Descriptions
+        bordered
+        size="small"
+        column={1}
+        items={fields.map(([key, label]) => ({
+          key,
+          label: <span title={key}>{label}</span>,
+          children: <Typography.Text code>{data.values[key] ?? 'Not reported'}</Typography.Text>,
+        }))}
+      />
+    </section>
+  );
+}
+
+export default function BrokerTimerDialog({
+  instanceId,
+  brokerName,
+  onClose,
+}: {
+  instanceId: string;
+  brokerName: string;
+  onClose: () => void;
+}) {
+  const [revision, setRevision] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [snapshot, setSnapshot] = useState<BrokerTimerSnapshot>();
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    let active = true;
+    const controller = new AbortController();
+    void Promise.resolve().then(async () => {
+      if (!active) return;
+      setLoading(true);
+      setSnapshot(undefined);
+      setError(undefined);
+      try {
+        const result = await inspectBrokerTimer(instanceId, brokerName, controller.signal);
+        if (active) setSnapshot(result);
+      } catch (failure) {
+        if (active)
+          setError(failure instanceof Error ? failure.message : 'Timer inspection failed');
+      } finally {
+        if (active) setLoading(false);
+      }
+    });
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [instanceId, brokerName, revision]);
+
+  return (
+    <Modal
+      open
+      title={`Timer status: ${brokerName}`}
+      onCancel={onClose}
+      width={820}
+      styles={{ body: { maxHeight: '70vh', overflowY: 'auto' } }}
+      footer={
+        <Space>
+          <Button loading={loading} onClick={() => setRevision((value) => value + 1)}>
+            Refresh snapshot
+          </Button>
+          <Button onClick={onClose}>Close</Button>
+        </Space>
+      }
+    >
+      <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+        <Alert
+          type="info"
+          showIcon
+          message="Read-only timer diagnostics"
+          description="Pending entries include messages that are not due yet. Zero metrics do not prove the timer service is enabled or healthy. Configuration and runtime are sampled separately."
+        />
+        {error && <Alert type="error" showIcon message={error} />}
+        {loading && <Spin aria-label="Loading timer status" />}
+        {snapshot && (
+          <>
+            <Typography.Text type="secondary">
+              {instanceId} / {snapshot.address} · {new Date(snapshot.sampledAt).toLocaleString()}
+            </Typography.Text>
+            {snapshot.configuration.values.timerWheelEnable === 'false' && (
+              <Alert
+                type="warning"
+                showIcon
+                message="Timer wheel is disabled; reported zero metrics do not indicate normal operation."
+              />
+            )}
+            {(snapshot.configuration.error || snapshot.runtime.error) && (
+              <Alert
+                type="warning"
+                showIcon
+                message="Partial snapshot: a data source is unavailable."
+              />
+            )}
+            <Section
+              title="Timer configuration"
+              data={snapshot.configuration}
+              fields={configurationFields}
+            />
+            <Section title="Timer runtime" data={snapshot.runtime} fields={runtimeFields} />
+          </>
+        )}
+      </Space>
+    </Modal>
+  );
+}

--- a/web/src/components/__tests__/BrokerTimerDialog.test.tsx
+++ b/web/src/components/__tests__/BrokerTimerDialog.test.tsx
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, fireEvent, render as renderComponent, screen, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { ConfigProvider } from 'antd';
+import { beforeEach, expect, it, vi } from 'vitest';
+import BrokerTimerDialog from '../BrokerTimerDialog';
+import { inspectBrokerTimer, type BrokerTimerSnapshot } from '../../api/brokerTimer';
+
+vi.mock('../../api/brokerTimer', () => ({ inspectBrokerTimer: vi.fn() }));
+
+// jsdom does not dispatch CSS animation completion events.
+const render = (element: ReactElement) =>
+  renderComponent(element, {
+    wrapper: ({ children }) => (
+      <ConfigProvider theme={{ token: { motion: false } }}>{children}</ConfigProvider>
+    ),
+  });
+
+const fixture: BrokerTimerSnapshot = {
+  brokerName: 'broker-a',
+  address: 'master:10911',
+  sampledAt: 1788825600000,
+  configuration: { values: { timerWheelEnable: 'true', timerPrecisionMs: '1000' }, error: null },
+  runtime: { values: { timerOffsetBehind: '9007199254740993', timerReadBehind: '7' }, error: null },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockReturnValue({
+      matches: false,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  });
+  vi.mocked(inspectBrokerTimer).mockResolvedValue(structuredClone(fixture));
+});
+
+it('shows exact counters, units, missing fields and sampling limitations', async () => {
+  render(<BrokerTimerDialog instanceId="instance-a" brokerName="broker-a" onClose={vi.fn()} />);
+  await waitFor(() => expect(screen.getByText('9007199254740993')).toBeVisible());
+  expect(screen.getByText('Dequeue behind (seconds)')).toBeVisible();
+  expect(screen.getByText('Enqueue behind (queue positions)')).toBeVisible();
+  expect(screen.getAllByText('Not reported').length).toBeGreaterThan(0);
+  expect(screen.getByText(/Pending entries include messages that are not due yet/)).toBeVisible();
+  expect(inspectBrokerTimer).toHaveBeenCalledWith(
+    'instance-a',
+    'broker-a',
+    expect.any(AbortSignal),
+  );
+});
+
+it('warns when the timer wheel is disabled even with zero runtime metrics', async () => {
+  vi.mocked(inspectBrokerTimer).mockResolvedValue({
+    ...fixture,
+    configuration: { values: { timerWheelEnable: 'false' }, error: null },
+    runtime: { values: { timerReadBehind: '0' }, error: null },
+  });
+  render(<BrokerTimerDialog instanceId="instance-a" brokerName="broker-a" onClose={vi.fn()} />);
+  await waitFor(() => expect(screen.getByText(/Timer wheel is disabled/)).toBeVisible());
+  expect(screen.getByText('0')).toBeVisible();
+});
+
+it('keeps configuration visible after the runtime RPC fails', async () => {
+  vi.mocked(inspectBrokerTimer).mockResolvedValue({
+    ...fixture,
+    runtime: { values: {}, error: 'Runtime denied' },
+  });
+  render(<BrokerTimerDialog instanceId="instance-a" brokerName="broker-a" onClose={vi.fn()} />);
+  await waitFor(() => expect(screen.getByText('Runtime denied')).toBeVisible());
+  expect(screen.getByText('1000')).toBeVisible();
+  expect(screen.getByText(/Partial snapshot/)).toBeVisible();
+});
+
+it('refreshes after a top-level failure and clears its error', async () => {
+  vi.mocked(inspectBrokerTimer).mockRejectedValueOnce(new Error('Master unavailable'));
+  render(<BrokerTimerDialog instanceId="instance-a" brokerName="broker-a" onClose={vi.fn()} />);
+  await waitFor(() => expect(screen.getByText('Master unavailable')).toBeVisible());
+  fireEvent.click(screen.getByRole('button', { name: /Refresh snapshot/ }));
+  await waitFor(() => expect(screen.getByText('9007199254740993')).toBeVisible());
+  expect(screen.queryByText('Master unavailable')).not.toBeInTheDocument();
+  expect(inspectBrokerTimer).toHaveBeenCalledTimes(2);
+});
+
+it('aborts on unmount and ignores a late result', async () => {
+  let resolve!: (value: BrokerTimerSnapshot) => void;
+  vi.mocked(inspectBrokerTimer).mockReturnValue(
+    new Promise((done) => {
+      resolve = done;
+    }),
+  );
+  const { unmount } = render(
+    <BrokerTimerDialog instanceId="instance-a" brokerName="broker-a" onClose={vi.fn()} />,
+  );
+  await waitFor(() => expect(inspectBrokerTimer).toHaveBeenCalledTimes(1));
+  const signal = vi.mocked(inspectBrokerTimer).mock.calls[0][2];
+  unmount();
+  expect(signal.aborted).toBe(true);
+  await act(async () => resolve(fixture));
+  expect(screen.queryByText('9007199254740993')).not.toBeInTheDocument();
+});
+
+it('isolates a late response from a previous instance', async () => {
+  let resolve!: (value: BrokerTimerSnapshot) => void;
+  vi.mocked(inspectBrokerTimer).mockReturnValueOnce(
+    new Promise((done) => {
+      resolve = done;
+    }),
+  );
+  const { rerender } = render(
+    <BrokerTimerDialog instanceId="instance-a" brokerName="broker-a" onClose={vi.fn()} />,
+  );
+  await waitFor(() => expect(inspectBrokerTimer).toHaveBeenCalledTimes(1));
+  const signal = vi.mocked(inspectBrokerTimer).mock.calls[0][2];
+  rerender(<BrokerTimerDialog instanceId="instance-b" brokerName="broker-b" onClose={vi.fn()} />);
+  await waitFor(() => expect(screen.getByText('9007199254740993')).toBeVisible());
+  await act(async () => resolve({ ...fixture, runtime: { values: {}, error: 'Old response' } }));
+  expect(signal.aborted).toBe(true);
+  expect(screen.queryByText('Old response')).not.toBeInTheDocument();
+});
+
+it('closes through the owner callback', async () => {
+  const close = vi.fn();
+  render(<BrokerTimerDialog instanceId="instance-a" brokerName="broker-a" onClose={close} />);
+  await waitFor(() => expect(inspectBrokerTimer).toHaveBeenCalledTimes(1));
+  fireEvent.click(screen.getAllByRole('button', { name: 'Close' })[1]);
+  expect(close).toHaveBeenCalledOnce();
+});

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -32,6 +32,7 @@ import { supportsApacheRuntime, type Instance } from '../../api/instance';
 import { listInstances } from '../../services/instanceService';
 import { useVisiblePolling } from '../../hooks/useVisiblePolling';
 import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
+import BrokerTimerDialog from '../../components/BrokerTimerDialog';
 
 // ─── Types ──────────────────────────────────────────────────────
 type NodeStatus = 'running' | 'readonly' | 'maintenance' | 'unknown';
@@ -190,6 +191,7 @@ const BrokerClusterPage = () => {
   const [proxyData, setProxyData] = useState<ProxyRecord[]>([]);
   const [instances, setInstances] = useState<Instance[]>([]);
   const [selectedInstanceId, setSelectedInstanceId] = useState<string | undefined>(undefined);
+  const [timerTarget, setTimerTarget] = useState<{ instanceId: string; brokerName: string }>();
   const mountedRef = useRef(true);
   const loadRequestId = useRef(0);
   const { t } = useLang();
@@ -325,6 +327,25 @@ const BrokerClusterPage = () => {
     (activeTab === 'broker' && brokerData.length === 0);
 
   const brokerColumns = [
+    {
+      title: 'Timer',
+      key: 'timer',
+      render: (_: unknown, broker: BrokerRecord) => (
+        <Button
+          size="small"
+          disabled={!selectedInstanceId || isMockMode()}
+          onClick={() =>
+            selectedInstanceId &&
+            setTimerTarget({
+              instanceId: selectedInstanceId,
+              brokerName: broker.brokerName,
+            })
+          }
+        >
+          Timer status
+        </Button>
+      ),
+    },
     {
       title: t('brokerCluster.k8sCluster'),
       dataIndex: 'k8sCluster',
@@ -497,6 +518,13 @@ const BrokerClusterPage = () => {
 
   return (
     <div style={{ padding: 0 }}>
+      {timerTarget && timerTarget.instanceId === selectedInstanceId && (
+        <BrokerTimerDialog
+          key={timerTarget.instanceId + '/' + timerTarget.brokerName}
+          {...timerTarget}
+          onClose={() => setTimerTarget(undefined)}
+        />
+      )}
       <div
         style={{
           display: 'flex',
@@ -521,7 +549,10 @@ const BrokerClusterPage = () => {
           <Select
             aria-label="选择实例"
             value={selectedInstanceId}
-            onChange={setSelectedInstanceId}
+            onChange={(value) => {
+              setTimerTarget(undefined);
+              setSelectedInstanceId(value);
+            }}
             placeholder="选择实例"
             style={{ minWidth: 180 }}
             options={instances.map((instance) => ({ value: instance.name, label: instance.name }))}


### PR DESCRIPTION
<!-- Make sure the base branch is `master`: that is the RocketMQ Studio trunk. -->

### Which Issue(s) This PR Fixes

- Fixes #4431
- Replaces #4111, closed by the branch switch in #4379.

### Brief Description

This is a resubmission of #4111 against `master`, following the branch switch notice in #4379. The fork branch is unchanged; `master` is now the RocketMQ Studio trunk.

## 变更目的

Broker 列表增加只读 `Timer status`，同时展示定时服务配置和进度。例如时间轮已关闭但运行指标均为零时，明确展示关闭状态，避免将零指标误读为正常运行。入队暂停、出队暂停和 RocksDB 扫描状态可辅助定位定时消息延迟。

已检索全部 Issue/PR 标题正文中的 timerReadBehind、timerCongest、timerOffsetBehind、timerWheelEnable 和定时诊断相关词，并补充在线 `timer diagnostics` 检索，未发现同类查询入口。

## 实现

- 新增 `GET /api/brokers/timer`，绑定所选 Apache 实例与登记的 Broker 主节点，不接受任意地址，也不回退从节点。
- 独立读取 Broker 配置及运行指标，只输出定时字段；部分失败保留另一来源结果，缺失字段不回填零。
- 指标以字符串跨 JSON 和浏览器传递，保留超过安全整数范围的精度；标明出队落后单位为秒，时间轮待处理条目包含未来消息。
- 增加只读弹窗、手动刷新、禁用状态提示、关闭取消和实例切换后的迟到结果隔离。
- 增加中文使用文档、协议边界与回滚说明，无新增依赖、数据库或配置变更。

字段依据官方 [TimerMessageStore 5.5.0](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java) 和 [AdminBrokerProcessor 5.5.0](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java)。配置与运行指标是两次采样，RocksDB 引擎切换也会影响解释，本页面不自动判定健康状态或切换引擎。

### How Did You Test This Change?

## 本地验证

基线 `d6dee7d7ccfcf4886f02466ec51452a6928b2cc8`，Java 21、Node 24.18.0，2026-09-08。

```bash
cd server
mvn -B -ntp org.jacoco:jacoco-maven-plugin:0.8.13:prepare-agent -Dtest=BrokerTimerTest,RuntimeAdminClientResolverTest,ClusterControllerTest verify org.jacoco:jacoco-maven-plugin:0.8.13:report
cd ../web
npx vitest run src/api/brokerTimer.test.ts src/components/__tests__/BrokerTimerDialog.test.tsx src/pages/studio/__tests__/BrokerCluster.test.tsx
npm run build
```

- 后端 59 个测试通过，包括新增 16 个定时诊断场景；Checkstyle 零违规，打包通过。
- 新服务 JaCoCo 行覆盖率 43/43、分支 26/26，接口与结果记录覆盖率 100%。
- 前端 24 个测试通过；修改文件 ESLint、TypeScript 和 Vite 构建通过。
- Playwright 在本地真实 Broker 页面验证入口、请求携带 instance-a/broker-a、关闭状态警告、`9007199254740993` 精度及滚动面板；全部 API 使用本地受控 GET 响应，非 GET 中止。
- `git diff --cached --check` 通过；10 个文件，853 行新增、1 行删除。

首次后端测试因沙箱阻止 Mockito JVM attach 失败，放行同一条本地命令后通过。浏览器拦截规则曾误匹配 Vite 源码路径，收紧到本地 /api/ 后完成页面验证。

原样上游基线已有 3 个全量后端失败及依赖漏洞，本项无新增依赖，相关验证无新增失败；不将增量验证表述为项目级全量验收。真实集群 E2E、性能、压力、容量及混沌测试未执行。

无迁移，直接部署。回滚本提交即可移除查询接口和入口，无 Broker 数据修改。提交含 `[skip ci]`，验证在本地执行。

### Checklist

- [x] One coherent change; unrelated modifications are not bundled in
- [x] Commit subject follows Conventional Commits (`feat:` / `fix:` / `refactor:` / `chore:` / `docs:` / `perf:`)
- [x] Tests added or updated for non-trivial changes, test methods named `...Test`
- [x] New UI text has both Chinese and English entries under `web/src/i18n/`, or the change does not add UI text
- [x] Architecture constraints stay green (`mvn test` runs the ArchUnit checks), or the original verification scope is stated above
- [x] New source files carry the ASF license header, or no new source files were added
- [x] Documentation touched where behaviour changed (README / `docs/` / in-app help), or no documentation change was required
