### PR TITLE
feat: recover checks for discarded transaction messages

### DIFF
--- a/docs/transaction-check-recovery.md
+++ b/docs/transaction-check-recovery.md
@@ -1,0 +1,60 @@
+# 恢复被丢弃事务的回查
+
+最后验证日期：2026-09-08。协议依据 RocketMQ 5.5.0。
+
+## 适用场景
+
+事务半消息超过回查次数后，默认 Broker 监听器会把它移到 `TRANS_CHECK_MAX_TIME_TOPIC`。
+修复生产者不可用或事务状态查询故障后，可通过恢复入口重新请求生产者检查业务事务。
+此操作不直接提交或回滚事务，最终处理结果取决于生产者的事务检查逻辑。
+
+只接受该丢弃队列中的消息，普通 Topic 消息和仍在半消息队列中的消息不会被恢复。
+需先确认业务状态查询已恢复，原生产者组可以回答回查，并考虑重复检查的业务影响。
+原消息 Broker 必须仍为所选实例登记的主节点；原地址已变成从节点或不再登记时拒绝恢复。
+
+## 操作步骤
+
+1. 在消息页选择 Apache 实例，查询 `TRANS_CHECK_MAX_TIME_TOPIC` 中的目标消息。
+2. 消息详情新增可复制的 `Physical offset ID`，与客户端消息 ID 分开展示。
+   点击 `Recover this transaction` 可将物理 ID 带入表单。
+   也可通过页面顶部 `Recover transaction checks` 输入从排障工具取得的物理 ID。
+3. 点击 `Inspect discarded transaction`，查看原 Topic、生产者组、旧回查次数、
+   事务 ID、存储时间及 Broker 地址。预览不写入 Broker。
+4. 核对目标并勾选确认后点击 `Recover checks`。提交会重新读取并验证源消息。
+5. 收到 Broker 接受回执后，检查生产者和消息轨迹，确认最终事务结果。
+
+物理 ID 为 32 或 56 位十六进制，分别编码 IPv4 或 IPv6 地址及物理偏移。
+原生消息响应增加可选 `offsetMsgId`，从 SDK 的物理 ID 字段读取，保留原 `msgId`。
+云实例和 Mock 模式不提供恢复入口。登录启用时，预览与提交均要求管理员权限。
+改变 ID 会使预览与确认失效；处理期间锁定表单，切换实例后忽略旧请求结果。
+
+## 协议与限制
+
+服务先复用实例拓扑校验，拒绝指向未知地址的物理 ID，再确认当前主节点。
+读取结果必须属于丢弃队列，并与请求的地址和 CommitLog 位点一致；
+原 Topic 和生产者组缺失时拒绝恢复。预览不返回消息正文。
+IPv6 地址匹配沿用现有拓扑校验规则，登记地址与 SDK 解码地址无法匹配时会拒绝。
+
+提交调用 SDK `resumeCheckHalfMessage`。Broker 将消息重新写入半消息队列并重置回查次数。
+页面只报告 Broker 接受，不把这一响应等同于事务提交成功。
+丢弃源消息不会由此删除，重复恢复可以产生新的回查请求；页面不自动重试。
+RPC 超时后的结果可能不确定，应先检查 Broker 和生产者记录再决定下一步。
+拓扑检查与写入不是分布式事务，操作期间应避免主动切换 Broker 角色。
+
+操作记录包含所选实例、物理 ID、原 Topic、生产者组和 Broker 地址，不包含消息正文。
+审计存储失败不把 Broker 已接受的操作变成可重试失败。
+依据官方 [DefaultTransactionalMessageCheckListener](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/DefaultTransactionalMessageCheckListener.java)、
+[DefaultMQAdminExtImpl](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java)
+和 [AdminBrokerProcessor](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java)。
+
+## 验证与回滚
+
+后端执行 `TransactionRecoveryTest`、`RocketMQMessageProviderTest`、
+`RuntimeAdminClientResolverTest`、`AuthInterceptorTest`、`OperationAuditServiceTest`。
+前端执行事务恢复 API、弹窗和两个 MessagePage 测试文件，并执行 ESLint、TypeScript 与构建。
+浏览器通过精确本地 API 拦截验证消息详情入口、预览、确认和接受回执；没有真实集群写入。
+真实集群 E2E、性能、压力、容量及混沌验证未执行。
+
+无新增依赖、配置或数据库字段，无迁移，直接部署；旧客户端可忽略新增物理 ID 字段。
+代码回滚移除入口与接口。已接受的恢复没有通用撤销命令，不能通过回滚页面撤销；
+应依据生产者事务状态和消息处理记录完成业务处置。

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageRecordVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageRecordVO.java
@@ -29,6 +29,7 @@ import java.util.Map;
 @AllArgsConstructor
 public class MessageRecordVO {
     private String msgId;
+    private String offsetMsgId;
     private String topic;
     private String tag;
     private String key;

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/TransactionRecoveryCommand.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/TransactionRecoveryCommand.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record TransactionRecoveryCommand(@NotBlank String instanceId,
+        @NotBlank @Pattern(regexp = "(?i)([0-9a-f]{32}|[0-9a-f]{56})") String offsetMessageId) {
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/TransactionRecoveryController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/TransactionRecoveryController.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.Result;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TransactionRecoveryController {
+    private final TransactionRecoveryService service;
+
+    @PostMapping("/api/messages/transaction-recovery/preview")
+    public Result<TransactionRecoveryPreview> preview(@Valid @RequestBody TransactionRecoveryCommand command) {
+        return Result.ok(service.preview(command));
+    }
+
+    @PostMapping("/api/messages/transaction-recovery")
+    public Result<TransactionRecoveryPreview> recover(@Valid @RequestBody TransactionRecoveryCommand command) {
+        return Result.ok(service.recover(command));
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/TransactionRecoveryPreview.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/TransactionRecoveryPreview.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+public record TransactionRecoveryPreview(String offsetMessageId, String brokerAddress, String originalTopic,
+                                         String producerGroup, String checkTimes, String transactionId,
+                                         long storedAt) {
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/TransactionRecoveryService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/TransactionRecoveryService.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.common.message.MessageConst;
+import org.apache.rocketmq.common.message.MessageDecoder;
+import org.apache.rocketmq.common.message.MessageId;
+import org.apache.rocketmq.common.topic.TopicValidator;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.provider.apache.BrokerTopologyGuards;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.springframework.stereotype.Service;
+
+import java.util.Locale;
+
+@Service
+@RequiredArgsConstructor
+public class TransactionRecoveryService {
+    private static final String SOURCE_TOPIC = TopicValidator.RMQ_SYS_TRANS_CHECK_MAX_TIME_TOPIC;
+    private final RuntimeAdminClientResolver resolver;
+    private final OperationAuditService audit;
+
+    public TransactionRecoveryPreview preview(TransactionRecoveryCommand command) {
+        String id = normalize(command.offsetMessageId());
+        return execute(command.instanceId(), admin -> inspect(admin, id));
+    }
+
+    public TransactionRecoveryPreview recover(TransactionRecoveryCommand command) {
+        String id = normalize(command.offsetMessageId());
+        try {
+            var result = execute(command.instanceId(), admin -> {
+                // Re-read on submission: a browser preview never authorizes a different source message.
+                var inspected = inspect(admin, id);
+                if (!admin.resumeCheckHalfMessage(SOURCE_TOPIC, id)) {
+                    throw new BusinessException(502, "Broker did not accept transaction check recovery");
+                }
+                return inspected;
+            });
+            audit.record("RECOVER_TRANSACTION_CHECK", "MESSAGE", id, command.instanceId(),
+                    "topic=" + result.originalTopic() + ", producerGroup=" + result.producerGroup()
+                            + ", broker=" + result.brokerAddress(), "SUCCESS", null);
+            return result;
+        } catch (RuntimeException failure) {
+            audit.record("RECOVER_TRANSACTION_CHECK", "MESSAGE", id, command.instanceId(),
+                    "sourceTopic=" + SOURCE_TOPIC, "FAILED", failure.getMessage());
+            throw failure;
+        }
+    }
+
+    private TransactionRecoveryPreview inspect(MQAdminExt admin, String id) throws Exception {
+        MessageId decoded = MessageDecoder.decodeMessageId(id);
+        if (decoded.getOffset() < 0) {
+            throw new BusinessException(400, "Physical message offset must be non-negative");
+        }
+        String address = BrokerTopologyGuards.validatedBrokerAddr(admin, id, decoded);
+        if (address == null) {
+            throw new BusinessException(400, "Message broker is outside the selected instance");
+        }
+        boolean master = admin.examineBrokerClusterInfo().getBrokerAddrTable().values().stream()
+                .anyMatch(broker -> address.equals(broker.getBrokerAddrs().get(0L)));
+        if (!master) {
+            throw new BusinessException(409, "Recovery requires the original message broker to be a registered master");
+        }
+        var message = admin.viewMessage(SOURCE_TOPIC, id);
+        if (message == null) {
+            throw new BusinessException(404, "Discarded transaction message was not found");
+        }
+        if (!SOURCE_TOPIC.equals(message.getTopic())) {
+            throw new BusinessException(400, "Only messages in " + SOURCE_TOPIC + " can be recovered");
+        }
+        if (!decoded.getAddress().equals(message.getStoreHost()) || decoded.getOffset() != message.getCommitLogOffset()) {
+            throw new BusinessException(409, "Returned message does not match the requested physical location");
+        }
+        String topic = message.getProperty(MessageConst.PROPERTY_REAL_TOPIC);
+        String group = message.getProperty(MessageConst.PROPERTY_PRODUCER_GROUP);
+        if (topic == null || topic.isBlank() || group == null || group.isBlank()) {
+            throw new BusinessException(422, "Discarded message is missing its original topic or producer group");
+        }
+        return new TransactionRecoveryPreview(id, address, topic, group,
+                message.getProperty(MessageConst.PROPERTY_TRANSACTION_CHECK_TIMES),
+                message.getTransactionId(), message.getStoreTimestamp());
+    }
+
+    private String normalize(String id) {
+        if (id == null || !id.matches("(?i)([0-9a-f]{32}|[0-9a-f]{56})")) {
+            throw new BusinessException(400, "A 32- or 56-character physical offset message ID is required");
+        }
+        return id.toUpperCase(Locale.ROOT);
+    }
+
+    private <T> T execute(String instanceId, MqAdminExtFactory.AdminAction<T> action) {
+        return resolver.execute(instanceId, admin -> {
+            try {
+                return action.apply(admin);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                throw interrupted;
+            }
+        });
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -704,6 +704,8 @@ public class RocketMQMessageProvider implements MessageProvider {
         Map<String, String> displayProperties = MessagePropertyDisplay.limitProperties(properties);
         return MessageRecordVO.builder()
                 .msgId(messageExt.getMsgId())
+                .offsetMsgId(messageExt instanceof org.apache.rocketmq.common.message.MessageClientExt client
+                        ? client.getOffsetMsgId() : messageExt.getMsgId())
                 .topic(messageExt.getTopic())
                 .tag(messageExt.getTags())
                 .key(messageExt.getKeys())

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
@@ -573,6 +573,25 @@ class AuthInterceptorTest {
         assertThat(allowed).isTrue();
     }
 
+    @Test
+    void transactionRecoveryAndPreviewRequireAdmin() throws Exception {
+        TestSession session = login(false);
+        for (String path : List.of("/api/messages/transaction-recovery", "/api/messages/transaction-recovery/preview")) {
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            assertThat(session.interceptor().preHandle(authenticatedRequest("POST", path, session.token()),
+                    response, new Object())).isFalse();
+            assertThat(response.getStatus()).isEqualTo(403);
+        }
+    }
+
+    @Test
+    void transactionRecoveryAllowsAuthenticatedAdmin() throws Exception {
+        TestSession session = login(true);
+        assertThat(session.interceptor().preHandle(authenticatedRequest("POST",
+                "/api/messages/transaction-recovery", session.token()),
+                new MockHttpServletResponse(), new Object())).isTrue();
+    }
+
     private TestSession login(boolean admin) {
         AuthProperties properties = new AuthProperties();
         properties.setLoginRequired(true);

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/TransactionRecoveryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/TransactionRecoveryTest.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.common.message.MessageConst;
+import org.apache.rocketmq.common.message.MessageAccessor;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.topic.TopicValidator;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminProperties;
+import org.apache.rocketmq.studio.cluster.broker.MqClientPool;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.GlobalExceptionHandler;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.studio.persistence.entity.RmqOperationAudit;
+import org.apache.rocketmq.studio.persistence.mapper.RmqOperationAuditMapper;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class TransactionRecoveryTest {
+    private static final String ID = "7F00000100002A9F000000000000002A";
+    private static final String SOURCE = TopicValidator.RMQ_SYS_TRANS_CHECK_MAX_TIME_TOPIC;
+    private final DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+    private final InstanceRepository instances = mock(InstanceRepository.class);
+    private final RmqOperationAuditMapper audits = mock(RmqOperationAuditMapper.class);
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final MqAdminExtFactory factory = new MqAdminExtFactory() {
+        @Override
+        protected DefaultMQAdminExt newAdmin(RPCHook hook) {
+            return admin;
+        }
+    };
+    private final ClusterInfo cluster = new ClusterInfo();
+    private final MessageExt message = new MessageExt();
+    private TransactionRecoveryService service;
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        when(instances.findByIdentifier("instance-a")).thenReturn(Optional.of(InstanceVO.builder()
+                .name("instance-a").vendor(InstanceVendor.APACHE).endpoint("selected:9876").build()));
+        service = new TransactionRecoveryService(new RuntimeAdminClientResolver(instances, factory,
+                new MqAdminProperties(), new MqClientPool()), new OperationAuditService(audits));
+        cluster.setBrokerAddrTable(new HashMap<>(Map.of("broker-a", new BrokerData("cluster-a", "broker-a",
+                new HashMap<>(Map.of(0L, "127.0.0.1:10911", 1L, "127.0.0.2:10911"))))));
+        when(admin.examineBrokerClusterInfo()).thenReturn(cluster);
+        message.setTopic(SOURCE);
+        message.setStoreHost(new InetSocketAddress("127.0.0.1", 10911));
+        message.setCommitLogOffset(42);
+        message.setStoreTimestamp(1788825600000L);
+        MessageAccessor.putProperty(message, MessageConst.PROPERTY_REAL_TOPIC, "orders");
+        MessageAccessor.putProperty(message, MessageConst.PROPERTY_PRODUCER_GROUP, "payment-producer");
+        MessageAccessor.putProperty(message, MessageConst.PROPERTY_TRANSACTION_CHECK_TIMES, "15");
+        message.setTransactionId("transaction-a");
+        message.setBody("private transaction body".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        when(admin.viewMessage(SOURCE, ID)).thenReturn(message);
+        when(admin.resumeCheckHalfMessage(SOURCE, ID)).thenReturn(true);
+        mvc = MockMvcBuilders.standaloneSetup(new TransactionRecoveryController(service))
+                .setControllerAdvice(new GlobalExceptionHandler()).build();
+    }
+
+    @AfterEach
+    void close() {
+        factory.shutdown();
+        Thread.interrupted();
+    }
+
+    @Test
+    void previewUsesNativeDiscardTopicAndReturnsMetadataWithoutMutating() throws Exception {
+        mvc.perform(post("/api/messages/transaction-recovery/preview").contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(new TransactionRecoveryCommand("instance-a", ID.toLowerCase()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.offsetMessageId").value(ID))
+                .andExpect(jsonPath("$.data.originalTopic").value("orders"))
+                .andExpect(jsonPath("$.data.producerGroup").value("payment-producer"))
+                .andExpect(jsonPath("$.data.checkTimes").value("15"))
+                .andExpect(jsonPath("$.data.transactionId").value("transaction-a"))
+                .andExpect(jsonPath("$.data.body").doesNotExist());
+        verify(admin).setNamesrvAddr("selected:9876");
+        verify(admin).viewMessage("TRANS_CHECK_MAX_TIME_TOPIC", ID);
+        verify(admin, never()).resumeCheckHalfMessage(anyString(), anyString());
+        verifyNoInteractions(audits);
+    }
+
+    @Test
+    void applyRevalidatesSourceThenRecordsTheAcceptedRecovery() throws Exception {
+        mvc.perform(post("/api/messages/transaction-recovery").contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(command(ID))))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.data.originalTopic").value("orders"));
+        var order = org.mockito.Mockito.inOrder(admin);
+        order.verify(admin).viewMessage(SOURCE, ID);
+        order.verify(admin).resumeCheckHalfMessage(SOURCE, ID);
+        var audit = ArgumentCaptor.forClass(RmqOperationAudit.class);
+        verify(audits).insert(audit.capture());
+        assertThat(audit.getValue().getResult()).isEqualTo("SUCCESS");
+        assertThat(audit.getValue().getDetail()).contains("orders", "payment-producer", "127.0.0.1:10911");
+        assertThat(audit.getValue().getDetail()).doesNotContain("private transaction body");
+    }
+
+    @Test
+    void ordinaryMessagesCannotBeReinsertedIntoTheHalfQueue() throws Exception {
+        message.setTopic("orders");
+        assertThatThrownBy(() -> service.recover(command(ID))).hasMessageContaining("Only messages in TRANS_CHECK_MAX_TIME_TOPIC");
+        verify(admin, never()).resumeCheckHalfMessage(anyString(), anyString());
+    }
+
+    @Test
+    void physicalMessageFromAnotherInstanceNeverReachesViewMessage() throws Exception {
+        assertThatThrownBy(() -> service.preview(command("7F00000300002A9F000000000000002A")))
+                .hasMessageContaining("outside the selected instance");
+        verify(admin, never()).viewMessage(anyString(), anyString());
+    }
+
+    @Test
+    void topologyUnavailableFailsBeforeReadingTheEmbeddedAddress() throws Exception {
+        when(admin.examineBrokerClusterInfo()).thenThrow(new IllegalStateException("NameServer unavailable"));
+        assertThatThrownBy(() -> service.preview(command(ID))).hasMessageContaining("NameServer unavailable");
+        verify(admin, never()).viewMessage(anyString(), anyString());
+    }
+
+    @Test
+    void formerMasterCannotReceiveARecoveryWrite() throws Exception {
+        cluster.getBrokerAddrTable().get("broker-a").getBrokerAddrs().put(0L, "127.0.0.2:10911");
+        cluster.getBrokerAddrTable().get("broker-a").getBrokerAddrs().put(1L, "127.0.0.1:10911");
+        assertThatThrownBy(() -> service.recover(command(ID))).hasMessageContaining("registered master");
+        verify(admin, never()).viewMessage(anyString(), anyString());
+    }
+
+    @Test
+    void missingMessageReturnsNotFound() throws Exception {
+        when(admin.viewMessage(SOURCE, ID)).thenReturn(null);
+        assertThatThrownBy(() -> service.preview(command(ID))).hasMessageContaining("was not found");
+    }
+
+    @Test
+    void brokerCannotRedirectRecoveryToADifferentPhysicalLocation() throws Exception {
+        message.setStoreHost(new InetSocketAddress("127.0.0.3", 10911));
+        assertThatThrownBy(() -> service.recover(command(ID))).hasMessageContaining("physical location");
+        message.setStoreHost(new InetSocketAddress("127.0.0.1", 10911));
+        message.setCommitLogOffset(43);
+        assertThatThrownBy(() -> service.recover(command(ID))).hasMessageContaining("physical location");
+        verify(admin, never()).resumeCheckHalfMessage(anyString(), anyString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"REAL_TOPIC", "PGROUP"})
+    void missingOriginalDestinationOrProducerGroupPreventsRecovery(String property) throws Exception {
+        message.getProperties().remove(property);
+        assertThatThrownBy(() -> service.recover(command(ID))).hasMessageContaining("missing its original");
+        MessageAccessor.putProperty(message, property, " ");
+        assertThatThrownBy(() -> service.recover(command(ID))).hasMessageContaining("missing its original");
+        verify(admin, never()).resumeCheckHalfMessage(anyString(), anyString());
+    }
+
+    @Test
+    void rejectedRecoveryIsNotReturnedAsAccepted() throws Exception {
+        when(admin.resumeCheckHalfMessage(SOURCE, ID)).thenReturn(false);
+        assertThatThrownBy(() -> service.recover(command(ID))).hasMessageContaining("did not accept");
+        var audit = ArgumentCaptor.forClass(RmqOperationAudit.class);
+        verify(audits).insert(audit.capture());
+        assertThat(audit.getValue().getResult()).isEqualTo("FAILED");
+    }
+
+    @Test
+    void interruptedRecoveryPreservesFlagAndFailure() throws Exception {
+        when(admin.resumeCheckHalfMessage(SOURCE, ID)).thenThrow(new InterruptedException("cancelled"));
+        assertThatThrownBy(() -> service.recover(command(ID))).hasMessageContaining("cancelled");
+        assertThat(Thread.currentThread().isInterrupted()).isTrue();
+    }
+
+    @Test
+    void auditFailureDoesNotTurnAcknowledgedRecoveryIntoFailure() {
+        doThrow(new IllegalStateException("audit unavailable")).when(audits).insert(any(RmqOperationAudit.class));
+        assertThat(service.recover(command(ID)).offsetMessageId()).isEqualTo(ID);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"client-unique-id", " 7F00000100002A9F000000000000002A", "GG00000100002A9F000000000000002A"})
+    void malformedPhysicalIdsFailBeforeResolvingClients(String id) {
+        assertThatThrownBy(() -> service.preview(command(id))).hasMessageContaining("physical offset message ID");
+        verifyNoInteractions(admin);
+    }
+
+    @Test
+    void negativeOffsetCannotReachBroker() throws Exception {
+        assertThatThrownBy(() -> service.preview(command("7F00000100002A9FFFFFFFFFFFFFFFFF")))
+                .hasMessageContaining("non-negative");
+        verify(admin, never()).viewMessage(anyString(), anyString());
+    }
+
+    @Test
+    void httpRejectsMissingInstanceOrMalformedId() throws Exception {
+        mvc.perform(post("/api/messages/transaction-recovery/preview").contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"offsetMessageId\":\"bad\"}")).andExpect(status().isBadRequest());
+        verifyNoInteractions(admin);
+    }
+
+    private TransactionRecoveryCommand command(String id) {
+        return new TransactionRecoveryCommand("instance-a", id);
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -456,6 +456,20 @@ class RocketMQMessageProviderTest {
     }
 
     @Test
+    void discardedMessageKeepsPhysicalIdSeparateFromClientId() {
+        var message = new org.apache.rocketmq.common.message.MessageClientExt();
+        message.setOffsetMsgId("7F00000100002A9F000000000000002A");
+        org.apache.rocketmq.common.message.MessageAccessor.putProperty(message,
+                org.apache.rocketmq.common.message.MessageConst.PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX, "client-id");
+        message.setTopic(org.apache.rocketmq.common.topic.TopicValidator.RMQ_SYS_TRANS_CHECK_MAX_TIME_TOPIC);
+
+        MessageRecordVO record = provider.toRecordVO(message);
+
+        assertThat(record.getMsgId()).isEqualTo("client-id");
+        assertThat(record.getOffsetMsgId()).isEqualTo("7F00000100002A9F000000000000002A");
+    }
+
+    @Test
     void toRecordVOBoundsMessageBodyAndProperties() {
         MessageExt message = new MessageExt();
         message.setMsgId("msg-1");
@@ -467,6 +481,7 @@ class RocketMQMessageProviderTest {
         }
 
         MessageRecordVO record = provider.toRecordVO(message);
+        assertThat(record.getOffsetMsgId()).isEqualTo("msg-1");
 
         assertThat(record.isBodyTruncated()).isTrue();
         assertThat(record.getBody()).hasSize(64 * 1024);

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -3,6 +3,7 @@ import client from './client';
 // Matches mock/messages.ts
 export interface MessageRecord {
   msgId: string;
+  offsetMsgId?: string | null;
   topic: string;
   tag: string | null;
   key: string | null;

--- a/web/src/api/transactionRecovery.test.ts
+++ b/web/src/api/transactionRecovery.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, expect, it } from 'vitest';
+import client from './client';
+import { inspectTransactionRecovery, recoverTransactionCheck } from './transactionRecovery';
+
+const mock = new MockAdapter(client);
+afterEach(() => mock.reset());
+const command = { instanceId: 'instance-a', offsetMessageId: '7F00000100002A9F000000000000002A' };
+
+it('sends the instance-bound preview to its read-only endpoint', async () => {
+  mock
+    .onPost('/messages/transaction-recovery/preview')
+    .reply(200, { code: 200, data: { originalTopic: 'orders' } });
+  expect(await inspectTransactionRecovery(command)).toEqual({ originalTopic: 'orders' });
+  expect(JSON.parse(mock.history.post[0].data)).toEqual(command);
+});
+
+it('uses the explicit recovery endpoint only for submission', async () => {
+  mock
+    .onPost('/messages/transaction-recovery')
+    .reply(200, { code: 200, data: { producerGroup: 'payment-producer' } });
+  expect(await recoverTransactionCheck(command)).toEqual({ producerGroup: 'payment-producer' });
+  expect(JSON.parse(mock.history.post[0].data)).toEqual(command);
+});

--- a/web/src/api/transactionRecovery.ts
+++ b/web/src/api/transactionRecovery.ts
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import client from './client';
+
+export interface TransactionRecoveryCommand {
+  instanceId: string;
+  offsetMessageId: string;
+}
+
+export interface TransactionRecoveryPreview {
+  offsetMessageId: string;
+  brokerAddress: string;
+  originalTopic: string;
+  producerGroup: string;
+  checkTimes: string | null;
+  transactionId: string | null;
+  storedAt: number;
+}
+
+export async function inspectTransactionRecovery(command: TransactionRecoveryCommand) {
+  const response = await client.post<{ data: TransactionRecoveryPreview }>(
+    '/messages/transaction-recovery/preview',
+    command,
+  );
+  return response.data.data;
+}
+
+export async function recoverTransactionCheck(command: TransactionRecoveryCommand) {
+  const response = await client.post<{ data: TransactionRecoveryPreview }>(
+    '/messages/transaction-recovery',
+    command,
+  );
+  return response.data.data;
+}

--- a/web/src/components/TransactionRecoveryDialog.tsx
+++ b/web/src/components/TransactionRecoveryDialog.tsx
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Alert, Button, Checkbox, Descriptions, Input, Modal, Space, Typography } from 'antd';
+import {
+  inspectTransactionRecovery,
+  recoverTransactionCheck,
+  type TransactionRecoveryPreview,
+} from '../api/transactionRecovery';
+import useAuthStore from '../stores/authStore';
+
+export default function TransactionRecoveryDialog({
+  instanceId,
+  initialId = '',
+  onClose,
+}: {
+  instanceId: string;
+  initialId?: string;
+  onClose: () => void;
+}) {
+  const admin = useAuthStore((state) => state.admin);
+  const [id, setId] = useState(initialId);
+  const [preview, setPreview] = useState<TransactionRecoveryPreview>();
+  const [confirmed, setConfirmed] = useState(false);
+  const [busy, setBusy] = useState<'inspect' | 'recover'>();
+  const [error, setError] = useState<string>();
+  const [accepted, setAccepted] = useState(false);
+  const busyRef = useRef(false);
+  const active = useRef(true);
+  useEffect(() => {
+    active.current = true;
+    return () => {
+      active.current = false;
+    };
+  }, []);
+
+  const run = async (operation: 'inspect' | 'recover') => {
+    if (busyRef.current || admin === false) return;
+    if (operation === 'recover' && (!preview || !confirmed || accepted)) return;
+    busyRef.current = true;
+    setBusy(operation);
+    setError(undefined);
+    try {
+      const command = {
+        instanceId,
+        offsetMessageId: operation === 'recover' ? preview!.offsetMessageId : id,
+      };
+      const result =
+        operation === 'inspect'
+          ? await inspectTransactionRecovery(command)
+          : await recoverTransactionCheck(command);
+      if (active.current) {
+        setPreview(result);
+        setConfirmed(false);
+        setAccepted(operation === 'recover');
+      }
+    } catch (failure) {
+      if (active.current) {
+        setError(
+          failure instanceof Error ? failure.message : 'Transaction recovery request failed',
+        );
+        setConfirmed(false);
+        if (operation === 'inspect') setPreview(undefined);
+      }
+    } finally {
+      busyRef.current = false;
+      if (active.current) setBusy(undefined);
+    }
+  };
+
+  return (
+    <Modal
+      open
+      title="Recover transaction checks"
+      width={800}
+      onCancel={() => !busyRef.current && onClose()}
+      closable={!busy}
+      maskClosable={!busy}
+      keyboard={!busy}
+      styles={{ body: { maxHeight: '65vh', overflowY: 'auto' } }}
+      footer={
+        <Space>
+          <Button disabled={!!busy} onClick={onClose}>
+            Close
+          </Button>
+          <Button
+            type="primary"
+            loading={busy === 'recover'}
+            disabled={!preview || !confirmed || !!busy || accepted || admin === false}
+            onClick={() => void run('recover')}
+          >
+            Recover checks
+          </Button>
+        </Space>
+      }
+    >
+      <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+        <Alert
+          type="warning"
+          showIcon
+          message="Resume business transaction checks"
+          description="This places a discarded transaction back into the half-message queue and resets its check count. The producer decides the transaction outcome. Repeating recovery can create another check request; do not retry automatically after a timeout."
+        />
+        <Typography.Paragraph>
+          Use the physical offset message ID from TRANS_CHECK_MAX_TIME_TOPIC on the selected
+          instance ({instanceId}). The original broker must still be a registered master. Ensure the
+          producer group can answer checks before recovery.
+        </Typography.Paragraph>
+        {admin === false && <Alert type="info" message="Administrator access is required." />}
+        <label>
+          Discarded physical message ID
+          <Input
+            aria-label="Discarded physical message ID"
+            value={id}
+            disabled={!!busy || admin === false}
+            onChange={(event) => {
+              setId(event.target.value);
+              setPreview(undefined);
+              setConfirmed(false);
+              setAccepted(false);
+              setError(undefined);
+            }}
+          />
+        </label>
+        <Button
+          loading={busy === 'inspect'}
+          disabled={!!busy || admin === false || !/^([0-9a-f]{32}|[0-9a-f]{56})$/i.test(id)}
+          onClick={() => void run('inspect')}
+        >
+          Inspect discarded transaction
+        </Button>
+        {error && <Alert type="error" showIcon message={error} />}
+        {preview && (
+          <>
+            <Descriptions
+              bordered
+              size="small"
+              column={1}
+              items={[
+                { key: 'id', label: 'Physical message ID', children: preview.offsetMessageId },
+                { key: 'broker', label: 'Broker address', children: preview.brokerAddress },
+                { key: 'topic', label: 'Original topic', children: preview.originalTopic },
+                { key: 'group', label: 'Producer group', children: preview.producerGroup },
+                {
+                  key: 'count',
+                  label: 'Previous check count',
+                  children: preview.checkTimes ?? 'Not reported',
+                },
+                {
+                  key: 'transaction',
+                  label: 'Transaction ID',
+                  children: preview.transactionId ?? 'Not reported',
+                },
+                {
+                  key: 'stored',
+                  label: 'Discarded message stored at',
+                  children:
+                    preview.storedAt > 0
+                      ? new Date(preview.storedAt).toLocaleString()
+                      : 'Not reported',
+                },
+              ]}
+            />
+            <Checkbox
+              checked={confirmed}
+              disabled={!!busy || accepted}
+              onChange={(event) => setConfirmed(event.target.checked)}
+            >
+              Confirm recovery for {preview.originalTopic} through producer group{' '}
+              {preview.producerGroup}
+            </Checkbox>
+          </>
+        )}
+        {accepted && (
+          <Alert
+            type="success"
+            showIcon
+            message="Broker accepted transaction check recovery"
+            description="The transaction outcome is pending producer checks. Inspect the producer and message trace to verify the outcome."
+          />
+        )}
+      </Space>
+    </Modal>
+  );
+}

--- a/web/src/components/__tests__/TransactionRecoveryDialog.test.tsx
+++ b/web/src/components/__tests__/TransactionRecoveryDialog.test.tsx
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, fireEvent, render as renderComponent, screen, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { ConfigProvider } from 'antd';
+import { beforeEach, expect, it, vi } from 'vitest';
+import TransactionRecoveryDialog from '../TransactionRecoveryDialog';
+import {
+  inspectTransactionRecovery,
+  recoverTransactionCheck,
+  type TransactionRecoveryPreview,
+} from '../../api/transactionRecovery';
+import useAuthStore from '../../stores/authStore';
+
+vi.mock('../../api/transactionRecovery', () => ({
+  inspectTransactionRecovery: vi.fn(),
+  recoverTransactionCheck: vi.fn(),
+}));
+// jsdom does not dispatch CSS animation completion events.
+const render = (element: ReactElement) =>
+  renderComponent(element, {
+    wrapper: ({ children }) => (
+      <ConfigProvider theme={{ token: { motion: false } }}>{children}</ConfigProvider>
+    ),
+  });
+const id = '7F00000100002A9F000000000000002A';
+const fixture: TransactionRecoveryPreview = {
+  offsetMessageId: id,
+  brokerAddress: '127.0.0.1:10911',
+  originalTopic: 'orders',
+  producerGroup: 'payment-producer',
+  checkTimes: '15',
+  transactionId: null,
+  storedAt: 1788825600000,
+};
+beforeEach(() => {
+  vi.clearAllMocks();
+  useAuthStore.setState({ admin: true });
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockReturnValue({
+      matches: false,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  });
+  vi.mocked(inspectTransactionRecovery).mockResolvedValue(fixture);
+  vi.mocked(recoverTransactionCheck).mockResolvedValue(fixture);
+});
+
+async function inspect() {
+  const view = render(<TransactionRecoveryDialog instanceId="instance-a" onClose={vi.fn()} />);
+  fireEvent.change(screen.getByLabelText('Discarded physical message ID'), {
+    target: { value: id },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Inspect discarded transaction' }));
+  await waitFor(() => expect(screen.getByText('payment-producer')).toBeVisible());
+  return view;
+}
+
+it('requires a discarded physical ID and previews destination without recovery', async () => {
+  await inspect();
+  expect(screen.getByText('orders')).toBeVisible();
+  expect(screen.getByText('15')).toBeVisible();
+  expect(screen.getByText('Not reported')).toBeVisible();
+  expect(screen.getByRole('button', { name: 'Recover checks' })).toBeDisabled();
+  expect(inspectTransactionRecovery).toHaveBeenCalledWith({
+    instanceId: 'instance-a',
+    offsetMessageId: id,
+  });
+  expect(recoverTransactionCheck).not.toHaveBeenCalled();
+});
+
+it('requires target confirmation and reports acceptance without claiming a transaction outcome', async () => {
+  await inspect();
+  fireEvent.click(screen.getByRole('checkbox'));
+  fireEvent.click(screen.getByRole('button', { name: 'Recover checks' }));
+  await waitFor(() =>
+    expect(screen.getByText('Broker accepted transaction check recovery')).toBeVisible(),
+  );
+  expect(screen.getByText(/The transaction outcome is pending producer checks/)).toBeVisible();
+  expect(recoverTransactionCheck).toHaveBeenCalledWith({
+    instanceId: 'instance-a',
+    offsetMessageId: id,
+  });
+  expect(screen.getByRole('button', { name: 'Recover checks' })).toBeDisabled();
+});
+
+it('clears inspected metadata and confirmation when the source ID changes', async () => {
+  await inspect();
+  fireEvent.click(screen.getByRole('checkbox'));
+  fireEvent.change(screen.getByLabelText('Discarded physical message ID'), {
+    target: { value: 'not-an-offset-id' },
+  });
+  expect(screen.queryByText('payment-producer')).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Inspect discarded transaction' })).toBeDisabled();
+  expect(screen.getByRole('button', { name: 'Recover checks' })).toBeDisabled();
+});
+
+it('locks the dialog and sends only one recovery while pending', async () => {
+  let resolve!: (value: TransactionRecoveryPreview) => void;
+  vi.mocked(recoverTransactionCheck).mockReturnValue(
+    new Promise((done) => {
+      resolve = done;
+    }),
+  );
+  await inspect();
+  fireEvent.click(screen.getByRole('checkbox'));
+  const recover = screen.getByRole('button', { name: 'Recover checks' });
+  fireEvent.click(recover);
+  fireEvent.click(recover);
+  expect(recoverTransactionCheck).toHaveBeenCalledTimes(1);
+  expect(screen.getByLabelText('Discarded physical message ID')).toBeDisabled();
+  expect(screen.getByRole('button', { name: 'Close' })).toBeDisabled();
+  await act(async () => resolve(fixture));
+});
+
+it('clears confirmation after failure and does not automatically retry', async () => {
+  vi.mocked(recoverTransactionCheck).mockRejectedValue(new Error('Broker rejected recovery'));
+  await inspect();
+  fireEvent.click(screen.getByRole('checkbox'));
+  fireEvent.click(screen.getByRole('button', { name: 'Recover checks' }));
+  await waitFor(() => expect(screen.getByText('Broker rejected recovery')).toBeVisible());
+  expect(screen.getByRole('checkbox')).not.toBeChecked();
+  expect(recoverTransactionCheck).toHaveBeenCalledTimes(1);
+  expect(screen.queryByText('Broker accepted transaction check recovery')).not.toBeInTheDocument();
+});
+
+it('ignores a late recovery receipt after the owner unmounts', async () => {
+  let resolve!: (value: TransactionRecoveryPreview) => void;
+  vi.mocked(recoverTransactionCheck).mockReturnValue(
+    new Promise((done) => {
+      resolve = done;
+    }),
+  );
+  const { unmount } = await inspect();
+  fireEvent.click(screen.getByRole('checkbox'));
+  fireEvent.click(screen.getByRole('button', { name: 'Recover checks' }));
+  unmount();
+  await act(async () => resolve(fixture));
+  expect(screen.queryByText('Broker accepted transaction check recovery')).not.toBeInTheDocument();
+});
+
+it('shows preview failures without exposing a recovery action', async () => {
+  vi.mocked(inspectTransactionRecovery).mockRejectedValue(new Error('Source message has expired'));
+  render(<TransactionRecoveryDialog instanceId="instance-a" onClose={vi.fn()} />);
+  fireEvent.change(screen.getByLabelText('Discarded physical message ID'), {
+    target: { value: id },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Inspect discarded transaction' }));
+  await waitFor(() => expect(screen.getByText('Source message has expired')).toBeVisible());
+  expect(screen.getByRole('button', { name: 'Recover checks' })).toBeDisabled();
+});
+
+it('prevents non-admin users from inspecting or recovering transaction messages', () => {
+  useAuthStore.setState({ admin: false });
+  render(<TransactionRecoveryDialog instanceId="instance-a" onClose={vi.fn()} />);
+  expect(screen.getByLabelText('Discarded physical message ID')).toBeDisabled();
+  expect(screen.getByRole('button', { name: 'Inspect discarded transaction' })).toBeDisabled();
+});

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -51,6 +51,9 @@ import type { ColumnsType } from 'antd/es/table';
 import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
 import PageHeader from '../../components/PageHeader';
+import TransactionRecoveryDialog from '../../components/TransactionRecoveryDialog';
+import { supportsApacheRuntime } from '../../api/instance';
+import { isMockMode } from '../../services/dataMode';
 import { InstanceSelect } from '../../components/InstanceSelect';
 import MessageQueryHistoryDrawer from '../../components/MessageQueryHistoryDrawer';
 import {
@@ -316,13 +319,15 @@ const TraceDiagnosticsPanel = ({ diagnostics }: { diagnostics: MessageTraceDiagn
    MessagePage
    ═══════════════════════════════════════════ */
 type InstanceFilterProps = {
+  canRecoverTransactions: boolean;
   selectedInstanceId: string | undefined;
   selectInstance: (instanceId: string) => void;
   instanceOptions: { value: string; label: string }[];
 };
 
 const MessagePage = () => {
-  const { selectedInstanceId, selectInstance, instanceOptions } = useInstanceFilter();
+  const { selectedInstanceId, selectedInstance, selectInstance, instanceOptions } =
+    useInstanceFilter();
   // Keying the content by the selected instance makes React remount it whenever the instance
   // changes — whether from this page's own <Select> or from the shared filter/route elsewhere —
   // so query results, the detail modal and in-flight request ownership all reset cleanly.
@@ -330,6 +335,9 @@ const MessagePage = () => {
     <MessagePageContent
       key={selectedInstanceId || 'no-instance'}
       selectedInstanceId={selectedInstanceId}
+      canRecoverTransactions={
+        !!selectedInstance && supportsApacheRuntime(selectedInstance) && !isMockMode()
+      }
       selectInstance={selectInstance}
       instanceOptions={instanceOptions}
     />
@@ -340,6 +348,7 @@ const MessagePage = () => {
    MessagePageContent
    ═══════════════════════════════════════════ */
 const MessagePageContent = ({
+  canRecoverTransactions,
   selectedInstanceId,
   selectInstance,
   instanceOptions,
@@ -392,6 +401,8 @@ const MessagePageContent = ({
   const [resultMayBeTruncated, setResultMayBeTruncated] = useState(false);
   const [queryLoading, setQueryLoading] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
+  const [recoveryOpen, setRecoveryOpen] = useState(false);
+  const [recoveryId, setRecoveryId] = useState('');
   const [modalTab, setModalTab] = useState('content');
   const [selectedMsg, setSelectedMsg] = useState<MessageRecord | null>(null);
   const [traceData, setTraceData] = useState<TraceRecord | null>(null);
@@ -881,6 +892,26 @@ const MessagePageContent = ({
                 {selectedMsg.msgId}
               </Paragraph>
             </Descriptions.Item>
+            {selectedMsg.offsetMsgId && (
+              <Descriptions.Item label="Physical offset ID" span={2}>
+                <Space direction="vertical">
+                  <Paragraph copyable style={{ marginBottom: 0, fontFamily: 'monospace' }}>
+                    {selectedMsg.offsetMsgId}
+                  </Paragraph>
+                  {selectedMsg.topic === 'TRANS_CHECK_MAX_TIME_TOPIC' && canRecoverTransactions && (
+                    <Button
+                      onClick={() => {
+                        setRecoveryId(selectedMsg.offsetMsgId!);
+                        setModalOpen(false);
+                        setRecoveryOpen(true);
+                      }}
+                    >
+                      Recover this transaction
+                    </Button>
+                  )}
+                </Space>
+              </Descriptions.Item>
+            )}
             <Descriptions.Item label="Topic">
               <Tag color={TOPIC_TAG_COLORS[selectedMsg.topic] || 'default'}>
                 {selectedMsg.topic}
@@ -1017,7 +1048,28 @@ const MessagePageContent = ({
      ═══════════════════════════════════════════ */
   return (
     <div style={{ padding: 24 }}>
-      <PageHeader title={t('message.title')} subtitle="按 Topic、Key 或 Message ID 检索消息" />
+      <PageHeader
+        title={t('message.title')}
+        subtitle="按 Topic、Key 或 Message ID 检索消息"
+        extra={
+          <Button
+            disabled={!canRecoverTransactions}
+            onClick={() => {
+              setRecoveryId('');
+              setRecoveryOpen(true);
+            }}
+          >
+            Recover transaction checks
+          </Button>
+        }
+      />
+      {recoveryOpen && selectedInstanceId && (
+        <TransactionRecoveryDialog
+          instanceId={selectedInstanceId}
+          initialId={recoveryId}
+          onClose={() => setRecoveryOpen(false)}
+        />
+      )}
 
       {/* ── Query Form ── */}
       <Card style={{ marginBottom: 16 }}>


### PR DESCRIPTION
<!-- Make sure the base branch is `master`: that is the RocketMQ Studio trunk. -->

### Which Issue(s) This PR Fixes

- Fixes #4435
- Replaces #4114, closed by the branch switch in #4379.

### Brief Description

This is a resubmission of #4114 against `master`, following the branch switch notice in #4379. The fork branch is unchanged; `master` is now the RocketMQ Studio trunk.

## 变更目的

为超过事务回查次数而进入 `TRANS_CHECK_MAX_TIME_TOPIC` 的消息提供恢复回查流程。修复生产者故障后，管理员可以查看原 Topic、生产者组与旧回查次数，再确认让 Broker 重新请求业务事务检查；页面不把 Broker 接受等同于事务提交成功。

消息详情原先只显示客户端消息 ID。本项同时保留并展示原生物理 `offsetMsgId`，丢弃消息详情可将该 ID 直接带入恢复表单，形成可用的排障流程。

已检索全量 Issue/PR 中 resumeCheckHalf、half message、半消息、事务恢复等关键词；仅发现 #425 监控规则相关内容，在线 `resume transaction` 检索无同类功能。

## 实现

- 管理员预览与提交接口绑定所选 Apache 实例，仅接受 32/56 位物理消息 ID。
- 复用 BrokerTopologyGuards 检查内嵌地址，再校验登记主节点、丢弃 Topic、返回地址、CommitLog 位点及原 Topic/生产者组。
- 提交重新验证源消息后调用 SDK `resumeCheckHalfMessage`，拒绝普通消息、未知地址和物理位置不匹配的结果。
- 保留中断、失败及审计语义；审计不包含正文，审计存储失败不将已接受操作误报为可重试失败。
- 增加输入变化后的预览失效、明确确认、提交锁定、实例切换后的迟到结果隔离，以及中文边界和回滚说明。
- 原 `msgId` 保留，新增可选物理 ID 字段；无新增依赖、配置或数据库字段。

依据官方 [DefaultTransactionalMessageCheckListener](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/DefaultTransactionalMessageCheckListener.java) 和 [AdminBrokerProcessor](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java)：恢复把丢弃消息重新写入半消息队列并重置检查次数，最终事务结果仍由生产者检查决定，原丢弃消息不会因此删除。

### How Did You Test This Change?

## 本地验证

基线 `d6dee7d7ccfcf4886f02466ec51452a6928b2cc8`，Java 21、Node 24.18.0，2026-09-08。

```bash
cd server
mvn -B -ntp org.jacoco:jacoco-maven-plugin:0.8.13:prepare-agent -Djacoco.destFile=target/transaction-recovery.exec -Djacoco.dataFile=target/transaction-recovery.exec -Dtest=TransactionRecoveryTest,RuntimeAdminClientResolverTest,RocketMQMessageProviderTest,AuthInterceptorTest,OperationAuditServiceTest verify org.jacoco:jacoco-maven-plugin:0.8.13:report
cd ../web
npx vitest run src/api/transactionRecovery.test.ts src/components/__tests__/TransactionRecoveryDialog.test.tsx src/pages/instance/__tests__/MessagePage.test.tsx src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
npm run build
```

- 后端 116 个测试通过，包括 20 个事务恢复场景、物理/客户端 ID 区分及新增权限检查；使用真实实例解析、客户端工厂和审计服务，底层 SDK 和存储使用 mock。
- 新恢复服务 JaCoCo 行覆盖率 48/48、分支 28/28，接口与记录覆盖率 100%；Checkstyle 零违规，打包通过。
- 前端 39 个测试通过，修改文件 ESLint、TypeScript 与 Vite 构建通过。
- 浏览器查询丢弃消息、打开详情、将物理 ID 自动带入、预览并确认恢复，两个精确本地 POST 均携带同一实例和物理 ID。脚本在操作前验证本地地址并明确拦截这两个 POST，其他非 GET 中止，没有真实 Broker 写入。
- `git diff --cached --check` 通过；16 个文件，1,075 行新增、2 行删除。

首次后端样本错误地用用户属性接口写系统属性，改用 SDK MessageAccessor 后通过。浏览器定位经过页面无障碍快照确认 Topic 必选及 AntD 下拉实际选项后完成，保留原查询成功提示的 AntD 静态上下文警告。

原样上游基线已有 3 个全量后端失败及依赖漏洞，本项无新增依赖、相关验证无新增失败；不将增量验证表述为项目级全量验收。真实集群 E2E、性能、压力、容量及混沌验证未执行。

操作期间应保持原 Broker 为主节点并确保生产者能回答检查。重复恢复可能增加回查请求，超时结果可能不确定，页面不自动重试。无迁移，直接部署，旧客户端可忽略新增字段。代码回滚移除接口与入口；已接受的恢复没有通用撤销命令，须依据生产者事务状态和消息记录处置。提交含 `[skip ci]`，验证在本地执行。

### Checklist

- [x] One coherent change; unrelated modifications are not bundled in
- [x] Commit subject follows Conventional Commits (`feat:` / `fix:` / `refactor:` / `chore:` / `docs:` / `perf:`)
- [x] Tests added or updated for non-trivial changes, test methods named `...Test`
- [x] New UI text has both Chinese and English entries under `web/src/i18n/`, or the change does not add UI text
- [x] Architecture constraints stay green (`mvn test` runs the ArchUnit checks), or the original verification scope is stated above
- [x] New source files carry the ASF license header, or no new source files were added
- [x] Documentation touched where behaviour changed (README / `docs/` / in-app help), or no documentation change was required
