### PR TITLE
feat: inspect controller leader views and replica membership

### DIFF
--- a/docs/controller-replica-diagnostics.md
+++ b/docs/controller-replica-diagnostics.md
@@ -1,0 +1,65 @@
+# Controller 副本成员诊断
+
+## 使用方式
+
+在 RocketMQ 集群页面选择真实 Apache 实例，从 Broker 行进入 `Replica membership`，
+点击 `Read controller state`。功能只读，不触发选主、修改配置或清理成员。
+关闭窗口或切换实例会取消浏览器请求并丢弃迟到结果。
+
+后端从所选实例的登记信息解析 Broker 地址，优先使用主节点；主节点尚未登记时，
+可从仍登记的副本读取配置。页面显示实际配置来源地址。
+只有 `enableControllerMode=true` 且存在 `controllerAddr` 时才查询 Controller。
+缺少配置字段显示 `UNKNOWN`，关闭模式显示 `DISABLED`，不把不支持误判成健康集群。
+
+## 元数据观察
+
+配置中的 Controller 地址去重后逐一读取。每个节点分别展示 Controller 组名、
+报告的 Leader ID、Leader 地址、自身角色和原始 peers。
+单个节点失败不会覆盖其他节点的元数据；失败响应保留类型或 Broker 响应码。
+界面不会返回 Broker 配置中的其他属性。
+
+| 元数据一致性 | 含义 |
+| --- | --- |
+| `MATCHING` | 所有配置节点均有返回，组名、Leader ID 和地址字段相同 |
+| `DIVERGENT` | 至少两个成功响应对这些字段的报告不同 |
+| `PARTIAL` | 成功响应相同，但至少一个配置节点查询失败 |
+| `UNAVAILABLE` | 没有成功元数据响应，或未能查询 Controller |
+
+这些状态描述本次字段比较，不代表多数派可用、选主成功或故障转移就绪。
+字段相同也可能共同报告空 Leader；此时不会继续查询成员，并给出缺失提示。
+读取是顺序进行的，选主期间不同响应可能来自不同时间点。
+
+## Broker 成员与同步集合
+
+从首个成功且报告 Leader 地址的 Controller 开始发现 Leader，查询所选 Broker 名称的成员记录。
+RocketMQ SDK 会重新查询元数据并向当时的 Leader 请求同步集合，
+因此成员信息与前面的 Controller 元数据不是原子快照。
+页面标注发现入口地址，不把该地址冒充最终处理成员查询的 Leader。
+
+成员面板展示主 Broker ID、地址、主任期、同步集合任期，以及集合内外的副本。
+Broker ID 以十进制字符串传输；不能把 NameServer 中表示主节点的路由别名 `0`
+当作 Controller 的稳定成员 ID。
+
+`Sync-set member` 和 `Controller liveness` 分别展示同步集合成员资格和存活标记。
+集合内的节点也可能暂时被报告为不存活，不能将两者合并为一个“健康”状态。
+缺失的存活标记显示 `Unknown`；本功能不推导日志复制字节差或数据无损保证。
+缺少所选 Broker 成员记录、成员 ID 重复或同一成员出现在两个集合时明确报错，
+不会以空列表或部分成员代替完整记录。
+
+成员查询失败仍保留先前读取的 Controller 元数据。网络恢复后可以手动刷新，
+刷新开始时清除旧结果，避免把旧采样误认为当前结果。
+
+## 验证、限制与回滚
+
+本地测试覆盖实例解析、登记副本回退、配置缺失、单节点失败、Leader 视图差异、
+成员集合冲突、整数精度、中断恢复和前端异步生命周期。
+浏览器验证使用本地只读接口拦截，不连接真实 Controller。
+未完成真实选主期间的集成、压力、容量或网络分区测试。
+
+无新增依赖，无数据迁移。撤销本提交即可移除入口与接口，不改变 Broker 或 Controller 状态。
+最后核验日期：2026-09-08。
+
+协议依据为 RocketMQ 5.5.0 的
+[GetMetaDataResponseHeader](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/controller/GetMetaDataResponseHeader.java)、
+[BrokerReplicasInfo](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/BrokerReplicasInfo.java)
+和 [MQClientAPIImpl.getInSyncStateData](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java#L3405)。

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ControllerReplicaController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ControllerReplicaController.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.Result;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/brokers/controller-replicas")
+public class ControllerReplicaController {
+    private final ControllerReplicaService service;
+
+    @GetMapping
+    public Result<ControllerReplicaSnapshot> inspect(@RequestParam String instanceId,
+            @RequestParam String brokerName) {
+        return Result.ok(service.inspect(instanceId, brokerName));
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ControllerReplicaService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ControllerReplicaService.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.remoting.protocol.body.BrokerReplicasInfo;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class ControllerReplicaService {
+    private final RuntimeAdminClientResolver resolver;
+
+    public ControllerReplicaSnapshot inspect(String instanceId, String brokerName) {
+        if (!StringUtils.hasText(brokerName)) {
+            throw new BusinessException(400, "Broker name is required");
+        }
+        return resolver.execute(instanceId, admin -> {
+            try {
+                return inspect(admin, brokerName);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new BusinessException(502, "Controller inspection was interrupted");
+            }
+        });
+    }
+
+    private ControllerReplicaSnapshot inspect(MQAdminExt admin, String brokerName) throws Exception {
+        var cluster = admin.examineBrokerClusterInfo();
+        if (cluster == null || cluster.getBrokerAddrTable() == null) {
+            throw new BusinessException(502, "Registered broker metadata is unavailable");
+        }
+        var broker = cluster.getBrokerAddrTable().get(brokerName);
+        if (broker == null || broker.getBrokerAddrs() == null) {
+            throw new BusinessException(404, "Broker is not registered in the selected instance");
+        }
+        String source = broker.getBrokerAddrs().get(0L);
+        if (!StringUtils.hasText(source)) {
+            source = broker.getBrokerAddrs().values().stream().filter(StringUtils::hasText).sorted()
+                    .findFirst().orElseThrow(() -> new BusinessException(404, "Broker has no registered address"));
+        }
+        var config = admin.getBrokerConfig(source);
+        if (config == null) {
+            throw new BusinessException(502, "Broker configuration is unavailable");
+        }
+        String enabled = config.getProperty("enableControllerMode");
+        String mode = "true".equalsIgnoreCase(enabled) ? "ENABLED"
+                : "false".equalsIgnoreCase(enabled) ? "DISABLED" : "UNKNOWN";
+        var addresses = Arrays.stream(config.getProperty("controllerAddr", "").split(";"))
+                .map(String::trim).filter(StringUtils::hasText).distinct().sorted().toList();
+        if (!"ENABLED".equals(mode) || addresses.isEmpty()) {
+            return new ControllerReplicaSnapshot(brokerName, source, mode, Instant.now(), List.of(),
+                    "UNAVAILABLE", null, "Controller mode is disabled, unknown, or has no configured addresses");
+        }
+        var nodes = new ArrayList<ControllerReplicaSnapshot.Node>();
+        for (String address : addresses) {
+            try {
+                var header = admin.getControllerMetaData(address);
+                if (header == null) {
+                    throw new BusinessException(502, "Controller returned no metadata");
+                }
+                nodes.add(new ControllerReplicaSnapshot.Node(address, header.getGroup(), header.getControllerLeaderId(),
+                        header.getControllerLeaderAddress(), header.isLeader(), header.getPeers(), null));
+            } catch (InterruptedException exception) {
+                throw exception;
+            } catch (Exception exception) {
+                nodes.add(new ControllerReplicaSnapshot.Node(address, null, null, null, null, null, error(exception)));
+            }
+        }
+        ControllerReplicaSnapshot.Membership membership = null;
+        String membershipError = "No controller reported a leader address";
+        var discovery = nodes.stream().filter(node -> node.error() == null
+                && StringUtils.hasText(node.leaderAddress())).findFirst();
+        if (discovery.isPresent()) {
+            String address = discovery.get().address();
+            try {
+                // The SDK discovers the leader again; this is not the preceding metadata snapshot.
+                var response = admin.getInSyncStateData(address, List.of(brokerName));
+                var info = response == null || response.getReplicasInfoTable() == null
+                        ? null : response.getReplicasInfoTable().get(brokerName);
+                if (info == null || info.getInSyncReplicas() == null || info.getNotInSyncReplicas() == null) {
+                    throw new BusinessException(502, "Controller has no complete replica record for this broker");
+                }
+                var replicas = new ArrayList<ControllerReplicaSnapshot.Replica>();
+                var ids = new HashSet<Long>();
+                append(replicas, ids, info.getInSyncReplicas(), brokerName, true);
+                append(replicas, ids, info.getNotInSyncReplicas(), brokerName, false);
+                replicas.sort(Comparator.comparing(row -> Long.parseLong(row.brokerId())));
+                membership = new ControllerReplicaSnapshot.Membership(address,
+                        info.getMasterBrokerId() == null ? null : info.getMasterBrokerId().toString(),
+                        info.getMasterAddress(), info.getMasterEpoch(), info.getSyncStateSetEpoch(), List.copyOf(replicas));
+                membershipError = null;
+            } catch (InterruptedException exception) {
+                throw exception;
+            } catch (Exception exception) {
+                membershipError = error(exception);
+            }
+        }
+        var successful = nodes.stream().filter(node -> node.error() == null).toList();
+        String agreement = "UNAVAILABLE";
+        if (!successful.isEmpty()) {
+            var first = successful.getFirst();
+            boolean same = successful.stream().allMatch(node -> Objects.equals(first.group(), node.group())
+                    && Objects.equals(first.leaderId(), node.leaderId())
+                    && Objects.equals(first.leaderAddress(), node.leaderAddress()));
+            agreement = !same ? "DIVERGENT" : successful.size() < nodes.size() ? "PARTIAL" : "MATCHING";
+        }
+        return new ControllerReplicaSnapshot(brokerName, source, mode, Instant.now(), List.copyOf(nodes),
+                agreement, membership, membershipError);
+    }
+
+    private void append(List<ControllerReplicaSnapshot.Replica> rows, HashSet<Long> ids,
+            List<BrokerReplicasInfo.ReplicaIdentity> replicas, String brokerName, boolean inSync) {
+        for (var replica : replicas) {
+            if (replica == null || !brokerName.equals(replica.getBrokerName()) || replica.getBrokerId() == null
+                    || replica.getBrokerId() < 0 || !ids.add(replica.getBrokerId())) {
+                throw new BusinessException(502, "Replica identity is invalid or appears in both sets");
+            }
+            rows.add(new ControllerReplicaSnapshot.Replica(replica.getBrokerId().toString(),
+                    replica.getBrokerAddress(), inSync, replica.getAlive()));
+        }
+    }
+
+    private String error(Exception exception) {
+        if (exception instanceof BusinessException) {
+            return exception.getMessage();
+        }
+        if (exception instanceof MQBrokerException brokerException) {
+            return "Broker response code: " + brokerException.getResponseCode();
+        }
+        return "Controller request failed: " + exception.getClass().getSimpleName();
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ControllerReplicaSnapshot.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ControllerReplicaSnapshot.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import java.time.Instant;
+import java.util.List;
+
+public record ControllerReplicaSnapshot(String brokerName, String configSource, String mode,
+        Instant sampledAt, List<Node> controllers, String agreement, Membership membership,
+        String membershipError) {
+    public record Node(String address, String group, String leaderId, String leaderAddress,
+            Boolean leader, String peers, String error) { }
+
+    public record Membership(String discoveryAddress, String masterBrokerId, String masterAddress,
+            int masterEpoch, int syncStateSetEpoch, List<Replica> replicas) { }
+
+    public record Replica(String brokerId, String address, boolean inSyncSet, Boolean alive) { }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ControllerReplicaServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ControllerReplicaServiceTest.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.remoting.protocol.body.BrokerReplicasInfo;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.header.controller.GetMetaDataResponseHeader;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ControllerReplicaServiceTest {
+    private final DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+    private final InstanceRepository repository = mock(InstanceRepository.class);
+    private final Properties config = new Properties();
+    private final ClusterInfo cluster = new ClusterInfo();
+    private final BrokerReplicasInfo replicas = new BrokerReplicasInfo();
+    private final GetMetaDataResponseHeader leader = new GetMetaDataResponseHeader(
+            "controller-group", "n0", "controller-a:9878", true, "n0-controller-a:9878;n1-controller-b:9878");
+    private final GetMetaDataResponseHeader follower = new GetMetaDataResponseHeader(
+            "controller-group", "n0", "controller-a:9878", false, "n0-controller-a:9878;n1-controller-b:9878");
+    private ControllerReplicaService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        var factory = new MqAdminExtFactory() {
+            @Override
+            protected DefaultMQAdminExt newAdmin(RPCHook hook) { return admin; }
+        };
+        service = new ControllerReplicaService(new RuntimeAdminClientResolver(repository, factory,
+                new MqAdminProperties(), mock(MqClientPool.class)));
+        when(repository.findByIdentifier("instance-a")).thenReturn(Optional.of(
+                InstanceVO.builder().endpoint("ns-a:9876").vendor(InstanceVendor.APACHE).build()));
+        cluster.setBrokerAddrTable(new HashMap<>());
+        cluster.getBrokerAddrTable().put("broker-a", new BrokerData("cluster-a", "broker-a",
+                new HashMap<>(Map.of(0L, "master:10911", 1L, "replica:10911"))));
+        config.setProperty("enableControllerMode", "true");
+        config.setProperty("controllerAddr", "controller-b:9878;controller-a:9878;controller-a:9878");
+        config.setProperty("secretKey", "must-not-be-returned");
+        when(admin.examineBrokerClusterInfo()).thenReturn(cluster);
+        when(admin.getBrokerConfig("master:10911")).thenReturn(config);
+        when(admin.getControllerMetaData("controller-a:9878")).thenReturn(leader);
+        when(admin.getControllerMetaData("controller-b:9878")).thenReturn(follower);
+        replicas.addReplicaInfo("broker-a", new BrokerReplicasInfo.ReplicasInfo(9007199254740993L,
+                "master:10911", 12, 18,
+                new ArrayList<>(List.of(new BrokerReplicasInfo.ReplicaIdentity("broker-a", 9007199254740993L,
+                        "master:10911", true))),
+                new ArrayList<>(List.of(new BrokerReplicasInfo.ReplicaIdentity("broker-a", 2L,
+                        "replica:10911", false)))));
+        when(admin.getInSyncStateData("controller-a:9878", List.of("broker-a"))).thenReturn(replicas);
+    }
+
+    private ControllerReplicaSnapshot inspect() { return service.inspect("instance-a", "broker-a"); }
+
+    @Test
+    void readsConfiguredEndpointsAndKeepsIdentityPrecisionAndLivenessSeparate() throws Exception {
+        var result = inspect();
+        assertThat(result.mode()).isEqualTo("ENABLED");
+        assertThat(result.configSource()).isEqualTo("master:10911");
+        assertThat(result.agreement()).isEqualTo("MATCHING");
+        assertThat(result.controllers()).extracting(ControllerReplicaSnapshot.Node::address)
+                .containsExactly("controller-a:9878", "controller-b:9878");
+        assertThat(result.membership().masterBrokerId()).isEqualTo("9007199254740993");
+        assertThat(result.membership().masterEpoch()).isEqualTo(12);
+        assertThat(result.membership().syncStateSetEpoch()).isEqualTo(18);
+        assertThat(result.membership().replicas().getFirst().brokerId()).isEqualTo("2");
+        assertThat(result.membership().replicas().getFirst().inSyncSet()).isFalse();
+        assertThat(result.membership().replicas().getFirst().alive()).isFalse();
+        assertThat(result.membershipError()).isNull();
+        verify(admin, times(1)).getControllerMetaData("controller-a:9878");
+        verify(admin).getInSyncStateData("controller-a:9878", List.of("broker-a"));
+    }
+
+    @Test
+    void permitsInspectionThroughRegisteredReplicaWhenMasterIsAbsent() throws Exception {
+        cluster.getBrokerAddrTable().get("broker-a").getBrokerAddrs().remove(0L);
+        when(admin.getBrokerConfig("replica:10911")).thenReturn(config);
+        assertThat(inspect().configSource()).isEqualTo("replica:10911");
+    }
+
+    @Test
+    void disabledUnknownOrUnconfiguredControllerModeDoesNotProbeControllers() throws Exception {
+        config.setProperty("enableControllerMode", "false");
+        assertThat(inspect().mode()).isEqualTo("DISABLED");
+        config.remove("enableControllerMode");
+        assertThat(inspect().mode()).isEqualTo("UNKNOWN");
+        config.setProperty("enableControllerMode", "true");
+        config.setProperty("controllerAddr", "");
+        assertThat(inspect().controllers()).isEmpty();
+        verify(admin, never()).getControllerMetaData(anyString());
+    }
+
+    @Test
+    void reportsPartialMetadataWithoutLosingReachableMembership() throws Exception {
+        when(admin.getControllerMetaData("controller-b:9878"))
+                .thenThrow(new MQBrokerException(ResponseCode.NO_PERMISSION, "secret remark"));
+        var result = inspect();
+        assertThat(result.agreement()).isEqualTo("PARTIAL");
+        assertThat(result.controllers().getLast().error()).contains("Broker response code:").doesNotContain("secret");
+        assertThat(result.membership()).isNotNull();
+    }
+
+    @Test
+    void discoversMembershipThroughAnotherConfiguredNodeWhenTheFirstTimesOut() throws Exception {
+        when(admin.getControllerMetaData("controller-a:9878")).thenThrow(
+                new org.apache.rocketmq.remoting.exception.RemotingTimeoutException("controller-a:9878", 3000));
+        when(admin.getInSyncStateData("controller-b:9878", List.of("broker-a"))).thenReturn(replicas);
+        var result = inspect();
+        assertThat(result.agreement()).isEqualTo("PARTIAL");
+        assertThat(result.controllers().getFirst().error()).contains("RemotingTimeoutException");
+        assertThat(result.membership().discoveryAddress()).isEqualTo("controller-b:9878");
+    }
+
+    @Test
+    void invalidReplicaIdentityCannotBeReportedAsACompleteMembership() {
+        var replica = replicas.getReplicasInfoTable().get("broker-a").getInSyncReplicas().getFirst();
+        replica.setBrokerName("different-broker");
+        assertThat(inspect().membershipError()).contains("identity is invalid");
+        replica.setBrokerName("broker-a");
+        replica.setBrokerId(null);
+        assertThat(inspect().membershipError()).contains("identity is invalid");
+    }
+
+    @Test
+    void divergentLeaderViewsAreNotLabelledMatching() {
+        follower.setControllerLeaderId("n1");
+        follower.setControllerLeaderAddress("controller-b:9878");
+        assertThat(inspect().agreement()).isEqualTo("DIVERGENT");
+    }
+
+    @Test
+    void preservesMetadataWhenMembershipIsUnavailable() throws Exception {
+        when(admin.getInSyncStateData("controller-a:9878", List.of("broker-a")))
+                .thenThrow(new MQBrokerException(ResponseCode.SYSTEM_ERROR, "leader changed"));
+        var result = inspect();
+        assertThat(result.controllers()).hasSize(2);
+        assertThat(result.membership()).isNull();
+        assertThat(result.membershipError()).contains("Broker response code:");
+    }
+
+    @Test
+    void emptyControllerRepliesAreNotSuccessfulObservations() throws Exception {
+        when(admin.getControllerMetaData(anyString())).thenReturn(null);
+        var result = inspect();
+        assertThat(result.agreement()).isEqualTo("UNAVAILABLE");
+        assertThat(result.controllers()).allMatch(node -> node.error() != null);
+        verify(admin, never()).getInSyncStateData(anyString(), anyList());
+    }
+
+    @Test
+    void noReportedLeaderSkipsMembershipQuery() throws Exception {
+        leader.setControllerLeaderAddress(null);
+        follower.setControllerLeaderAddress("");
+        assertThat(inspect().membershipError()).contains("No controller reported");
+        verify(admin, never()).getInSyncStateData(anyString(), anyList());
+    }
+
+    @Test
+    void unavailableReplicaRecordAndContradictorySetsAreExplicitErrors() {
+        var info = replicas.getReplicasInfoTable().remove("broker-a");
+        assertThat(inspect().membershipError()).contains("no complete replica record");
+        replicas.addReplicaInfo("broker-a", info);
+        info.getNotInSyncReplicas().add(info.getInSyncReplicas().getFirst());
+        assertThat(inspect().membershipError()).contains("both sets");
+        assertThat(inspect().membership()).isNull();
+    }
+
+    @Test
+    void nullableLivenessIsPreservedAndDoesNotRemoveSyncMembership() {
+        var replica = replicas.getReplicasInfoTable().get("broker-a").getInSyncReplicas().getFirst();
+        replica.setAlive(null);
+        var result = inspect().membership().replicas().getLast();
+        assertThat(result.inSyncSet()).isTrue();
+        assertThat(result.alive()).isNull();
+    }
+
+    @Test
+    void rejectsUnregisteredBrokerAndMissingConfiguration() throws Exception {
+        assertThatThrownBy(() -> service.inspect("instance-a", "other"))
+                .hasMessageContaining("not registered");
+        assertThatThrownBy(() -> service.inspect("instance-a", ""))
+                .hasMessageContaining("required");
+        when(admin.getBrokerConfig("master:10911")).thenReturn(null);
+        assertThatThrownBy(this::inspect).hasMessageContaining("configuration is unavailable");
+        cluster.getBrokerAddrTable().get("broker-a").getBrokerAddrs().clear();
+        assertThatThrownBy(this::inspect).hasMessageContaining("no registered address");
+        when(admin.examineBrokerClusterInfo()).thenReturn(null);
+        assertThatThrownBy(this::inspect).hasMessageContaining("metadata is unavailable");
+    }
+
+    @Test
+    void interruptsRatherThanContinuingWithAFalsePartialResult() throws Exception {
+        doThrow(new InterruptedException()).when(admin).getControllerMetaData("controller-a:9878");
+        try {
+            assertThatThrownBy(this::inspect).hasMessageContaining("interrupted");
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+            verify(admin, never()).getControllerMetaData("controller-b:9878");
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void interruptedMembershipAlsoRestoresInterruptFlag() throws Exception {
+        doThrow(new InterruptedException()).when(admin).getInSyncStateData(anyString(), anyList());
+        try {
+            assertThatThrownBy(this::inspect).hasMessageContaining("interrupted");
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void readOnlyControllerEndpointReturnsExactIdsWithoutOtherBrokerConfiguration() throws Exception {
+        var mvc = MockMvcBuilders.standaloneSetup(new ControllerReplicaController(service)).build();
+        var result = mvc.perform(get("/api/brokers/controller-replicas").param("instanceId", "instance-a")
+                        .param("brokerName", "broker-a"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.membership.masterBrokerId").value("9007199254740993"))
+                .andReturn().getResponse().getContentAsString();
+        assertThat(result).doesNotContain("must-not-be-returned", "secretKey");
+    }
+}

--- a/web/src/api/controllerReplicas.test.ts
+++ b/web/src/api/controllerReplicas.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, describe, expect, it } from 'vitest';
+import client from './client';
+import { inspectControllerReplicas } from './controllerReplicas';
+
+const mock = new MockAdapter(client);
+afterEach(() => mock.reset());
+describe('Controller replica API', () => {
+  it('uses a selected-instance GET and preserves partial observations', async () => {
+    const signal = new AbortController().signal;
+    mock.onGet('/brokers/controller-replicas').reply((config) => {
+      expect(config.params).toEqual({ instanceId: 'instance-a', brokerName: 'broker-a' });
+      expect(config.signal).toBe(signal);
+      return [
+        200,
+        {
+          code: 0,
+          data: { agreement: 'PARTIAL', membership: null, membershipError: 'Unavailable' },
+        },
+      ];
+    });
+    expect((await inspectControllerReplicas('instance-a', 'broker-a', signal)).agreement).toBe(
+      'PARTIAL',
+    );
+    expect(mock.history.post).toHaveLength(0);
+  });
+  it('rejects a failed inspection without treating it as an empty healthy cluster', async () => {
+    mock
+      .onGet('/brokers/controller-replicas')
+      .reply(200, { code: 502, message: 'Broker configuration is unavailable' });
+    await expect(inspectControllerReplicas('instance-a', 'broker-a')).rejects.toThrow(
+      'Broker configuration is unavailable',
+    );
+  });
+});

--- a/web/src/api/controllerReplicas.ts
+++ b/web/src/api/controllerReplicas.ts
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import client from './client';
+
+export interface ControllerReplicaSnapshot {
+  brokerName: string;
+  configSource: string;
+  mode: 'ENABLED' | 'DISABLED' | 'UNKNOWN';
+  sampledAt: string;
+  agreement: 'MATCHING' | 'DIVERGENT' | 'PARTIAL' | 'UNAVAILABLE';
+  controllers: {
+    address: string;
+    group: string | null;
+    leaderId: string | null;
+    leaderAddress: string | null;
+    leader: boolean | null;
+    peers: string | null;
+    error: string | null;
+  }[];
+  membership: {
+    discoveryAddress: string;
+    masterBrokerId: string | null;
+    masterAddress: string | null;
+    masterEpoch: number;
+    syncStateSetEpoch: number;
+    replicas: {
+      brokerId: string;
+      address: string | null;
+      inSyncSet: boolean;
+      alive: boolean | null;
+    }[];
+  } | null;
+  membershipError: string | null;
+}
+export async function inspectControllerReplicas(
+  instanceId: string,
+  brokerName: string,
+  signal?: AbortSignal,
+) {
+  const response = await client.get<{ data: ControllerReplicaSnapshot }>(
+    '/brokers/controller-replicas',
+    {
+      params: { instanceId, brokerName },
+      signal,
+      timeout: 60000,
+    },
+  );
+  return response.data.data;
+}

--- a/web/src/components/ControllerReplicaDialog.tsx
+++ b/web/src/components/ControllerReplicaDialog.tsx
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { Alert, Button, Card, Descriptions, Modal, Space, Table, Tag, Typography } from 'antd';
+import {
+  inspectControllerReplicas,
+  type ControllerReplicaSnapshot,
+} from '../api/controllerReplicas';
+
+export function ControllerReplicaDialog({
+  instanceId,
+  brokerName,
+  onClose,
+}: {
+  instanceId: string;
+  brokerName: string;
+  onClose: () => void;
+}) {
+  const [snapshot, setSnapshot] = useState<ControllerReplicaSnapshot>();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const active = useRef(true);
+  const locked = useRef(false);
+  const request = useRef<AbortController>();
+  useEffect(() => {
+    active.current = true;
+    return () => {
+      active.current = false;
+      request.current?.abort();
+    };
+  }, []);
+  const read = async () => {
+    if (locked.current) return;
+    locked.current = true;
+    setBusy(true);
+    setError('');
+    setSnapshot(undefined);
+    const controller = new AbortController();
+    request.current = controller;
+    try {
+      const result = await inspectControllerReplicas(instanceId, brokerName, controller.signal);
+      if (active.current) setSnapshot(result);
+    } catch (failure) {
+      if (active.current)
+        setError(failure instanceof Error ? failure.message : 'Controller inspection failed');
+    } finally {
+      locked.current = false;
+      if (active.current) setBusy(false);
+    }
+  };
+  const membership = snapshot?.membership;
+  return (
+    <Modal
+      open
+      title={`Controller replicas · ${brokerName}`}
+      width={1000}
+      style={{ top: 24 }}
+      onCancel={onClose}
+      footer={
+        <Space>
+          <Button onClick={onClose}>Close</Button>
+          <Button type="primary" loading={busy} onClick={() => void read()}>
+            Read controller state
+          </Button>
+        </Space>
+      }
+    >
+      <Space
+        direction="vertical"
+        size={16}
+        style={{ width: '100%', maxHeight: 'calc(100vh - 210px)', overflow: 'auto' }}
+      >
+        <Alert
+          type="info"
+          showIcon
+          message="Controller observations are separate from broker replication progress."
+          description="Matching metadata does not prove quorum health or failover readiness. Sync-set membership and liveness are reported independently. The SDK discovers the leader again when reading membership."
+        />
+        {error && <Alert type="error" showIcon message={error} />}
+        {snapshot && (
+          <>
+            <Descriptions
+              size="small"
+              column={2}
+              items={[
+                { key: 'mode', label: 'Controller mode', children: snapshot.mode },
+                { key: 'source', label: 'Broker config source', children: snapshot.configSource },
+                {
+                  key: 'agreement',
+                  label: 'Metadata agreement',
+                  children: (
+                    <Tag color={snapshot.agreement === 'DIVERGENT' ? 'orange' : 'default'}>
+                      {snapshot.agreement}
+                    </Tag>
+                  ),
+                },
+                { key: 'sampled', label: 'Read completed at', children: snapshot.sampledAt },
+              ]}
+            />
+            {snapshot.controllers.map((node) => (
+              <Card
+                size="small"
+                key={node.address}
+                title={node.address}
+                extra={
+                  <Tag>
+                    {node.leader === null
+                      ? 'Unknown role'
+                      : node.leader
+                        ? 'Reports leader'
+                        : 'Reports follower'}
+                  </Tag>
+                }
+              >
+                {node.error && <Alert type="warning" showIcon message={node.error} />}
+                <Descriptions
+                  size="small"
+                  column={2}
+                  items={[
+                    {
+                      key: 'group',
+                      label: 'Controller group',
+                      children: node.group ?? 'Unavailable',
+                    },
+                    {
+                      key: 'leaderId',
+                      label: 'Leader ID',
+                      children: node.leaderId ?? 'Unavailable',
+                    },
+                    {
+                      key: 'leaderAddress',
+                      label: 'Leader address',
+                      children: node.leaderAddress ?? 'Unavailable',
+                    },
+                    {
+                      key: 'peers',
+                      label: 'Reported peers',
+                      children: (
+                        <Typography.Text code style={{ overflowWrap: 'anywhere' }}>
+                          {node.peers ?? 'Unavailable'}
+                        </Typography.Text>
+                      ),
+                    },
+                  ]}
+                />
+              </Card>
+            ))}
+            {snapshot.membershipError && (
+              <Alert type="warning" showIcon message={snapshot.membershipError} />
+            )}
+            {membership && (
+              <Card size="small" title="Broker replica membership">
+                <Descriptions
+                  size="small"
+                  column={2}
+                  items={[
+                    {
+                      key: 'discovery',
+                      label: 'Leader discovery endpoint',
+                      children: membership.discoveryAddress,
+                    },
+                    {
+                      key: 'master',
+                      label: 'Master ID / address',
+                      children: `${membership.masterBrokerId ?? 'Unavailable'} / ${membership.masterAddress ?? 'Unavailable'}`,
+                    },
+                    { key: 'masterEpoch', label: 'Master epoch', children: membership.masterEpoch },
+                    {
+                      key: 'setEpoch',
+                      label: 'Sync-set epoch',
+                      children: membership.syncStateSetEpoch,
+                    },
+                  ]}
+                />
+                <Table
+                  size="small"
+                  pagination={false}
+                  rowKey="brokerId"
+                  dataSource={membership.replicas}
+                  scroll={{ x: 600 }}
+                  columns={[
+                    { title: 'Broker ID', dataIndex: 'brokerId' },
+                    {
+                      title: 'Address',
+                      dataIndex: 'address',
+                      render: (value) => value ?? 'Unavailable',
+                    },
+                    {
+                      title: 'Sync-set member',
+                      dataIndex: 'inSyncSet',
+                      render: (value) => (value ? 'In set' : 'Outside set'),
+                    },
+                    {
+                      title: 'Controller liveness',
+                      dataIndex: 'alive',
+                      render: (value) => (
+                        <Tag color={value === false ? 'orange' : 'default'}>
+                          {value === null ? 'Unknown' : value ? 'Alive' : 'Not alive'}
+                        </Tag>
+                      ),
+                    },
+                  ]}
+                />
+              </Card>
+            )}
+          </>
+        )}
+      </Space>
+    </Modal>
+  );
+}

--- a/web/src/components/__tests__/ControllerReplicaDialog.test.tsx
+++ b/web/src/components/__tests__/ControllerReplicaDialog.test.tsx
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { ConfigProvider } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ControllerReplicaDialog } from '../ControllerReplicaDialog';
+import {
+  inspectControllerReplicas,
+  type ControllerReplicaSnapshot,
+} from '../../api/controllerReplicas';
+
+vi.mock('../../api/controllerReplicas', () => ({ inspectControllerReplicas: vi.fn() }));
+const sample: ControllerReplicaSnapshot = {
+  brokerName: 'broker-a',
+  configSource: 'master:10911',
+  mode: 'ENABLED',
+  sampledAt: '2026-09-08T00:00:00Z',
+  agreement: 'MATCHING',
+  controllers: [
+    {
+      address: 'controller-a:9878',
+      group: 'controller-group',
+      leaderId: 'n0',
+      leaderAddress: 'controller-a:9878',
+      leader: true,
+      peers: 'n0-controller-a:9878',
+      error: null,
+    },
+  ],
+  membership: {
+    discoveryAddress: 'controller-a:9878',
+    masterBrokerId: '9007199254740993',
+    masterAddress: 'master:10911',
+    masterEpoch: 12,
+    syncStateSetEpoch: 18,
+    replicas: [
+      { brokerId: '9007199254740993', address: 'master:10911', inSyncSet: true, alive: true },
+      { brokerId: '2', address: 'replica:10911', inSyncSet: true, alive: false },
+      { brokerId: '3', address: null, inSyncSet: false, alive: null },
+    ],
+  },
+  membershipError: null,
+};
+const open = (onClose = vi.fn()) =>
+  render(
+    <ConfigProvider theme={{ token: { motion: false } }}>
+      <ControllerReplicaDialog instanceId="instance-a" brokerName="broker-a" onClose={onClose} />
+    </ConfigProvider>,
+  );
+const read = () => fireEvent.click(screen.getByRole('button', { name: /Read controller state/ }));
+
+describe('Controller replica diagnostics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: false,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+    vi.mocked(inspectControllerReplicas).mockResolvedValue(sample);
+  });
+
+  it('queries manually and keeps liveness separate from sync-set membership', async () => {
+    open();
+    expect(inspectControllerReplicas).not.toHaveBeenCalled();
+    read();
+    await screen.findByText('9007199254740993');
+    expect(inspectControllerReplicas).toHaveBeenCalledWith(
+      'instance-a',
+      'broker-a',
+      expect.any(AbortSignal),
+    );
+    expect(screen.getAllByText('In set')).toHaveLength(2);
+    expect(screen.getByText('Not alive')).toBeInTheDocument();
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+    expect(screen.getByText('Outside set')).toBeInTheDocument();
+    expect(screen.getByText('MATCHING')).toBeInTheDocument();
+    expect(screen.getByText(/Matching metadata does not prove/)).toBeInTheDocument();
+  });
+
+  it('shows a disabled mode without inventing membership', async () => {
+    vi.mocked(inspectControllerReplicas).mockResolvedValue({
+      ...sample,
+      mode: 'DISABLED',
+      agreement: 'UNAVAILABLE',
+      controllers: [],
+      membership: null,
+      membershipError: 'Controller mode is disabled',
+    });
+    open();
+    read();
+    await screen.findByText('DISABLED');
+    expect(screen.getByText('Controller mode is disabled')).toBeInTheDocument();
+    expect(screen.queryByText('Broker replica membership')).not.toBeInTheDocument();
+  });
+
+  it('preserves metadata while showing a membership failure', async () => {
+    vi.mocked(inspectControllerReplicas).mockResolvedValue({
+      ...sample,
+      membership: null,
+      membershipError: 'Broker response code: 1',
+    });
+    open();
+    read();
+    await screen.findByText('Broker response code: 1');
+    expect(screen.getByText('controller-group')).toBeInTheDocument();
+    expect(screen.getByText('Reports leader')).toBeInTheDocument();
+  });
+
+  it('displays divergent and failed controller observations explicitly', async () => {
+    vi.mocked(inspectControllerReplicas).mockResolvedValue({
+      ...sample,
+      agreement: 'DIVERGENT',
+      controllers: [
+        ...sample.controllers,
+        {
+          address: 'controller-b:9878',
+          group: null,
+          leaderId: null,
+          leaderAddress: null,
+          leader: null,
+          peers: null,
+          error: 'Controller request failed',
+        },
+      ],
+    });
+    open();
+    read();
+    await screen.findByText('DIVERGENT');
+    expect(screen.getByText('Controller request failed')).toBeInTheDocument();
+    expect(screen.getByText('Unknown role')).toBeInTheDocument();
+  });
+
+  it('prevents concurrent reads and discards a response after closing', async () => {
+    let resolve!: (value: ControllerReplicaSnapshot) => void;
+    vi.mocked(inspectControllerReplicas).mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    const view = open();
+    read();
+    read();
+    expect(inspectControllerReplicas).toHaveBeenCalledTimes(1);
+    const signal = vi.mocked(inspectControllerReplicas).mock.calls[0][2];
+    view.unmount();
+    expect(signal?.aborted).toBe(true);
+    await act(async () => resolve(sample));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('clears stale results before refreshing and reports read failures', async () => {
+    open();
+    read();
+    await screen.findByText('MATCHING');
+    vi.mocked(inspectControllerReplicas).mockRejectedValue(new Error('Broker is not registered'));
+    read();
+    await screen.findByText('Broker is not registered');
+    expect(screen.queryByText('MATCHING')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -31,6 +31,7 @@ import type { ClusterInfo } from '../../api/cluster';
 import { supportsApacheRuntime, type Instance } from '../../api/instance';
 import { listInstances } from '../../services/instanceService';
 import { useVisiblePolling } from '../../hooks/useVisiblePolling';
+import { ControllerReplicaDialog } from '../../components/ControllerReplicaDialog';
 import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 
 // ─── Types ──────────────────────────────────────────────────────
@@ -190,6 +191,10 @@ const BrokerClusterPage = () => {
   const [proxyData, setProxyData] = useState<ProxyRecord[]>([]);
   const [instances, setInstances] = useState<Instance[]>([]);
   const [selectedInstanceId, setSelectedInstanceId] = useState<string | undefined>(undefined);
+  const [controllerTarget, setControllerTarget] = useState<{
+    instanceId: string;
+    brokerName: string;
+  }>();
   const mountedRef = useRef(true);
   const loadRequestId = useRef(0);
   const { t } = useLang();
@@ -325,6 +330,25 @@ const BrokerClusterPage = () => {
     (activeTab === 'broker' && brokerData.length === 0);
 
   const brokerColumns = [
+    {
+      title: 'Controller',
+      key: 'controller',
+      render: (_: unknown, record: BrokerRecord) => (
+        <Button
+          size="small"
+          disabled={!selectedInstanceId || isMockMode()}
+          onClick={() => {
+            if (selectedInstanceId)
+              setControllerTarget({
+                instanceId: selectedInstanceId,
+                brokerName: record.brokerName,
+              });
+          }}
+        >
+          Replica membership
+        </Button>
+      ),
+    },
     {
       title: t('brokerCluster.k8sCluster'),
       dataIndex: 'k8sCluster',
@@ -521,7 +545,10 @@ const BrokerClusterPage = () => {
           <Select
             aria-label="选择实例"
             value={selectedInstanceId}
-            onChange={setSelectedInstanceId}
+            onChange={(value) => {
+              setControllerTarget(undefined);
+              setSelectedInstanceId(value);
+            }}
             placeholder="选择实例"
             style={{ minWidth: 180 }}
             options={instances.map((instance) => ({ value: instance.name, label: instance.name }))}
@@ -614,6 +641,13 @@ const BrokerClusterPage = () => {
           />
         </Card>
       </Spin>
+      {controllerTarget && controllerTarget.instanceId === selectedInstanceId && (
+        <ControllerReplicaDialog
+          key={controllerTarget.instanceId + controllerTarget.brokerName}
+          {...controllerTarget}
+          onClose={() => setControllerTarget(undefined)}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
<!-- Make sure the base branch is `master`: that is the RocketMQ Studio trunk. -->

### Which Issue(s) This PR Fixes

- Fixes #4443
- Replaces #4129, closed by the branch switch in #4379.

### Brief Description

This is a resubmission of #4129 against `master`, following the branch switch notice in #4379. The fork branch is unchanged; `master` is now the RocketMQ Studio trunk.

Controller 模式的 Broker 故障排查需要分别查看 Controller 的 Leader 视图与 Broker 同步集合成员。现有集群页面缺少这项只读诊断，本 PR 增加 Replica membership 入口、实例绑定接口、协议测试和中文操作文档。

## 改动说明

- 从所选实例登记的 Broker 读取 Controller 配置；主节点尚未登记时可从已登记副本读取。模式关闭、字段缺失或地址未配置有明确反馈，不返回其他 Broker 配置。
- 对配置中的 Controller 去重并逐节点读取组名、Leader、角色与 peers，保留部分失败。展示 MATCHING、DIVERGENT、PARTIAL、UNAVAILABLE 字段比较结果，不把一致报告解释为多数派健康。
- 使用原生 getInSyncStateData 查询所选 Broker 的主成员、任期和同步集合内外副本。64 位成员 ID 保持字符串；存活标记与同步集合资格分开呈现，缺失标记保持未知。无选主或配置修改操作。
- 成员查询失败仍保留 Controller 元数据；界面只手动查询，关闭和实例切换取消浏览器请求并丢弃迟到结果。

协议依据：[BrokerReplicasInfo](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/BrokerReplicasInfo.java) 和 [MQClientAPIImpl.getInSyncStateData](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java#L3405)。SDK 查询成员前会再次发现 Leader，因此接口明确记录发现入口地址，不声称元数据与成员来自同一原子快照。

### How Did You Test This Change?

## 原提交验证记录

本地后端 65 项、前端 23 项测试通过，新增服务覆盖 87/87 行、64/74 分支。Checkstyle、TypeScript/Vite 构建及后端打包通过；ESLint 0 错误、10 条现有告警。浏览器通过本地 GET 拦截验证真实入口、部分失败、大整数及同步成员与存活标记的区别，并检查滚动面板和底部按钮。

## 兼容性与回滚

无新增依赖，无数据迁移，撤销该提交即可回滚。未运行真实 Controller 选主期间 E2E、压力、容量和网络分区测试；既有全量测试失败与依赖审计缺口保留在任务记录，未宣称全量门槛通过。按用户授权执行增量验证，提交包含 [skip ci]，未运行远端工作流。核验日期：2026-09-08。

### Checklist

- [x] One coherent change; unrelated modifications are not bundled in
- [x] Commit subject follows Conventional Commits (`feat:` / `fix:` / `refactor:` / `chore:` / `docs:` / `perf:`)
- [x] Tests added or updated for non-trivial changes, test methods named `...Test`
- [x] New UI text has both Chinese and English entries under `web/src/i18n/`, or the change does not add UI text
- [x] Architecture constraints stay green (`mvn test` runs the ArchUnit checks), or the original verification scope is stated above
- [x] New source files carry the ASF license header, or no new source files were added
- [x] Documentation touched where behaviour changed (README / `docs/` / in-app help), or no documentation change was required
