### PR TITLE
feat: inspect and configure CommitLog runtime read-ahead

### DIFF
--- a/docs/commitlog-read-ahead.md
+++ b/docs/commitlog-read-ahead.md
@@ -1,0 +1,59 @@
+# CommitLog 运行时预读控制
+
+## 用途与范围
+
+真实 Apache 实例的 Broker 集群列表提供 `Read-ahead` 入口，调整所选节点的
+CommitLog 文件预读建议。该操作用于维护窗口中的磁盘读取行为排查，
+不改变消费者流控阈值、消息保留时间或逻辑消费位点。
+
+操作只针对页面显示的 Broker 名称与地址。服务端在读取和提交前均检查该地址
+仍登记在所选实例的同名 Broker 下；不会自动切换到另一个主节点或副本。
+页面列出哪个节点，就只对该节点应用配置。
+
+## 操作步骤
+
+1. 在维护窗口记录磁盘 I/O、读延迟和页缓存情况，明确观察与恢复方案。
+2. 点击 `Inspect current mode`，读取当前 `dataReadAheadEnable`。
+3. 选择不同的目标模式并勾选确认，再点击 `Apply runtime mode`。
+4. 查看 RPC 确认和配置回读，并检查 Broker 日志及实际 I/O 指标。
+5. 如需恢复，重新读取当前配置，再应用记录中的原模式。
+
+| 界面模式 | 原生参数 | 配置字段 |
+| --- | --- | --- |
+| `Normal read-ahead` | `MADV_NORMAL`，值 `0` | `dataReadAheadEnable=true` |
+| `Random access advice` | `MADV_RANDOM`，值 `1` | `dataReadAheadEnable=false` |
+
+预览缺少可识别的布尔配置时明确报错，不默认按关闭处理。
+提交携带原值，当前值变化则返回冲突。相同值不重复触发文件扫描。
+
+## 确认范围与限制
+
+原生命令修改运行时配置，并扫描现有映射文件设置读取建议。
+`CONFIG_CONFIRMED` 表示命令收到确认且配置回读一致，不表示每个文件的操作系统调用成功。
+Windows 会跳过文件扫描；其他平台上的扫描异常和部分 `madvise` 失败可能只写日志，
+Broker 仍可返回成功。本功能无法确认内核的实际预读行为，也不提供性能提升保证。
+
+当命令异常、回读失败或回读不一致时，回执为 `UNKNOWN`，并分别保留是否收到命令确认、
+原配置和已取得的回读。不能把未知结果当作未修改，不自动重试或回滚。
+浏览器关闭、切换实例或断网不能撤回已发送的 Broker 请求。
+
+原生操作没有显式持久化配置；重启后的行为应以部署文件和 Broker 启动配置为准。
+其他后续配置保存动作也可能持久化当前运行时字段，不应依赖重启作为自动回滚。
+需持久化时应通过既定配置发布流程处理，并重新验证启动行为。
+
+## 验证与代码回滚
+
+POST 沿用管理员权限拦截。操作审计记录节点地址、原值、目标值和结果；
+审计存储失败不会覆盖已经产生的 Broker 回执。
+
+本地测试覆盖实例与节点绑定、参数映射、旧值冲突、未知配置、RPC 与回读分别失败、
+中断标记、审计失败和前端确认生命周期。浏览器通过本地 GET/POST 拦截验证，
+未改变真实 Broker 配置。真实 Linux/Windows 内核效果、I/O 性能、压力、容量与故障切换验证未执行。
+
+无新增依赖或数据库迁移。撤销代码提交即可移除入口和接口；运行时配置按前述步骤恢复。
+最后核验日期：2026-09-08。
+
+源码依据为 RocketMQ 5.5.0 的
+[AdminBrokerProcessor.setCommitLogReadaheadMode](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java#L1007)、
+[CommitLog.scanFileAndSetReadMode](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/store/src/main/java/org/apache/rocketmq/store/CommitLog.java#L2513)
+和 [Configuration](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/remoting/src/main/java/org/apache/rocketmq/remoting/Configuration.java#L281)。

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerReadAheadController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerReadAheadController.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.Result;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/brokers/read-ahead")
+public class BrokerReadAheadController {
+    private final BrokerReadAheadService service;
+
+    @GetMapping
+    public Result<BrokerReadAheadService.Snapshot> inspect(@RequestParam String instanceId,
+            @RequestParam String brokerName, @RequestParam String address) {
+        return Result.ok(service.inspect(instanceId, brokerName, address));
+    }
+
+    @PostMapping
+    public Result<BrokerReadAheadService.Receipt> apply(@RequestBody BrokerReadAheadService.Request request) {
+        return Result.ok(service.apply(request));
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerReadAheadService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerReadAheadService.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class BrokerReadAheadService {
+    private final RuntimeAdminClientResolver resolver;
+    private final OperationAuditService audit;
+
+    public record Snapshot(String brokerName, String address, boolean enabled, Instant sampledAt) { }
+    public record Request(String instanceId, String brokerName, String address, Boolean expectedEnabled,
+            Boolean enabled) { }
+    public record Receipt(String status, boolean acknowledged, Snapshot before, Snapshot observed) { }
+
+    public Snapshot inspect(String instanceId, String brokerName, String address) {
+        validate(brokerName, address);
+        return resolver.execute(instanceId, admin -> {
+            try {
+                requireRegistered(admin, brokerName, address);
+                return read(admin, brokerName, address);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new BusinessException(502, "Read-ahead inspection was interrupted");
+            }
+        });
+    }
+
+    public Receipt apply(Request request) {
+        validate(request.brokerName(), request.address());
+        if (request.enabled() == null || request.expectedEnabled() == null) {
+            throw new BusinessException(400, "Requested and reviewed read-ahead values are required");
+        }
+        return resolver.execute(request.instanceId(), admin -> {
+            Snapshot before;
+            try {
+                requireRegistered(admin, request.brokerName(), request.address());
+                before = read(admin, request.brokerName(), request.address());
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new BusinessException(502, "Read-ahead preflight was interrupted");
+            }
+            if (before.enabled() != request.expectedEnabled()) {
+                throw new BusinessException(409, "Read-ahead configuration changed; inspect again");
+            }
+            if (before.enabled() == request.enabled()) {
+                return new Receipt("UNCHANGED", false, before, before);
+            }
+            boolean acknowledged = false;
+            Snapshot observed = null;
+            try {
+                // Native command applies MADV_NORMAL (0) or MADV_RANDOM (1) to existing mapped files.
+                admin.setCommitLogReadAheadMode(request.address(), request.enabled() ? "0" : "1");
+                acknowledged = true;
+                observed = read(admin, request.brokerName(), request.address());
+            } catch (Exception exception) {
+                if (exception instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            String status = acknowledged && observed != null && observed.enabled() == request.enabled()
+                    ? "CONFIG_CONFIRMED" : "UNKNOWN";
+            audit.record("SET_COMMITLOG_READ_AHEAD", "BROKER", request.brokerName(), request.instanceId(),
+                    "address=" + request.address() + ", before=" + before.enabled() + ", requested=" + request.enabled(),
+                    status, "UNKNOWN".equals(status) ? "Read configuration and broker logs before recovery" : null);
+            return new Receipt(status, acknowledged, before, observed);
+        });
+    }
+
+    private Snapshot read(MQAdminExt admin, String brokerName, String address) throws Exception {
+        var properties = admin.getBrokerConfig(address);
+        String value = properties == null ? null : properties.getProperty("dataReadAheadEnable");
+        if (!"true".equalsIgnoreCase(value) && !"false".equalsIgnoreCase(value)) {
+            throw new BusinessException(422, "Broker does not expose a supported dataReadAheadEnable value");
+        }
+        return new Snapshot(brokerName, address, Boolean.parseBoolean(value), Instant.now());
+    }
+
+    private void requireRegistered(MQAdminExt admin, String brokerName, String address) throws Exception {
+        var cluster = admin.examineBrokerClusterInfo();
+        if (cluster == null || cluster.getBrokerAddrTable() == null) {
+            throw new BusinessException(502, "Broker registry is unavailable");
+        }
+        var broker = cluster.getBrokerAddrTable().get(brokerName);
+        if (broker == null || broker.getBrokerAddrs() == null || !broker.getBrokerAddrs().containsValue(address)) {
+            throw new BusinessException(404, "Broker address is not registered in the selected instance");
+        }
+    }
+
+    private void validate(String brokerName, String address) {
+        if (!StringUtils.hasText(brokerName) || !StringUtils.hasText(address)) {
+            throw new BusinessException(400, "Broker name and registered address are required");
+        }
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
@@ -366,6 +366,24 @@ class AuthInterceptorTest {
     }
 
     @Test
+    void shouldRejectReadAheadChangesForNonAdmin() throws Exception {
+        TestSession session = login(false);
+        var response = new MockHttpServletResponse();
+        boolean allowed = session.interceptor().preHandle(authenticatedRequest(
+                "POST", "/api/brokers/read-ahead", session.token()), response, new Object());
+        assertThat(allowed).isFalse();
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void shouldAllowReadAheadChangesForAdmin() throws Exception {
+        TestSession session = login(true);
+        boolean allowed = session.interceptor().preHandle(authenticatedRequest(
+                "POST", "/api/brokers/read-ahead", session.token()), new MockHttpServletResponse(), new Object());
+        assertThat(allowed).isTrue();
+    }
+
+    @Test
     void shouldRejectMutatingPostForNonAdminUser() throws Exception {
         TestSession session = login(false);
         MockHttpServletRequest request = authenticatedRequest(

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/BrokerReadAheadServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/BrokerReadAheadServiceTest.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.studio.persistence.entity.RmqOperationAudit;
+import org.apache.rocketmq.studio.persistence.mapper.RmqOperationAuditMapper;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class BrokerReadAheadServiceTest {
+    private final DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+    private final InstanceRepository repository = mock(InstanceRepository.class);
+    private final RmqOperationAuditMapper audits = mock(RmqOperationAuditMapper.class);
+    private final Properties config = new Properties();
+    private final ClusterInfo cluster = new ClusterInfo();
+    private BrokerReadAheadService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        var factory = new MqAdminExtFactory() {
+            @Override
+            protected DefaultMQAdminExt newAdmin(RPCHook hook) { return admin; }
+        };
+        service = new BrokerReadAheadService(new RuntimeAdminClientResolver(repository, factory,
+                new MqAdminProperties(), mock(MqClientPool.class)), new OperationAuditService(audits));
+        when(repository.findByIdentifier("instance-a")).thenReturn(Optional.of(
+                InstanceVO.builder().endpoint("ns-a:9876").vendor(InstanceVendor.APACHE).build()));
+        cluster.setBrokerAddrTable(new HashMap<>());
+        cluster.getBrokerAddrTable().put("broker-a", new BrokerData("cluster-a", "broker-a",
+                new HashMap<>(Map.of(0L, "master:10911", 1L, "replica:10911"))));
+        when(admin.examineBrokerClusterInfo()).thenReturn(cluster);
+        config.setProperty("dataReadAheadEnable", "true");
+        config.setProperty("secretKey", "not-in-response");
+        when(admin.getBrokerConfig(anyString())).thenReturn(config);
+        when(admin.setCommitLogReadAheadMode(anyString(), anyString())).thenAnswer(invocation -> {
+            config.setProperty("dataReadAheadEnable", "0".equals(invocation.getArgument(1)) ? "true" : "false");
+            return null;
+        });
+    }
+
+    private BrokerReadAheadService.Snapshot inspect() { return service.inspect("instance-a", "broker-a", "master:10911"); }
+    private BrokerReadAheadService.Request request(boolean before, boolean enabled) {
+        return new BrokerReadAheadService.Request("instance-a", "broker-a", "master:10911", before, enabled);
+    }
+
+    @Test
+    void readsOnlyTheRuntimeSettingFromTheRegisteredNode() throws Exception {
+        assertThat(inspect().enabled()).isTrue();
+        assertThat(inspect().address()).isEqualTo("master:10911");
+        assertThat(service.inspect("instance-a", "broker-a", "replica:10911").enabled()).isTrue();
+        verify(admin, never()).setCommitLogReadAheadMode(anyString(), anyString());
+    }
+
+    @Test
+    void mapsNativeModesAndConfirmsConfigurationWithoutClaimingOsSuccess() throws Exception {
+        var disabled = service.apply(request(true, false));
+        assertThat(disabled.status()).isEqualTo("CONFIG_CONFIRMED");
+        assertThat(disabled.acknowledged()).isTrue();
+        assertThat(disabled.before().enabled()).isTrue();
+        assertThat(disabled.observed().enabled()).isFalse();
+        verify(admin).setCommitLogReadAheadMode("master:10911", "1");
+        assertThat(service.apply(request(false, true)).observed().enabled()).isTrue();
+        verify(admin).setCommitLogReadAheadMode("master:10911", "0");
+    }
+
+    @Test
+    void stalePreviewAndUnregisteredAddressesNeverWrite() throws Exception {
+        config.setProperty("dataReadAheadEnable", "false");
+        assertThatThrownBy(() -> service.apply(request(true, false))).hasMessageContaining("changed");
+        assertThatThrownBy(() -> service.inspect("instance-a", "broker-a", "unregistered:10911"))
+                .hasMessageContaining("not registered");
+        cluster.getBrokerAddrTable().clear();
+        assertThatThrownBy(() -> service.apply(request(false, true))).hasMessageContaining("not registered");
+        verify(admin, never()).setCommitLogReadAheadMode(anyString(), anyString());
+    }
+
+    @Test
+    void unchangedRequestDoesNotSendAnOsAdviceScan() throws Exception {
+        assertThat(service.apply(request(true, true)).status()).isEqualTo("UNCHANGED");
+        verify(admin, never()).setCommitLogReadAheadMode(anyString(), anyString());
+    }
+
+    @Test
+    void failedWriteIsUncertainAndNotRetried() throws Exception {
+        doThrow(new MQBrokerException(ResponseCode.SYSTEM_ERROR, "failed"))
+                .when(admin).setCommitLogReadAheadMode(anyString(), anyString());
+        var result = service.apply(request(true, false));
+        assertThat(result.status()).isEqualTo("UNKNOWN");
+        assertThat(result.acknowledged()).isFalse();
+        assertThat(result.observed()).isNull();
+        verify(admin).setCommitLogReadAheadMode("master:10911", "1");
+    }
+
+    @Test
+    void anAcknowledgementWithoutAChangedConfigurationIsNotConfirmed() throws Exception {
+        doReturn("accepted").when(admin).setCommitLogReadAheadMode(anyString(), anyString());
+        var result = service.apply(request(true, false));
+        assertThat(result.status()).isEqualTo("UNKNOWN");
+        assertThat(result.acknowledged()).isTrue();
+        assertThat(result.observed().enabled()).isTrue();
+    }
+
+    @Test
+    void failedReadbackRetainsAcknowledgementAndAuditFailureDoesNotChangeReceipt() throws Exception {
+        when(admin.getBrokerConfig("master:10911")).thenReturn(config)
+                .thenThrow(new MQBrokerException(ResponseCode.NO_PERMISSION, "denied"));
+        doThrow(new IllegalStateException("audit unavailable")).when(audits).insert(any(RmqOperationAudit.class));
+        var result = service.apply(request(true, false));
+        assertThat(result.status()).isEqualTo("UNKNOWN");
+        assertThat(result.acknowledged()).isTrue();
+        assertThat(result.observed()).isNull();
+    }
+
+    @Test
+    void missingAndUnknownValuesAreNotAssumedDisabled() throws Exception {
+        config.remove("dataReadAheadEnable");
+        assertThatThrownBy(this::inspect).hasMessageContaining("supported dataReadAheadEnable");
+        config.setProperty("dataReadAheadEnable", "unsupported");
+        assertThatThrownBy(this::inspect).hasMessageContaining("supported dataReadAheadEnable");
+        when(admin.getBrokerConfig(anyString())).thenReturn(null);
+        assertThatThrownBy(this::inspect).hasMessageContaining("supported dataReadAheadEnable");
+    }
+
+    @Test
+    void requiredFieldsAndRegistryFailuresBlockBeforeWriting() throws Exception {
+        assertThatThrownBy(() -> service.inspect("instance-a", "", "master:10911")).hasMessageContaining("required");
+        assertThatThrownBy(() -> service.apply(new BrokerReadAheadService.Request(
+                "instance-a", "broker-a", "master:10911", null, true))).hasMessageContaining("reviewed");
+        when(admin.examineBrokerClusterInfo()).thenReturn(null);
+        assertThatThrownBy(this::inspect).hasMessageContaining("registry is unavailable");
+        verify(admin, never()).setCommitLogReadAheadMode(anyString(), anyString());
+    }
+
+    @Test
+    void previewAndPreflightInterruptionsRestoreFlagWithoutWriting() throws Exception {
+        doThrow(new InterruptedException()).when(admin).examineBrokerClusterInfo();
+        try {
+            assertThatThrownBy(this::inspect).hasMessageContaining("inspection was interrupted");
+            assertThat(Thread.interrupted()).isTrue();
+            assertThatThrownBy(() -> service.apply(request(true, false))).hasMessageContaining("preflight was interrupted");
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+            verify(admin, never()).setCommitLogReadAheadMode(anyString(), anyString());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void interruptedWriteReturnsUncertaintyAndPreservesInterruptFlag() throws Exception {
+        doThrow(new InterruptedException()).when(admin).setCommitLogReadAheadMode(anyString(), anyString());
+        try {
+            assertThat(service.apply(request(true, false)).status()).isEqualTo("UNKNOWN");
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void controllerReadsAndWritesWithoutReturningUnrelatedConfiguration() throws Exception {
+        var mvc = MockMvcBuilders.standaloneSetup(new BrokerReadAheadController(service)).build();
+        var response = mvc.perform(get("/api/brokers/read-ahead").param("instanceId", "instance-a")
+                        .param("brokerName", "broker-a").param("address", "master:10911"))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.data.enabled").value(true))
+                .andReturn().getResponse().getContentAsString();
+        assertThat(response).doesNotContain("secretKey", "not-in-response");
+        mvc.perform(post("/api/brokers/read-ahead").contentType("application/json")
+                        .content(new ObjectMapper().writeValueAsString(request(true, false))))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.data.status").value("CONFIG_CONFIRMED"));
+    }
+}

--- a/web/src/api/brokerReadAhead.test.ts
+++ b/web/src/api/brokerReadAhead.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, describe, expect, it } from 'vitest';
+import client from './client';
+import { inspectBrokerReadAhead, updateBrokerReadAhead } from './brokerReadAhead';
+const mock = new MockAdapter(client);
+const target = { instanceId: 'instance-a', brokerName: 'broker-a', address: 'master:10911' };
+afterEach(() => mock.reset());
+describe('Read-ahead API', () => {
+  it('binds inspection to the selected instance and exact broker node', async () => {
+    mock.onGet('/brokers/read-ahead').reply((config) => {
+      expect(config.params).toEqual(target);
+      return [200, { code: 0, data: { enabled: true } }];
+    });
+    expect((await inspectBrokerReadAhead(target)).enabled).toBe(true);
+    expect(mock.history.post).toHaveLength(0);
+  });
+  it('posts reviewed and desired booleans and preserves uncertain outcomes', async () => {
+    const signal = new AbortController().signal;
+    mock.onPost('/brokers/read-ahead').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({ ...target, expectedEnabled: true, enabled: false });
+      expect(config.signal).toBe(signal);
+      return [200, { code: 0, data: { status: 'UNKNOWN', acknowledged: true, observed: null } }];
+    });
+    expect((await updateBrokerReadAhead(target, true, false, signal)).status).toBe('UNKNOWN');
+  });
+});

--- a/web/src/api/brokerReadAhead.ts
+++ b/web/src/api/brokerReadAhead.ts
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import client from './client';
+
+export interface ReadAheadTarget {
+  instanceId: string;
+  brokerName: string;
+  address: string;
+}
+export interface ReadAheadSnapshot {
+  brokerName: string;
+  address: string;
+  enabled: boolean;
+  sampledAt: string;
+}
+export interface ReadAheadReceipt {
+  status: 'UNCHANGED' | 'CONFIG_CONFIRMED' | 'UNKNOWN';
+  acknowledged: boolean;
+  before: ReadAheadSnapshot;
+  observed: ReadAheadSnapshot | null;
+}
+export async function inspectBrokerReadAhead(params: ReadAheadTarget, signal?: AbortSignal) {
+  const response = await client.get<{ data: ReadAheadSnapshot }>('/brokers/read-ahead', {
+    params,
+    signal,
+  });
+  return response.data.data;
+}
+export async function updateBrokerReadAhead(
+  target: ReadAheadTarget,
+  expectedEnabled: boolean,
+  enabled: boolean,
+  signal?: AbortSignal,
+) {
+  const response = await client.post<{ data: ReadAheadReceipt }>(
+    '/brokers/read-ahead',
+    { ...target, expectedEnabled, enabled },
+    { signal, timeout: 0 },
+  );
+  return response.data.data;
+}

--- a/web/src/components/BrokerReadAheadDialog.tsx
+++ b/web/src/components/BrokerReadAheadDialog.tsx
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { Alert, Button, Checkbox, Descriptions, Modal, Radio, Space, Tag, Typography } from 'antd';
+import {
+  inspectBrokerReadAhead,
+  updateBrokerReadAhead,
+  type ReadAheadTarget,
+  type ReadAheadSnapshot,
+  type ReadAheadReceipt,
+} from '../api/brokerReadAhead';
+
+export function BrokerReadAheadDialog({
+  target,
+  onClose,
+}: {
+  target: ReadAheadTarget;
+  onClose: () => void;
+}) {
+  const [snapshot, setSnapshot] = useState<ReadAheadSnapshot>();
+  const [receipt, setReceipt] = useState<ReadAheadReceipt>();
+  const [enabled, setEnabled] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const active = useRef(true);
+  const locked = useRef(false);
+  const request = useRef<AbortController>();
+  useEffect(() => {
+    active.current = true;
+    return () => {
+      active.current = false;
+      request.current?.abort();
+    };
+  }, []);
+  const run = async (apply: boolean) => {
+    if (locked.current || (apply && (!snapshot || !confirmed))) return;
+    locked.current = true;
+    setBusy(true);
+    setError('');
+    const controller = new AbortController();
+    request.current = controller;
+    try {
+      if (apply && snapshot) {
+        setSnapshot(undefined);
+        setConfirmed(false);
+        const result = await updateBrokerReadAhead(
+          target,
+          snapshot.enabled,
+          enabled,
+          controller.signal,
+        );
+        if (active.current) setReceipt(result);
+      } else {
+        setSnapshot(undefined);
+        setReceipt(undefined);
+        setConfirmed(false);
+        const result = await inspectBrokerReadAhead(target, controller.signal);
+        if (active.current) {
+          setSnapshot(result);
+          setEnabled(result.enabled);
+        }
+      }
+    } catch (failure) {
+      if (active.current)
+        setError(
+          apply
+            ? 'Update was not confirmed. Inspect current configuration and broker logs before retrying.'
+            : failure instanceof Error
+              ? failure.message
+              : 'Read-ahead inspection failed',
+        );
+    } finally {
+      locked.current = false;
+      if (active.current) setBusy(false);
+    }
+  };
+  return (
+    <Modal
+      open
+      title="CommitLog read-ahead"
+      width={780}
+      style={{ top: 24 }}
+      closable={!busy}
+      maskClosable={!busy}
+      onCancel={() => {
+        if (!locked.current) onClose();
+      }}
+      footer={
+        <Space>
+          <Button disabled={busy} onClick={onClose}>
+            Close
+          </Button>
+          <Button loading={busy} onClick={() => void run(false)}>
+            Inspect current mode
+          </Button>
+          <Button
+            type="primary"
+            danger
+            loading={busy}
+            disabled={!snapshot || !confirmed || snapshot.enabled === enabled}
+            onClick={() => void run(true)}
+          >
+            Apply runtime mode
+          </Button>
+        </Space>
+      }
+    >
+      <Space
+        direction="vertical"
+        size={16}
+        style={{ width: '100%', maxHeight: 'calc(100vh - 210px)', overflow: 'auto' }}
+      >
+        <Alert
+          type="warning"
+          showIcon
+          message="This changes read-ahead advice for one broker's mapped CommitLog files."
+          description="Evaluate disk I/O and cache behavior in a maintenance window. Broker acknowledgement and configuration readback do not prove that every OS advice call succeeded; Windows skips the file scan."
+        />
+        <Descriptions
+          size="small"
+          column={1}
+          items={[
+            { key: 'broker', label: 'Broker', children: target.brokerName },
+            {
+              key: 'address',
+              label: 'Registered node',
+              children: <Typography.Text code>{target.address}</Typography.Text>,
+            },
+            {
+              key: 'before',
+              label: 'Reviewed configuration',
+              children:
+                (snapshot ?? receipt?.before)
+                  ? (snapshot ?? receipt?.before)?.enabled
+                    ? 'Normal read-ahead'
+                    : 'Random access advice'
+                  : 'Not read',
+            },
+          ]}
+        />
+        {error && <Alert type="error" showIcon message={error} />}
+        {snapshot && (
+          <>
+            <Radio.Group
+              value={enabled}
+              disabled={busy}
+              onChange={(event) => {
+                setEnabled(event.target.value);
+                setConfirmed(false);
+              }}
+            >
+              <Radio value={true}>Normal read-ahead</Radio>
+              <Radio value={false}>Random access advice</Radio>
+            </Radio.Group>
+            <Checkbox
+              checked={confirmed}
+              disabled={busy}
+              onChange={(event) => setConfirmed(event.target.checked)}
+            >
+              I reviewed this node and planned I/O observation and recovery.
+            </Checkbox>
+          </>
+        )}
+        {receipt && (
+          <Descriptions
+            size="small"
+            column={1}
+            items={[
+              { key: 'status', label: 'Result', children: <Tag>{receipt.status}</Tag> },
+              {
+                key: 'ack',
+                label: 'Broker acknowledgement',
+                children: receipt.acknowledged ? 'Received' : 'Not received or no write needed',
+              },
+              {
+                key: 'after',
+                label: 'Configuration readback',
+                children: receipt.observed
+                  ? receipt.observed.enabled
+                    ? 'Normal read-ahead'
+                    : 'Random access advice'
+                  : 'Unavailable',
+              },
+            ]}
+          />
+        )}
+        {receipt?.status === 'UNKNOWN' && (
+          <Alert
+            type="warning"
+            showIcon
+            message="The result is uncertain. Inspect configuration and broker logs before recovery."
+          />
+        )}
+        <Typography.Paragraph type="secondary" style={{ margin: 0 }}>
+          The native command changes runtime state and does not explicitly persist broker
+          configuration. To restore it, inspect again and apply the recorded previous mode. Check
+          deployment configuration separately for restart behavior.
+        </Typography.Paragraph>
+      </Space>
+    </Modal>
+  );
+}

--- a/web/src/components/__tests__/BrokerReadAheadDialog.test.tsx
+++ b/web/src/components/__tests__/BrokerReadAheadDialog.test.tsx
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { ConfigProvider } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BrokerReadAheadDialog } from '../BrokerReadAheadDialog';
+import {
+  inspectBrokerReadAhead,
+  updateBrokerReadAhead,
+  type ReadAheadSnapshot,
+} from '../../api/brokerReadAhead';
+
+vi.mock('../../api/brokerReadAhead', () => ({
+  inspectBrokerReadAhead: vi.fn(),
+  updateBrokerReadAhead: vi.fn(),
+}));
+const target = { instanceId: 'instance-a', brokerName: 'broker-a', address: 'master:10911' };
+const before: ReadAheadSnapshot = {
+  brokerName: target.brokerName,
+  address: target.address,
+  enabled: true,
+  sampledAt: '2026-09-08T00:00:00Z',
+};
+const open = (onClose = vi.fn()) =>
+  render(
+    <ConfigProvider theme={{ token: { motion: false } }}>
+      <BrokerReadAheadDialog target={target} onClose={onClose} />
+    </ConfigProvider>,
+  );
+const inspect = async () => {
+  fireEvent.click(screen.getByRole('button', { name: /Inspect current mode/ }));
+  await screen.findByRole('radio', { name: 'Random access advice' });
+};
+const choose = () => {
+  fireEvent.click(screen.getByRole('radio', { name: 'Random access advice' }));
+  fireEvent.click(screen.getByRole('checkbox'));
+};
+const apply = () => fireEvent.click(screen.getByRole('button', { name: /Apply runtime mode/ }));
+
+describe('Broker read-ahead', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: false,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+    vi.mocked(inspectBrokerReadAhead).mockResolvedValue(before);
+    vi.mocked(updateBrokerReadAhead).mockResolvedValue({
+      status: 'CONFIG_CONFIRMED',
+      acknowledged: true,
+      before,
+      observed: { ...before, enabled: false },
+    });
+  });
+
+  it('requires a changed mode and explicit confirmation after inspection', async () => {
+    open();
+    expect(inspectBrokerReadAhead).not.toHaveBeenCalled();
+    await inspect();
+    expect(screen.getByRole('button', { name: /Apply runtime mode/ })).toBeDisabled();
+    choose();
+    apply();
+    await screen.findByText('CONFIG_CONFIRMED');
+    expect(updateBrokerReadAhead).toHaveBeenCalledWith(
+      target,
+      true,
+      false,
+      expect.any(AbortSignal),
+    );
+    expect(screen.getByText('Received')).toBeInTheDocument();
+    expect(
+      screen.getByText(/do not prove that every OS advice call succeeded/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Apply runtime mode/ })).toBeDisabled();
+  });
+
+  it('changing the requested mode clears confirmation', async () => {
+    open();
+    await inspect();
+    choose();
+    fireEvent.click(screen.getByRole('radio', { name: 'Normal read-ahead' }));
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+    expect(screen.getByRole('button', { name: /Apply runtime mode/ })).toBeDisabled();
+  });
+
+  it('locks the dialog during a write and sends only one request', async () => {
+    let resolve!: (value: Awaited<ReturnType<typeof updateBrokerReadAhead>>) => void;
+    vi.mocked(updateBrokerReadAhead).mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    const close = vi.fn();
+    open(close);
+    await inspect();
+    choose();
+    apply();
+    apply();
+    expect(updateBrokerReadAhead).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(close).not.toHaveBeenCalled();
+    await act(async () =>
+      resolve({
+        status: 'CONFIG_CONFIRMED',
+        acknowledged: true,
+        before,
+        observed: { ...before, enabled: false },
+      }),
+    );
+  });
+
+  it('distinguishes an acknowledged but uncertain readback', async () => {
+    vi.mocked(updateBrokerReadAhead).mockResolvedValue({
+      status: 'UNKNOWN',
+      acknowledged: true,
+      before,
+      observed: null,
+    });
+    open();
+    await inspect();
+    choose();
+    apply();
+    await screen.findByText('UNKNOWN');
+    expect(screen.getByText('Received')).toBeInTheDocument();
+    expect(screen.getByText('Unavailable')).toBeInTheDocument();
+    expect(screen.getByText(/The result is uncertain/)).toBeInTheDocument();
+  });
+
+  it('requires a new inspection after the response is lost', async () => {
+    vi.mocked(updateBrokerReadAhead).mockRejectedValue(new Error('connection lost'));
+    open();
+    await inspect();
+    choose();
+    apply();
+    await screen.findByText(/Update was not confirmed/);
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Apply runtime mode/ })).toBeDisabled();
+  });
+
+  it('aborts on unmount and discards late inspection results', async () => {
+    let resolve!: (value: ReadAheadSnapshot) => void;
+    vi.mocked(inspectBrokerReadAhead).mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    const view = open();
+    fireEvent.click(screen.getByRole('button', { name: /Inspect current mode/ }));
+    const signal = vi.mocked(inspectBrokerReadAhead).mock.calls[0][1];
+    view.unmount();
+    expect(signal?.aborted).toBe(true);
+    await act(async () => resolve(before));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -31,6 +31,8 @@ import type { ClusterInfo } from '../../api/cluster';
 import { supportsApacheRuntime, type Instance } from '../../api/instance';
 import { listInstances } from '../../services/instanceService';
 import { useVisiblePolling } from '../../hooks/useVisiblePolling';
+import { BrokerReadAheadDialog } from '../../components/BrokerReadAheadDialog';
+import type { ReadAheadTarget } from '../../api/brokerReadAhead';
 import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 
 // ─── Types ──────────────────────────────────────────────────────
@@ -190,6 +192,7 @@ const BrokerClusterPage = () => {
   const [proxyData, setProxyData] = useState<ProxyRecord[]>([]);
   const [instances, setInstances] = useState<Instance[]>([]);
   const [selectedInstanceId, setSelectedInstanceId] = useState<string | undefined>(undefined);
+  const [readAheadTarget, setReadAheadTarget] = useState<ReadAheadTarget>();
   const mountedRef = useRef(true);
   const loadRequestId = useRef(0);
   const { t } = useLang();
@@ -325,6 +328,26 @@ const BrokerClusterPage = () => {
     (activeTab === 'broker' && brokerData.length === 0);
 
   const brokerColumns = [
+    {
+      title: 'Disk reads',
+      key: 'read-ahead',
+      render: (_: unknown, row: BrokerRecord) => (
+        <Button
+          size="small"
+          disabled={!selectedInstanceId || isMockMode()}
+          onClick={() => {
+            if (selectedInstanceId)
+              setReadAheadTarget({
+                instanceId: selectedInstanceId,
+                brokerName: row.brokerName,
+                address: row.address,
+              });
+          }}
+        >
+          Read-ahead
+        </Button>
+      ),
+    },
     {
       title: t('brokerCluster.k8sCluster'),
       dataIndex: 'k8sCluster',
@@ -521,7 +544,10 @@ const BrokerClusterPage = () => {
           <Select
             aria-label="选择实例"
             value={selectedInstanceId}
-            onChange={setSelectedInstanceId}
+            onChange={(value) => {
+              setReadAheadTarget(undefined);
+              setSelectedInstanceId(value);
+            }}
             placeholder="选择实例"
             style={{ minWidth: 180 }}
             options={instances.map((instance) => ({ value: instance.name, label: instance.name }))}
@@ -614,6 +640,13 @@ const BrokerClusterPage = () => {
           />
         </Card>
       </Spin>
+      {readAheadTarget && readAheadTarget.instanceId === selectedInstanceId && (
+        <BrokerReadAheadDialog
+          key={readAheadTarget.instanceId + readAheadTarget.address}
+          target={readAheadTarget}
+          onClose={() => setReadAheadTarget(undefined)}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
<!-- Make sure the base branch is `master`: that is the RocketMQ Studio trunk. -->

### Which Issue(s) This PR Fixes

- Fixes #4447
- Replaces #4131, closed by the branch switch in #4379.

### Brief Description

This is a resubmission of #4131 against `master`, following the branch switch notice in #4379. The fork branch is unchanged; `master` is now the RocketMQ Studio trunk.

排查 CommitLog 冷读和页缓存行为时，运维人员需要在明确节点上读取、调整预读建议并保留恢复依据。本 PR 为真实 Apache Broker 增加 Read-ahead 入口，使用原生 setCommitLogReadAheadMode 操作现有映射文件。

## 改动说明

- 读取及提交均绑定所选实例、Broker 名称与已登记地址，不自动换节点。缺失或未知 dataReadAheadEnable 不能当作关闭。
- 先读取旧值，再确认新值；提交前核对旧配置，相同值不重复扫描。Normal 对应 MADV_NORMAL=0，Random 对应 MADV_RANDOM=1。
- 回执分别记录 RPC 确认、原配置和配置回读。仅配置回读一致时显示 CONFIG_CONFIRMED；异常或不一致显示 UNKNOWN，不自动重试。审计失败不覆盖已有结果。
- 中文文档说明维护窗口、I/O 观察、恢复原值与重启配置限制。UI 在提交期间锁定，并在实例切换或关闭后丢弃迟到响应。

确认范围依据官方源码：[AdminBrokerProcessor](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java#L1007) 修改运行时配置；[CommitLog.scanFileAndSetReadMode](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/store/src/main/java/org/apache/rocketmq/store/CommitLog.java#L2513) 在 Windows 跳过扫描，并可能仅记录文件建议失败。因此不把配置确认称为内核调用全部成功，也不承诺性能提升。

### How Did You Test This Change?

## 原提交验证记录

本地后端 63 项、前端 23 项测试通过；新增服务 51/51 行、36/40 分支覆盖。Checkstyle、TypeScript/Vite 构建及后端打包通过；ESLint 0 错误、10 条现有告警。浏览器在同一脚本内明确拦截本地 GET/POST，验证节点、旧值、目标值与 CONFIG_CONFIRMED 回执，无真实 Broker 写入。

全部 Issue/PR 标题正文和在线 read ahead、setCommitLogReadAheadMode、dataReadAheadEnable、预读关键词检索未发现重复。与消费组冷读流控不同，这里调整单节点映射文件的读取建议，接口、界面、权限及故障测试和文档合并交付。

## 兼容性与回滚

无新增依赖或数据库迁移；撤销代码提交可移除接口和入口，运行时模式需重新读取并恢复原值。原生命令没有显式持久化，其他后续配置保存可能写入当前字段，不能把重启当作自动回滚。真实 Linux/Windows 内核效果、性能、压力、容量和故障切换测试未执行。既有全量测试与依赖审计缺口仍记录。提交含 [skip ci]，未运行远端工作流。核验日期：2026-09-08。

### Checklist

- [x] One coherent change; unrelated modifications are not bundled in
- [x] Commit subject follows Conventional Commits (`feat:` / `fix:` / `refactor:` / `chore:` / `docs:` / `perf:`)
- [x] Tests added or updated for non-trivial changes, test methods named `...Test`
- [x] New UI text has both Chinese and English entries under `web/src/i18n/`, or the change does not add UI text
- [x] Architecture constraints stay green (`mvn test` runs the ArchUnit checks), or the original verification scope is stated above
- [x] New source files carry the ASF license header, or no new source files were added
- [x] Documentation touched where behaviour changed (README / `docs/` / in-app help), or no documentation change was required
