### PR TITLE
feat: manage broker-local cold-read group limits

### DIFF
--- a/docs/cold-read-control.md
+++ b/docs/cold-read-control.md
@@ -1,0 +1,59 @@
+# Broker 冷读流控
+
+最后验证日期：2026-09-08。协议依据 RocketMQ 5.5.0。
+
+## 场景与入口
+
+当消费组回溯历史数据引起磁盘读取压力时，可在 Broker 列表打开 `Cold-read control`，
+查看该 Broker 的全局冷读计数、默认组阈值、管理员限额与自适应限额。
+所选实例必须支持 Apache 运行时管理，Mock 模式禁用入口。
+查询绑定所选实例登记的主节点 ID 0；找不到主节点时不会回退到从节点。
+
+表格合并运行表、管理员配置和自适应配置，保留只有配置、尚无冷读计数的组。
+自动生成的 `||adaptive` 键展示在相应组的自适应列，不允许作为人工修改目标。
+未报告的字段显示 `Not reported`；所有计数和阈值均以字符串传递，避免丢失 64 位整数精度。
+
+## 单组修改
+
+点击 `Use group` 或手工填写合法消费组名。允许预先配置尚未读取冷数据的组。
+选择设置正整数的字节阈值，或移除管理员覆盖；核对组名、Broker 和地址后勾选确认并提交。
+修改组名、数值或操作会清除确认。保存期间表单与关闭操作锁定，页面不自动重试写入。
+启用登录时，查询允许读者使用，修改需要管理员；前端权限提示不替代后端鉴权。
+
+修改只作用于目标 Broker 上的一个组，不批量广播到集群，也不修改流控总开关。
+移除管理员限额会重新采用自适应或默认阈值，不表示取消全部限流。
+成功回执后，服务端回读同一 Broker 的配置键：
+
+- 值符合预期：显示 `Broker configuration verified`。
+- 值不符或回读失败：显示已接受但未核实，先刷新并检查再决定后续操作。
+- 写入 RPC 本身失败：显示错误并记录失败审计；网络超时仍可能存在结果不确定性。
+
+回读不是原子事务；并发管理员或 Broker 切换仍可能改变配置。审计记录目标、动作、
+阈值、Broker 地址与核实结果，审计存储失败不将已完成写入变为可重试失败。
+
+## 单位与生命周期
+
+计数是清零周期内累积的字节数，不是每秒速率。官方实现启用流控时通常每 5 秒清零，
+调度耗时可使实际周期发生偏移；运行组长时间无冷读后会从运行表移除。
+全局阈值与组阈值共同参与流控，自适应策略可动态调整组限额。
+仅凭某个采样计数不能断言客户端已经受限，禁用状态也不因保存组限额而改变。
+
+组覆盖存储在 Broker 内存中，重启后需要重新配置；本功能不引入持久化或自动重放任务。
+配置与运行表是不同采样，计数可能在采样期间清零。其他 RocketMQ 版本需要结合其实现解释。
+依据官方 [ColdDataCgCtrService](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/coldctr/ColdDataCgCtrService.java)
+和 [AdminBrokerProcessor](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java)。
+
+## 接口、验证与回滚
+
+- `GET /api/brokers/cold-read?instanceId=...&brokerName=...`：查询配置与运行表。
+- `POST /api/brokers/cold-read/config`：提交 `instanceId`、`brokerName`、`group`、
+  `action=SET|REMOVE`；SET 需要十进制字符串 `threshold`，REMOVE 不接受阈值。
+
+后端验证：`mvn -B -ntp -Dtest=ColdReadTest,RuntimeAdminClientResolverTest,AuthInterceptorTest,OperationAuditServiceTest verify`。
+前端验证：运行 `coldRead.test.ts`、`ColdReadDialog.test.tsx`、`BrokerCluster.test.tsx`，
+执行修改文件 ESLint 和 `npm run build`。浏览器通过明确拦截的本地 API 检查确认流程。
+真实集群 E2E、性能、压力、容量与混沌测试未执行。
+
+无新增依赖、数据库或配置文件。无迁移，直接部署。
+代码回滚移除接口与入口；配置回滚需恢复原管理员阈值，原先没有覆盖时执行移除。
+操作前应记录原值，不能用重启 Broker 作为本功能的常规回滚方式。

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ColdReadCommand.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ColdReadCommand.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record ColdReadCommand(@NotBlank String instanceId, @NotBlank String brokerName,
+                              @NotBlank @Size(max = 255) @Pattern(regexp = "[%a-zA-Z0-9_|-]+") String group,
+                              @NotNull Action action, String threshold) {
+    public enum Action { SET, REMOVE }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ColdReadController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ColdReadController.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.Result;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ColdReadController {
+    private final ColdReadService service;
+
+    @GetMapping("/api/brokers/cold-read")
+    public Result<ColdReadSnapshot> inspect(@RequestParam String instanceId, @RequestParam String brokerName) {
+        return Result.ok(service.inspect(instanceId, brokerName));
+    }
+
+    @PostMapping("/api/brokers/cold-read/config")
+    public Result<ColdReadReceipt> change(@Valid @RequestBody ColdReadCommand command) {
+        return Result.ok(service.change(command));
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ColdReadReceipt.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ColdReadReceipt.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+public record ColdReadReceipt(String address, String group, ColdReadCommand.Action action, String threshold,
+                              boolean verified, String verificationError) {
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ColdReadService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ColdReadService.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.TreeSet;
+
+@Service
+@RequiredArgsConstructor
+public class ColdReadService {
+    private static final String ADAPTIVE_SUFFIX = "||adaptive";
+    private final RuntimeAdminClientResolver resolver;
+    private final ObjectMapper mapper;
+    private final OperationAuditService audit;
+
+    public ColdReadSnapshot inspect(String instanceId, String brokerName) {
+        return execute(instanceId, admin -> {
+            String address = address(admin, brokerName);
+            var info = parse(admin.getColdDataFlowCtrInfo(address));
+            var config = admin.getBrokerConfig(address);
+            if (config == null) {
+                throw new BusinessException(502, "Broker returned no configuration");
+            }
+            var runtime = info.path("runtimeTable");
+            var thresholds = info.path("configTable");
+            TreeSet<String> names = new TreeSet<>();
+            runtime.fieldNames().forEachRemaining(names::add);
+            thresholds.fieldNames().forEachRemaining(key -> names.add(key.endsWith(ADAPTIVE_SUFFIX)
+                    ? key.substring(0, key.length() - ADAPTIVE_SUFFIX.length()) : key));
+            List<ColdReadSnapshot.Group> groups = names.stream().map(name -> new ColdReadSnapshot.Group(name,
+                    number(thresholds.path(name)), number(thresholds.path(name + ADAPTIVE_SUFFIX)),
+                    number(runtime.path(name).path("coldAcc")),
+                    number(runtime.path(name).path("lastColdReadTimeMills")))).toList();
+            return new ColdReadSnapshot(brokerName.trim(), address, System.currentTimeMillis(),
+                    config.getProperty("coldDataFlowControlEnable"), config.getProperty("coldCtrStrategyEnable"),
+                    number(info.path("cgColdReadThreshold")), number(info.path("globalColdReadThreshold")),
+                    number(info.path("globalAcc")), groups);
+        });
+    }
+
+    public ColdReadReceipt change(ColdReadCommand command) {
+        String threshold = validate(command);
+        String detail = "broker=" + command.brokerName() + ", group=" + command.group()
+                + ", action=" + command.action() + ", threshold=" + threshold;
+        try {
+            var receipt = execute(command.instanceId(), admin -> {
+                String address = address(admin, command.brokerName());
+                if (command.action() == ColdReadCommand.Action.SET) {
+                    Properties properties = new Properties();
+                    properties.setProperty(command.group(), threshold);
+                    admin.updateColdDataFlowCtrGroupConfig(address, properties);
+                } else {
+                    admin.removeColdDataFlowCtrGroupConfig(address, command.group());
+                }
+                // The broker can acknowledge malformed entries without applying them; read back this one key.
+                try {
+                    var actual = number(parse(admin.getColdDataFlowCtrInfo(address)).path("configTable")
+                            .path(command.group()));
+                    boolean verified = Objects.equals(threshold, actual);
+                    return new ColdReadReceipt(address, command.group(), command.action(), threshold, verified,
+                            verified ? null : "Broker acknowledged the command but read-back differs; refresh before retrying.");
+                } catch (Exception verificationFailure) {
+                    if (verificationFailure instanceof InterruptedException) {
+                        Thread.currentThread().interrupt();
+                    }
+                    return new ColdReadReceipt(address, command.group(), command.action(), threshold, false,
+                            "Broker acknowledged the command; read-back is unavailable. Refresh before retrying.");
+                }
+            });
+            audit.record("CHANGE_COLD_READ_LIMIT", "BROKER", command.brokerName(), command.instanceId(),
+                    detail + ", address=" + receipt.address() + ", verified=" + receipt.verified(),
+                    "SUCCESS", null);
+            return receipt;
+        } catch (RuntimeException failure) {
+            audit.record("CHANGE_COLD_READ_LIMIT", "BROKER", command.brokerName(), command.instanceId(),
+                    detail, "FAILED", failure.getMessage());
+            throw failure;
+        }
+    }
+
+    private <T> T execute(String instanceId, MqAdminExtFactory.AdminAction<T> action) {
+        return resolver.execute(instanceId, admin -> {
+            try {
+                return action.apply(admin);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                throw interrupted;
+            }
+        });
+    }
+
+    private String validate(ColdReadCommand command) {
+        if (command.group() == null || !command.group().matches("[%a-zA-Z0-9_|-]{1,255}")
+                || command.group().endsWith(ADAPTIVE_SUFFIX)) {
+            throw new BusinessException(400, "A consumer group name without the reserved adaptive suffix is required");
+        }
+        if (command.action() == null) {
+            throw new BusinessException(400, "action is required");
+        }
+        if (command.action() == ColdReadCommand.Action.REMOVE) {
+            if (command.threshold() != null) {
+                throw new BusinessException(400, "REMOVE must not include a threshold");
+            }
+            return null;
+        }
+        try {
+            if (command.threshold() == null || !command.threshold().matches("[1-9][0-9]{0,18}")) {
+                throw new NumberFormatException();
+            }
+            return Long.toString(Long.parseLong(command.threshold()));
+        } catch (NumberFormatException invalid) {
+            throw new BusinessException(400, "threshold must be a positive 64-bit integer in bytes");
+        }
+    }
+
+    private String address(MQAdminExt admin, String brokerName) throws Exception {
+        if (brokerName == null || brokerName.isBlank()) {
+            throw new BusinessException(400, "brokerName is required");
+        }
+        var broker = admin.examineBrokerClusterInfo().getBrokerAddrTable().get(brokerName.trim());
+        if (broker == null) {
+            throw new BusinessException(404, "Broker is not registered: " + brokerName);
+        }
+        String address = broker.getBrokerAddrs().get(0L);
+        if (address == null || address.isBlank()) {
+            throw new BusinessException(409, "Broker has no registered master: " + brokerName);
+        }
+        return address;
+    }
+
+    private JsonNode parse(String json) throws Exception {
+        if (json == null || json.isBlank()) {
+            throw new BusinessException(502, "Broker returned no cold-read data");
+        }
+        JsonNode root;
+        try {
+            root = mapper.readTree(json);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException invalid) {
+            throw new BusinessException(502, "Broker returned invalid cold-read JSON");
+        }
+        if (!root.path("configTable").isObject() || !root.path("runtimeTable").isObject()) {
+            throw new BusinessException(502, "Broker returned unsupported cold-read tables");
+        }
+        return root;
+    }
+
+    private String number(JsonNode value) {
+        if (value.isMissingNode() || value.isNull()) {
+            return null;
+        }
+        if (!value.isIntegralNumber() || !value.canConvertToLong()) {
+            throw new BusinessException(502, "Broker returned an invalid cold-read counter");
+        }
+        return value.asText();
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ColdReadSnapshot.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ColdReadSnapshot.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import java.util.List;
+
+public record ColdReadSnapshot(String brokerName, String address, long sampledAt, String enabled,
+                               String adaptiveEnabled, String defaultThreshold, String globalThreshold,
+                               String globalBytes, List<Group> groups) {
+    public record Group(String name, String configuredThreshold, String adaptiveThreshold,
+                        String coldBytes, String lastReadMillis) {
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
@@ -573,6 +573,24 @@ class AuthInterceptorTest {
         assertThat(allowed).isTrue();
     }
 
+    @Test
+    void coldReadWritesRequireAdminWhileSnapshotsAllowReaders() throws Exception {
+        TestSession session = login(false);
+        MockHttpServletResponse denied = new MockHttpServletResponse();
+        assertThat(session.interceptor().preHandle(authenticatedRequest("POST",
+                "/api/brokers/cold-read/config", session.token()), denied, new Object())).isFalse();
+        assertThat(denied.getStatus()).isEqualTo(403);
+        assertThat(session.interceptor().preHandle(authenticatedRequest("GET",
+                "/api/brokers/cold-read", session.token()), new MockHttpServletResponse(), new Object())).isTrue();
+    }
+
+    @Test
+    void coldReadWritesAllowAuthenticatedAdmins() throws Exception {
+        TestSession session = login(true);
+        assertThat(session.interceptor().preHandle(authenticatedRequest("POST",
+                "/api/brokers/cold-read/config", session.token()), new MockHttpServletResponse(), new Object())).isTrue();
+    }
+
     private TestSession login(boolean admin) {
         AuthProperties properties = new AuthProperties();
         properties.setLoginRequired(true);

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ColdReadTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ColdReadTest.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.GlobalExceptionHandler;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.studio.persistence.entity.RmqOperationAudit;
+import org.apache.rocketmq.studio.persistence.mapper.RmqOperationAuditMapper;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ColdReadTest {
+    private final DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+    private final InstanceRepository instances = mock(InstanceRepository.class);
+    private final RmqOperationAuditMapper audits = mock(RmqOperationAuditMapper.class);
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final MqAdminExtFactory factory = new MqAdminExtFactory() {
+        @Override
+        protected DefaultMQAdminExt newAdmin(RPCHook hook) {
+            return admin;
+        }
+    };
+    private final ClusterInfo cluster = new ClusterInfo();
+    private ColdReadService service;
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        when(instances.findByIdentifier("instance-a")).thenReturn(Optional.of(InstanceVO.builder()
+                .name("instance-a").vendor(InstanceVendor.APACHE).endpoint("selected:9876").build()));
+        var resolver = new RuntimeAdminClientResolver(instances, factory, new MqAdminProperties(), new MqClientPool());
+        service = new ColdReadService(resolver, mapper, new OperationAuditService(audits));
+        cluster.setBrokerAddrTable(new HashMap<>(Map.of("broker-a", new BrokerData("cluster-a", "broker-a",
+                new HashMap<>(Map.of(0L, "master:10911", 1L, "replica:10911"))))));
+        when(admin.examineBrokerClusterInfo()).thenReturn(cluster);
+        Properties configuration = new Properties();
+        configuration.setProperty("coldDataFlowControlEnable", "false");
+        configuration.setProperty("coldCtrStrategyEnable", "true");
+        when(admin.getBrokerConfig("master:10911")).thenReturn(configuration);
+        when(admin.getColdDataFlowCtrInfo("master:10911")).thenReturn("""
+                {"runtimeTable":{"runtime-only":{"coldAcc":23,"lastColdReadTimeMills":1788825600000},
+                  "orders":{"coldAcc":9007199254740993,"lastColdReadTimeMills":1788825600001}},
+                 "configTable":{"orders":9007199254740995,"orders||adaptive":1000,"config-only":2000,
+                  "adaptive-only||adaptive":3000},
+                 "cgColdReadThreshold":100000,"globalColdReadThreshold":1000000,"globalAcc":9007199254740997}
+                """);
+        mvc = MockMvcBuilders.standaloneSetup(new ColdReadController(service))
+                .setControllerAdvice(new GlobalExceptionHandler()).build();
+    }
+
+    @AfterEach
+    void close() {
+        factory.shutdown();
+        Thread.interrupted();
+    }
+
+    @Test
+    void httpMergesConfiguredRuntimeAndAdaptiveGroupsWithoutLosingPrecision() throws Exception {
+        mvc.perform(get("/api/brokers/cold-read").param("instanceId", "instance-a").param("brokerName", " broker-a "))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.address").value("master:10911"))
+                .andExpect(jsonPath("$.data.enabled").value("false"))
+                .andExpect(jsonPath("$.data.globalBytes").value("9007199254740997"))
+                .andExpect(jsonPath("$.data.groups.length()").value(4))
+                .andExpect(jsonPath("$.data.groups[0].name").value("adaptive-only"))
+                .andExpect(jsonPath("$.data.groups[0].adaptiveThreshold").value("3000"))
+                .andExpect(jsonPath("$.data.groups[0].coldBytes").doesNotExist())
+                .andExpect(jsonPath("$.data.groups[2].configuredThreshold").value("9007199254740995"))
+                .andExpect(jsonPath("$.data.groups[2].coldBytes").value("9007199254740993"))
+                .andExpect(jsonPath("$.data.groups[3].lastReadMillis").value("1788825600000"));
+        verify(admin).setNamesrvAddr("selected:9876");
+        verify(admin, never()).getColdDataFlowCtrInfo("replica:10911");
+        verifyNoInteractions(audits);
+    }
+
+    @Test
+    void setSendsOneExactPropertyAndVerifiesTheBrokerResult() throws Exception {
+        var command = command(ColdReadCommand.Action.SET, "9007199254740995");
+        mvc.perform(post("/api/brokers/cold-read/config").contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(command)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.verified").value(true))
+                .andExpect(jsonPath("$.data.threshold").value("9007199254740995"));
+        var properties = ArgumentCaptor.forClass(Properties.class);
+        verify(admin).updateColdDataFlowCtrGroupConfig(org.mockito.ArgumentMatchers.eq("master:10911"),
+                properties.capture());
+        assertThat(properties.getValue()).containsOnly(Map.entry("orders", "9007199254740995"));
+        var audit = ArgumentCaptor.forClass(RmqOperationAudit.class);
+        verify(audits).insert(audit.capture());
+        assertThat(audit.getValue().getDetail()).contains("verified=true", "address=master:10911", "orders");
+        assertThat(audit.getValue().getResult()).isEqualTo("SUCCESS");
+    }
+
+    @Test
+    void removeOnlyDeletesTheAdminOverrideAndVerifiesAbsence() throws Exception {
+        when(admin.getColdDataFlowCtrInfo("master:10911")).thenReturn(
+                "{\"runtimeTable\":{},\"configTable\":{\"orders||adaptive\":200}}");
+        var result = service.change(command(ColdReadCommand.Action.REMOVE, null));
+        assertThat(result.verified()).isTrue();
+        assertThat(result.threshold()).isNull();
+        verify(admin).removeColdDataFlowCtrGroupConfig("master:10911", "orders");
+        verify(admin, never()).updateColdDataFlowCtrGroupConfig(anyString(), any());
+    }
+
+    @Test
+    void acknowledgedButUnappliedLimitIsNotReportedAsVerified() {
+        var result = service.change(command(ColdReadCommand.Action.SET, "5000"));
+        assertThat(result.verified()).isFalse();
+        assertThat(result.verificationError()).contains("read-back differs");
+    }
+
+    @Test
+    void failedReadBackDoesNotTurnAcknowledgedWriteIntoRetryableFailure() throws Exception {
+        when(admin.getColdDataFlowCtrInfo("master:10911")).thenThrow(new IllegalStateException("unavailable"));
+        var result = service.change(command(ColdReadCommand.Action.SET, "5000"));
+        assertThat(result.verified()).isFalse();
+        assertThat(result.verificationError()).contains("acknowledged", "Refresh before retrying");
+        verify(admin).updateColdDataFlowCtrGroupConfig(anyString(), any());
+    }
+
+    @Test
+    void interruptedReadBackRetainsTheAcknowledgementAndInterruptFlag() throws Exception {
+        when(admin.getColdDataFlowCtrInfo("master:10911")).thenThrow(new InterruptedException("cancelled"));
+        assertThat(service.change(command(ColdReadCommand.Action.SET, "5000")).verified()).isFalse();
+        assertThat(Thread.currentThread().isInterrupted()).isTrue();
+    }
+
+    @Test
+    void auditFailureDoesNotChangeVerifiedMutation() {
+        doThrow(new IllegalStateException("audit unavailable")).when(audits).insert(any(RmqOperationAudit.class));
+        assertThat(service.change(command(ColdReadCommand.Action.SET, "9007199254740995")).verified()).isTrue();
+    }
+
+    @Test
+    void mutationFailureIsAuditedWithoutReadBack() throws Exception {
+        doThrow(new IllegalStateException("write denied")).when(admin)
+                .updateColdDataFlowCtrGroupConfig(anyString(), any());
+        assertThatThrownBy(() -> service.change(command(ColdReadCommand.Action.SET, "5000")))
+                .hasMessageContaining("write denied");
+        verify(admin, never()).getColdDataFlowCtrInfo(anyString());
+        var audit = ArgumentCaptor.forClass(RmqOperationAudit.class);
+        verify(audits).insert(audit.capture());
+        assertThat(audit.getValue().getResult()).isEqualTo("FAILED");
+    }
+
+    @Test
+    void mutationInterruptionRestoresTheFlag() throws Exception {
+        doThrow(new InterruptedException("cancelled")).when(admin)
+                .removeColdDataFlowCtrGroupConfig(anyString(), anyString());
+        assertThatThrownBy(() -> service.change(command(ColdReadCommand.Action.REMOVE, null)))
+                .hasMessageContaining("cancelled");
+        assertThat(Thread.currentThread().isInterrupted()).isTrue();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"0", "-1", "1.5", " 10 ", "01", "9223372036854775808"})
+    void invalidThresholdCannotReachBroker(String threshold) {
+        assertThatThrownBy(() -> service.change(command(ColdReadCommand.Action.SET, threshold)))
+                .hasMessageContaining("positive 64-bit integer");
+        verifyNoInteractions(admin);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "orders\nother", "orders||adaptive"})
+    void invalidOrReservedGroupCannotReachBroker(String group) {
+        var command = new ColdReadCommand("instance-a", "broker-a", group, ColdReadCommand.Action.SET, "1");
+        assertThatThrownBy(() -> service.change(command)).hasMessageContaining("consumer group name");
+        verifyNoInteractions(admin);
+    }
+
+    @Test
+    void nullGroupActionAndUnexpectedRemoveThresholdAreRejected() {
+        assertThatThrownBy(() -> service.change(new ColdReadCommand("instance-a", "broker-a",
+                null, ColdReadCommand.Action.SET, "1"))).hasMessageContaining("consumer group name");
+        assertThatThrownBy(() -> service.change(command(null, null))).hasMessage("action is required");
+        assertThatThrownBy(() -> service.change(command(ColdReadCommand.Action.REMOVE, "1")))
+                .hasMessageContaining("must not include");
+        verifyNoInteractions(admin);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "not-json", "null", "{}", "{\"runtimeTable\":[],\"configTable\":{}}",
+        "{\"runtimeTable\":{},\"configTable\":{\"orders\":1.5}}",
+        "{\"runtimeTable\":{},\"configTable\":{\"orders\":9223372036854775808}}"})
+    void absentMalformedOrUnsupportedProtocolDoesNotBecomeHealthyZero(String json) throws Exception {
+        when(admin.getColdDataFlowCtrInfo("master:10911")).thenReturn(json);
+        assertThatThrownBy(() -> service.inspect("instance-a", "broker-a")).hasMessageContaining("Broker returned");
+    }
+
+    @Test
+    void emptyTablesAndNullCountersRemainUnreported() throws Exception {
+        when(admin.getColdDataFlowCtrInfo("master:10911")).thenReturn(
+                "{\"runtimeTable\":{},\"configTable\":{},\"globalAcc\":null}");
+        var result = service.inspect("instance-a", "broker-a");
+        assertThat(result.groups()).isEmpty();
+        assertThat(result.defaultThreshold()).isNull();
+        assertThat(result.globalBytes()).isNull();
+    }
+
+    @Test
+    void missingBrokerConfigurationCannotImplyFlowControlEnabled() throws Exception {
+        when(admin.getBrokerConfig("master:10911")).thenReturn(null);
+        assertThatThrownBy(() -> service.inspect("instance-a", "broker-a")).hasMessageContaining("no configuration");
+    }
+
+    @Test
+    void unknownBrokerAndMissingMasterDoNotProbeArbitraryAddresses() throws Exception {
+        assertThatThrownBy(() -> service.inspect("instance-a", "outside:10911"))
+                .hasMessageContaining("not registered");
+        cluster.getBrokerAddrTable().get("broker-a").getBrokerAddrs().remove(0L);
+        assertThatThrownBy(() -> service.inspect("instance-a", "broker-a")).hasMessageContaining("no registered master");
+        cluster.getBrokerAddrTable().get("broker-a").getBrokerAddrs().put(0L, " ");
+        assertThatThrownBy(() -> service.inspect("instance-a", "broker-a")).hasMessageContaining("no registered master");
+        verify(admin, never()).getColdDataFlowCtrInfo(anyString());
+    }
+
+    @Test
+    void missingInstanceOrBrokerAndInvalidHttpCommandAreRejected() throws Exception {
+        mvc.perform(get("/api/brokers/cold-read").param("brokerName", "broker-a"))
+                .andExpect(status().isBadRequest());
+        for (String name : new String[] {null, "", " "}) {
+            assertThatThrownBy(() -> service.inspect("instance-a", name)).hasMessage("brokerName is required");
+        }
+        mvc.perform(post("/api/brokers/cold-read/config").contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"instanceId\":\"instance-a\",\"group\":\"orders\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    private ColdReadCommand command(ColdReadCommand.Action action, String threshold) {
+        return new ColdReadCommand("instance-a", "broker-a", "orders", action, threshold);
+    }
+}

--- a/web/src/api/coldRead.test.ts
+++ b/web/src/api/coldRead.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, expect, it } from 'vitest';
+import client from './client';
+import { changeColdRead, inspectColdRead } from './coldRead';
+
+const mock = new MockAdapter(client);
+afterEach(() => mock.reset());
+
+it('binds reads to an instance and supports cancellation', async () => {
+  mock
+    .onGet('/brokers/cold-read')
+    .reply(200, { code: 200, data: { globalBytes: '9007199254740993' } });
+  const signal = new AbortController().signal;
+  expect(await inspectColdRead('instance-a', 'broker-a', signal)).toEqual({
+    globalBytes: '9007199254740993',
+  });
+  expect(mock.history.get[0].params).toEqual({ instanceId: 'instance-a', brokerName: 'broker-a' });
+  expect(mock.history.get[0].signal).toBe(signal);
+});
+
+it('sends one exact integer threshold as a string', async () => {
+  mock.onPost('/brokers/cold-read/config').reply(200, { code: 200, data: { verified: true } });
+  const command = {
+    instanceId: 'instance-a',
+    brokerName: 'broker-a',
+    group: 'orders',
+    action: 'SET' as const,
+    threshold: '9007199254740993',
+  };
+  expect(await changeColdRead(command)).toEqual({ verified: true });
+  expect(JSON.parse(mock.history.post[0].data)).toEqual(command);
+});
+
+it('removes only the named group without a threshold', async () => {
+  mock.onPost('/brokers/cold-read/config').reply(200, { code: 200, data: { verified: false } });
+  const command = {
+    instanceId: 'instance-a',
+    brokerName: 'broker-a',
+    group: 'orders',
+    action: 'REMOVE' as const,
+  };
+  await changeColdRead(command);
+  expect(JSON.parse(mock.history.post[0].data)).toEqual(command);
+});

--- a/web/src/api/coldRead.ts
+++ b/web/src/api/coldRead.ts
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import client from './client';
+
+export interface ColdReadGroup {
+  name: string;
+  configuredThreshold: string | null;
+  adaptiveThreshold: string | null;
+  coldBytes: string | null;
+  lastReadMillis: string | null;
+}
+
+export interface ColdReadSnapshot {
+  brokerName: string;
+  address: string;
+  sampledAt: number;
+  enabled: string | null;
+  adaptiveEnabled: string | null;
+  defaultThreshold: string | null;
+  globalThreshold: string | null;
+  globalBytes: string | null;
+  groups: ColdReadGroup[];
+}
+
+export interface ColdReadCommand {
+  instanceId: string;
+  brokerName: string;
+  group: string;
+  action: 'SET' | 'REMOVE';
+  threshold?: string;
+}
+
+export interface ColdReadReceipt {
+  address: string;
+  group: string;
+  action: 'SET' | 'REMOVE';
+  threshold: string | null;
+  verified: boolean;
+  verificationError: string | null;
+}
+
+export async function inspectColdRead(instanceId: string, brokerName: string, signal: AbortSignal) {
+  const res = await client.get<{ data: ColdReadSnapshot }>('/brokers/cold-read', {
+    params: { instanceId, brokerName },
+    signal,
+  });
+  return res.data.data;
+}
+
+export async function changeColdRead(command: ColdReadCommand) {
+  const res = await client.post<{ data: ColdReadReceipt }>('/brokers/cold-read/config', command);
+  return res.data.data;
+}

--- a/web/src/components/ColdReadDialog.tsx
+++ b/web/src/components/ColdReadDialog.tsx
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Descriptions,
+  Input,
+  Modal,
+  Radio,
+  Space,
+  Spin,
+  Table,
+  Typography,
+} from 'antd';
+import {
+  changeColdRead,
+  inspectColdRead,
+  type ColdReadCommand,
+  type ColdReadReceipt,
+  type ColdReadSnapshot,
+} from '../api/coldRead';
+import useAuthStore from '../stores/authStore';
+
+const value = (text: string | null) => text ?? 'Not reported';
+
+export default function ColdReadDialog({
+  instanceId,
+  brokerName,
+  onClose,
+}: {
+  instanceId: string;
+  brokerName: string;
+  onClose: () => void;
+}) {
+  const admin = useAuthStore((state) => state.admin);
+  const [snapshot, setSnapshot] = useState<ColdReadSnapshot>();
+  const [revision, setRevision] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [group, setGroup] = useState('');
+  const [threshold, setThreshold] = useState('');
+  const [action, setAction] = useState<ColdReadCommand['action']>('SET');
+  const [confirmed, setConfirmed] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [receipt, setReceipt] = useState<ColdReadReceipt>();
+  const busy = useRef(false);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    const controller = new AbortController();
+    void Promise.resolve().then(async () => {
+      if (!active) return;
+      setLoading(true);
+      setSnapshot(undefined);
+      setError(undefined);
+      try {
+        const result = await inspectColdRead(instanceId, brokerName, controller.signal);
+        if (active) setSnapshot(result);
+      } catch (failure) {
+        if (active)
+          setError(failure instanceof Error ? failure.message : 'Cold-read inspection failed');
+      } finally {
+        if (active) setLoading(false);
+      }
+    });
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [instanceId, brokerName, revision]);
+
+  const invalidate = () => {
+    setConfirmed(false);
+    setReceipt(undefined);
+  };
+  const validGroup = /^[%a-zA-Z0-9_|-]{1,255}$/.test(group) && !group.endsWith('||adaptive');
+  const validThreshold =
+    /^[1-9][0-9]{0,18}$/.test(threshold) && BigInt(threshold) <= 9223372036854775807n;
+  const canSave =
+    admin !== false &&
+    !!snapshot &&
+    validGroup &&
+    (action === 'REMOVE' || validThreshold) &&
+    confirmed &&
+    !saving &&
+    !receipt;
+
+  const save = async () => {
+    if (!canSave || busy.current) return;
+    busy.current = true;
+    setSaving(true);
+    setError(undefined);
+    try {
+      const result = await changeColdRead({
+        instanceId,
+        brokerName,
+        group,
+        action,
+        ...(action === 'SET' ? { threshold } : {}),
+      });
+      if (mounted.current) {
+        setReceipt(result);
+        setConfirmed(false);
+      }
+    } catch (failure) {
+      if (mounted.current)
+        setError(
+          failure instanceof Error
+            ? failure.message
+            : 'Cold-read update failed; refresh before retrying.',
+        );
+    } finally {
+      busy.current = false;
+      if (mounted.current) setSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      open
+      title={`Cold-read control: ${brokerName}`}
+      width={1050}
+      onCancel={() => !busy.current && onClose()}
+      closable={!saving}
+      maskClosable={!saving}
+      keyboard={!saving}
+      styles={{ body: { maxHeight: '70vh', overflowY: 'auto' } }}
+      footer={
+        <Space>
+          <Button
+            disabled={saving}
+            loading={loading}
+            onClick={() => {
+              invalidate();
+              setRevision((v) => v + 1);
+            }}
+          >
+            Refresh snapshot
+          </Button>
+          <Button disabled={saving} onClick={onClose}>
+            Close
+          </Button>
+        </Space>
+      }
+    >
+      <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+        <Alert
+          type="info"
+          showIcon
+          message="Broker-local cold-read limits"
+          description="Counters are bytes accumulated in a reset interval, not bytes per second. Group overrides are held in broker memory and must be reapplied after restart. Removing an override restores adaptive or default behavior."
+        />
+        {error && <Alert type="error" showIcon message={error} />}
+        {loading && <Spin aria-label="Loading cold-read control" />}
+        {snapshot && (
+          <>
+            <Typography.Text type="secondary">
+              {instanceId} / {snapshot.address} · {new Date(snapshot.sampledAt).toLocaleString()}
+            </Typography.Text>
+            {snapshot.enabled === 'false' && (
+              <Alert
+                type="warning"
+                showIcon
+                message="Cold-data flow control is disabled. Saving a group limit does not enable it."
+              />
+            )}
+            <Descriptions
+              bordered
+              size="small"
+              column={2}
+              items={[
+                {
+                  key: 'enabled',
+                  label: 'Flow control enabled',
+                  children: value(snapshot.enabled),
+                },
+                {
+                  key: 'adaptive',
+                  label: 'Adaptive strategy enabled',
+                  children: value(snapshot.adaptiveEnabled),
+                },
+                {
+                  key: 'default',
+                  label: 'Default group threshold (bytes)',
+                  children: value(snapshot.defaultThreshold),
+                },
+                {
+                  key: 'global',
+                  label: 'Global threshold (bytes)',
+                  children: value(snapshot.globalThreshold),
+                },
+                {
+                  key: 'acc',
+                  label: 'Global accumulated bytes',
+                  children: value(snapshot.globalBytes),
+                },
+              ]}
+            />
+            <Table
+              rowKey="name"
+              size="small"
+              dataSource={snapshot.groups}
+              pagination={{ pageSize: 5 }}
+              scroll={{ x: 850 }}
+              columns={[
+                { title: 'Consumer group', dataIndex: 'name' },
+                { title: 'Admin limit (bytes)', dataIndex: 'configuredThreshold', render: value },
+                { title: 'Adaptive limit (bytes)', dataIndex: 'adaptiveThreshold', render: value },
+                { title: 'Accumulated bytes', dataIndex: 'coldBytes', render: value },
+                { title: 'Last cold read (epoch ms)', dataIndex: 'lastReadMillis', render: value },
+                {
+                  title: 'Edit',
+                  key: 'edit',
+                  render: (_, row) => (
+                    <Button
+                      size="small"
+                      disabled={saving || admin === false}
+                      onClick={() => {
+                        setGroup(row.name);
+                        setThreshold(row.configuredThreshold ?? '');
+                        invalidate();
+                      }}
+                    >
+                      Use group
+                    </Button>
+                  ),
+                },
+              ]}
+            />
+            <Typography.Title level={5}>Change one group override</Typography.Title>
+            {admin === false && (
+              <Alert type="info" message="Administrator access is required to change limits." />
+            )}
+            <label>
+              Consumer group
+              <Input
+                aria-label="Consumer group"
+                value={group}
+                disabled={saving || admin === false}
+                onChange={(e) => {
+                  setGroup(e.target.value);
+                  invalidate();
+                }}
+              />
+            </label>
+            <Radio.Group
+              aria-label="Limit action"
+              value={action}
+              disabled={saving || admin === false}
+              onChange={(e) => {
+                setAction(e.target.value);
+                invalidate();
+              }}
+            >
+              <Radio value="SET">Set byte threshold</Radio>
+              <Radio value="REMOVE">Remove admin override</Radio>
+            </Radio.Group>
+            {action === 'SET' && (
+              <label>
+                Positive threshold in bytes
+                <Input
+                  aria-label="Positive threshold in bytes"
+                  inputMode="numeric"
+                  value={threshold}
+                  disabled={saving || admin === false}
+                  onChange={(e) => {
+                    setThreshold(e.target.value);
+                    invalidate();
+                  }}
+                />
+              </label>
+            )}
+            <Checkbox
+              checked={confirmed}
+              disabled={saving || admin === false}
+              onChange={(e) => setConfirmed(e.target.checked)}
+            >
+              Confirm {action === 'SET' ? `limit ${threshold || '?'} bytes for` : 'removal for'}{' '}
+              {group || '?'} on {brokerName} ({snapshot.address}) only
+            </Checkbox>
+            <Button type="primary" loading={saving} disabled={!canSave} onClick={() => void save()}>
+              Apply group limit
+            </Button>
+          </>
+        )}
+        {receipt && (
+          <Alert
+            showIcon
+            type={receipt.verified ? 'success' : 'warning'}
+            message={
+              receipt.verified
+                ? 'Broker configuration verified'
+                : 'Broker acknowledged; verification incomplete'
+            }
+            description={
+              receipt.verificationError ??
+              `${receipt.group}: ${receipt.action === 'SET' ? receipt.threshold + ' bytes' : 'admin override removed'} on ${receipt.address}. Refresh to inspect the latest counters.`
+            }
+          />
+        )}
+      </Space>
+    </Modal>
+  );
+}

--- a/web/src/components/__tests__/ColdReadDialog.test.tsx
+++ b/web/src/components/__tests__/ColdReadDialog.test.tsx
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, fireEvent, render as renderComponent, screen, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { ConfigProvider } from 'antd';
+import { beforeEach, expect, it, vi } from 'vitest';
+import ColdReadDialog from '../ColdReadDialog';
+import {
+  changeColdRead,
+  inspectColdRead,
+  type ColdReadReceipt,
+  type ColdReadSnapshot,
+} from '../../api/coldRead';
+import useAuthStore from '../../stores/authStore';
+
+vi.mock('../../api/coldRead', () => ({ inspectColdRead: vi.fn(), changeColdRead: vi.fn() }));
+// jsdom does not dispatch CSS animation completion events.
+const render = (element: ReactElement) =>
+  renderComponent(element, {
+    wrapper: ({ children }) => (
+      <ConfigProvider theme={{ token: { motion: false } }}>{children}</ConfigProvider>
+    ),
+  });
+const fixture: ColdReadSnapshot = {
+  brokerName: 'broker-a',
+  address: 'master:10911',
+  sampledAt: 1788825600000,
+  enabled: 'false',
+  adaptiveEnabled: 'true',
+  defaultThreshold: '1000',
+  globalThreshold: '10000',
+  globalBytes: '9007199254740993',
+  groups: [
+    {
+      name: 'orders',
+      configuredThreshold: '5000',
+      adaptiveThreshold: '1000',
+      coldBytes: null,
+      lastReadMillis: null,
+    },
+  ],
+};
+const receipt: ColdReadReceipt = {
+  address: 'master:10911',
+  group: 'orders',
+  action: 'SET',
+  threshold: '9007199254740995',
+  verified: true,
+  verificationError: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useAuthStore.setState({ admin: true });
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockReturnValue({
+      matches: false,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  });
+  vi.mocked(inspectColdRead).mockResolvedValue(structuredClone(fixture));
+  vi.mocked(changeColdRead).mockResolvedValue(receipt);
+});
+
+async function open() {
+  const view = render(
+    <ColdReadDialog instanceId="instance-a" brokerName="broker-a" onClose={vi.fn()} />,
+  );
+  await waitFor(() => expect(screen.getByText('9007199254740993')).toBeVisible());
+  return view;
+}
+
+function selectAndConfirm(threshold = '9007199254740995') {
+  fireEvent.click(screen.getByRole('button', { name: 'Use group' }));
+  fireEvent.change(screen.getByLabelText('Positive threshold in bytes'), {
+    target: { value: threshold },
+  });
+  fireEvent.click(screen.getByRole('checkbox'));
+}
+
+it('explains reset counters, disabled flow control and volatile broker scope', async () => {
+  await open();
+  expect(screen.getByText(/Counters are bytes accumulated in a reset interval/)).toBeVisible();
+  expect(screen.getByText(/Cold-data flow control is disabled/)).toBeVisible();
+  expect(screen.getAllByText('Not reported')).toHaveLength(2);
+  expect(screen.getByRole('button', { name: 'Apply group limit' })).toBeDisabled();
+});
+
+it('submits an exact byte threshold only after target confirmation', async () => {
+  await open();
+  selectAndConfirm();
+  fireEvent.click(screen.getByRole('button', { name: 'Apply group limit' }));
+  await waitFor(() => expect(screen.getByText('Broker configuration verified')).toBeVisible());
+  expect(changeColdRead).toHaveBeenCalledWith({
+    instanceId: 'instance-a',
+    brokerName: 'broker-a',
+    group: 'orders',
+    action: 'SET',
+    threshold: '9007199254740995',
+  });
+  expect(screen.getByRole('button', { name: 'Apply group limit' })).toBeDisabled();
+});
+
+it('invalidates confirmation after changing the operation and omits threshold on removal', async () => {
+  await open();
+  selectAndConfirm();
+  fireEvent.click(screen.getByLabelText('Remove admin override'));
+  expect(screen.getByRole('checkbox')).not.toBeChecked();
+  expect(screen.queryByLabelText('Positive threshold in bytes')).not.toBeInTheDocument();
+  fireEvent.click(screen.getByRole('checkbox'));
+  fireEvent.click(screen.getByRole('button', { name: 'Apply group limit' }));
+  await waitFor(() =>
+    expect(changeColdRead).toHaveBeenCalledWith({
+      instanceId: 'instance-a',
+      brokerName: 'broker-a',
+      group: 'orders',
+      action: 'REMOVE',
+    }),
+  );
+});
+
+it('rejects overflow, fractional limits and reserved adaptive names in the form', async () => {
+  await open();
+  for (const text of ['9223372036854775808', '1.5', '0']) {
+    selectAndConfirm(text);
+    expect(screen.getByRole('button', { name: 'Apply group limit' })).toBeDisabled();
+  }
+  selectAndConfirm('123');
+  fireEvent.change(screen.getByLabelText('Consumer group'), {
+    target: { value: 'orders||adaptive' },
+  });
+  fireEvent.click(screen.getByRole('checkbox'));
+  expect(screen.getByRole('button', { name: 'Apply group limit' })).toBeDisabled();
+  expect(changeColdRead).not.toHaveBeenCalled();
+});
+
+it('locks the form and prevents duplicate requests while saving', async () => {
+  let resolve!: (value: ColdReadReceipt) => void;
+  vi.mocked(changeColdRead).mockReturnValue(
+    new Promise((done) => {
+      resolve = done;
+    }),
+  );
+  await open();
+  selectAndConfirm();
+  const apply = screen.getByRole('button', { name: 'Apply group limit' });
+  fireEvent.click(apply);
+  fireEvent.click(apply);
+  expect(changeColdRead).toHaveBeenCalledTimes(1);
+  expect(screen.getByLabelText('Consumer group')).toBeDisabled();
+  expect(screen.getByRole('button', { name: 'Close' })).toBeDisabled();
+  await act(async () => resolve(receipt));
+});
+
+it('shows incomplete verification without claiming the limit was applied', async () => {
+  vi.mocked(changeColdRead).mockResolvedValue({
+    ...receipt,
+    verified: false,
+    verificationError: 'Refresh before retrying.',
+  });
+  await open();
+  selectAndConfirm();
+  fireEvent.click(screen.getByRole('button', { name: 'Apply group limit' }));
+  await waitFor(() =>
+    expect(screen.getByText('Broker acknowledged; verification incomplete')).toBeVisible(),
+  );
+  expect(screen.queryByText('Broker configuration verified')).not.toBeInTheDocument();
+  expect(changeColdRead).toHaveBeenCalledTimes(1);
+});
+
+it('keeps failed writes visible without automatic retries', async () => {
+  vi.mocked(changeColdRead).mockRejectedValue(new Error('Write denied'));
+  await open();
+  selectAndConfirm();
+  fireEvent.click(screen.getByRole('button', { name: 'Apply group limit' }));
+  await waitFor(() => expect(screen.getByText('Write denied')).toBeVisible());
+  expect(changeColdRead).toHaveBeenCalledTimes(1);
+});
+
+it('aborts a closing inspection and ignores the result', async () => {
+  let resolve!: (value: ColdReadSnapshot) => void;
+  vi.mocked(inspectColdRead).mockReturnValue(
+    new Promise((done) => {
+      resolve = done;
+    }),
+  );
+  const { unmount } = render(
+    <ColdReadDialog instanceId="instance-a" brokerName="broker-a" onClose={vi.fn()} />,
+  );
+  await waitFor(() => expect(inspectColdRead).toHaveBeenCalledTimes(1));
+  const signal = vi.mocked(inspectColdRead).mock.calls[0][2];
+  unmount();
+  expect(signal.aborted).toBe(true);
+  await act(async () => resolve(fixture));
+  expect(screen.queryByText('9007199254740993')).not.toBeInTheDocument();
+});
+
+it('ignores a write receipt after the owner unmounts the dialog', async () => {
+  let resolve!: (value: ColdReadReceipt) => void;
+  vi.mocked(changeColdRead).mockReturnValue(
+    new Promise((done) => {
+      resolve = done;
+    }),
+  );
+  const { unmount } = await open();
+  selectAndConfirm();
+  fireEvent.click(screen.getByRole('button', { name: 'Apply group limit' }));
+  unmount();
+  await act(async () => resolve(receipt));
+  expect(screen.queryByText('Broker configuration verified')).not.toBeInTheDocument();
+});
+
+it('allows a reader to inspect but disables modification', async () => {
+  useAuthStore.setState({ admin: false });
+  await open();
+  expect(screen.getByText('Administrator access is required to change limits.')).toBeVisible();
+  expect(screen.getByLabelText('Consumer group')).toBeDisabled();
+  expect(screen.getByRole('button', { name: 'Use group' })).toBeDisabled();
+});
+
+it('can refresh an unavailable snapshot', async () => {
+  vi.mocked(inspectColdRead).mockRejectedValueOnce(new Error('Broker unsupported'));
+  render(<ColdReadDialog instanceId="instance-a" brokerName="broker-a" onClose={vi.fn()} />);
+  await waitFor(() => expect(screen.getByText('Broker unsupported')).toBeVisible());
+  fireEvent.click(screen.getByRole('button', { name: 'Refresh snapshot' }));
+  await waitFor(() => expect(screen.getByText('9007199254740993')).toBeVisible());
+  expect(screen.queryByText('Broker unsupported')).not.toBeInTheDocument();
+});

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -32,6 +32,7 @@ import { supportsApacheRuntime, type Instance } from '../../api/instance';
 import { listInstances } from '../../services/instanceService';
 import { useVisiblePolling } from '../../hooks/useVisiblePolling';
 import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
+import ColdReadDialog from '../../components/ColdReadDialog';
 
 // ─── Types ──────────────────────────────────────────────────────
 type NodeStatus = 'running' | 'readonly' | 'maintenance' | 'unknown';
@@ -190,6 +191,10 @@ const BrokerClusterPage = () => {
   const [proxyData, setProxyData] = useState<ProxyRecord[]>([]);
   const [instances, setInstances] = useState<Instance[]>([]);
   const [selectedInstanceId, setSelectedInstanceId] = useState<string | undefined>(undefined);
+  const [coldReadTarget, setColdReadTarget] = useState<{
+    instanceId: string;
+    brokerName: string;
+  }>();
   const mountedRef = useRef(true);
   const loadRequestId = useRef(0);
   const { t } = useLang();
@@ -325,6 +330,25 @@ const BrokerClusterPage = () => {
     (activeTab === 'broker' && brokerData.length === 0);
 
   const brokerColumns = [
+    {
+      title: 'Cold read',
+      key: 'coldRead',
+      render: (_: unknown, broker: BrokerRecord) => (
+        <Button
+          size="small"
+          disabled={!selectedInstanceId || isMockMode()}
+          onClick={() =>
+            selectedInstanceId &&
+            setColdReadTarget({
+              instanceId: selectedInstanceId,
+              brokerName: broker.brokerName,
+            })
+          }
+        >
+          Cold-read control
+        </Button>
+      ),
+    },
     {
       title: t('brokerCluster.k8sCluster'),
       dataIndex: 'k8sCluster',
@@ -497,6 +521,13 @@ const BrokerClusterPage = () => {
 
   return (
     <div style={{ padding: 0 }}>
+      {coldReadTarget && coldReadTarget.instanceId === selectedInstanceId && (
+        <ColdReadDialog
+          key={coldReadTarget.instanceId + '/' + coldReadTarget.brokerName}
+          {...coldReadTarget}
+          onClose={() => setColdReadTarget(undefined)}
+        />
+      )}
       <div
         style={{
           display: 'flex',
@@ -521,7 +552,10 @@ const BrokerClusterPage = () => {
           <Select
             aria-label="选择实例"
             value={selectedInstanceId}
-            onChange={setSelectedInstanceId}
+            onChange={(value) => {
+              setColdReadTarget(undefined);
+              setSelectedInstanceId(value);
+            }}
             placeholder="选择实例"
             style={{ minWidth: 180 }}
             options={instances.map((instance) => ({ value: instance.name, label: instance.name }))}


### PR DESCRIPTION
<!-- Make sure the base branch is `master`: that is the RocketMQ Studio trunk. -->

### Which Issue(s) This PR Fixes

- Fixes #4433
- Replaces #4112, closed by the branch switch in #4379.

### Brief Description

This is a resubmission of #4112 against `master`, following the branch switch notice in #4379. The fork branch is unchanged; `master` is now the RocketMQ Studio trunk.

## 变更目的

Broker 列表增加 `Cold-read control`。运维人员可查看消费组回溯历史数据时的冷读用量、管理员限额与自适应限额，确认目标后只修改一个 Broker 上的一个消费组。

已检索全量 Issue/PR 标题正文中的 coldData、cold read、cold data、冷读等关键词，并补充在线 `cold data` 去重，未发现现有冷读流控功能。

## 实现范围

- 新增 GET 查询与管理员 POST 单组配置接口，绑定所选 Apache 实例及登记的主节点，不接受任意地址或回退从节点。
- 合并运行组、仅配置组和自适应组，区分管理员覆盖与 Broker 自动阈值；保留所有 64 位计数精度，缺失字段不回填零。
- 支持正整数字节阈值和移除管理员覆盖，拒绝保留的 `||adaptive` 配置键；不更改总开关或广播到其他 Broker。
- Broker 确认后回读目标键，区分已核实、值不符和回读不可用。已确认的写入不会因回读或审计失败被误报为可重试失败。
- 表单提供目标确认、修改后确认失效、保存锁定、权限提示和关闭后的迟到结果隔离，不自动重试写入。
- 添加中文使用说明、单位、生命周期、局限和回滚方法，无新增依赖或数据库变更。

官方 [ColdDataCgCtrService 5.5.0](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/coldctr/ColdDataCgCtrService.java) 将组限额保存在内存，并周期性清零累积字节计数。因此页面明确提示重启后需重新配置，计数不是字节/秒，移除覆盖恢复自适应或默认策略。

[AdminBrokerProcessor](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java) 对单条更新异常可能仍返回成功，因此服务校验输入并回读目标配置，不只依赖 RPC 确认。

### How Did You Test This Change?

## 本地验证

基线 `d6dee7d7ccfcf4886f02466ec51452a6928b2cc8`，Java 21、Node 24.18.0，2026-09-08。

```bash
cd server
mvn -B -ntp org.jacoco:jacoco-maven-plugin:0.8.13:prepare-agent -Djacoco.destFile=target/cold-read.exec -Djacoco.dataFile=target/cold-read.exec -Dtest=ColdReadTest,RuntimeAdminClientResolverTest,AuthInterceptorTest,OperationAuditServiceTest verify org.jacoco:jacoco-maven-plugin:0.8.13:report
cd ../web
npx vitest run src/api/coldRead.test.ts src/components/__tests__/ColdReadDialog.test.tsx src/pages/studio/__tests__/BrokerCluster.test.tsx
npm run build
```

- 后端 88 个测试通过：新增 34 个冷读协议/操作场景、2 个权限场景，覆盖真实实例解析、客户端工厂与审计服务；底层 SDK、实例仓储和审计 Mapper 使用 mock。
- 新服务 JaCoCo 行覆盖率 89/89，分支 52/52；Checkstyle 零违规、打包通过。
- 前端 29 个测试通过；修改文件 ESLint、TypeScript 与 Vite 构建通过。
- 浏览器在真实 Broker 列表进入面板，将 orders 的阈值改为 `9007199254740995` 并确认，只产生一个携带所选实例/组/精确字符串的本地 POST。该精确地址由同一脚本显式拦截返回受控结果，其他非 GET 中止，没有真实 Broker 写入。
- `git diff --cached --check` 通过；13 个文件，1,399 行新增、1 行删除。

首次 Checkstyle 发现参数化测试注解数组的两处缩进，修正后验证通过。原样上游基线已有 3 个全量后端失败及依赖漏洞，本项无新增依赖，相关验证无新增失败；不将增量验证表述为项目级全量验收。真实集群 E2E、性能、压力、容量与混沌测试未执行。

配置查询与回读不是原子事务，其他管理员或 Broker 切换可能改变结果。操作前应记录原值；代码回滚移除接口与入口，配置回滚恢复原管理员阈值，原本无覆盖时移除覆盖。无迁移，直接部署。提交含 `[skip ci]`，验证在本地执行。

### Checklist

- [x] One coherent change; unrelated modifications are not bundled in
- [x] Commit subject follows Conventional Commits (`feat:` / `fix:` / `refactor:` / `chore:` / `docs:` / `perf:`)
- [x] Tests added or updated for non-trivial changes, test methods named `...Test`
- [x] New UI text has both Chinese and English entries under `web/src/i18n/`, or the change does not add UI text
- [x] Architecture constraints stay green (`mvn test` runs the ArchUnit checks), or the original verification scope is stated above
- [x] New source files carry the ASF license header, or no new source files were added
- [x] Documentation touched where behaviour changed (README / `docs/` / in-app help), or no documentation change was required
