### PR TITLE
feat: review and run native broker queue cleanup

### DIFF
--- a/docs/broker-queue-cleanup.md
+++ b/docs/broker-queue-cleanup.md
@@ -1,0 +1,65 @@
+# Broker 队列存储清理
+
+## 适用场景与前提
+
+真实 Apache 实例的 Broker 集群列表提供 `Queue cleanup` 入口，执行原生队列存储维护。
+操作会删除 Broker 判定可清理的存储，不能自动撤销。维护前应具备已验证的存储备份、
+恢复流程和业务窗口，并暂停可能影响 Topic 配置及相关数据范围的并发管理操作。
+
+本功能只操作页面明确显示的一个登记节点，不把操作扩散到整个 Broker 组或集群。
+它没有试运行模式；显示的当前 Topic 配置列表也不是待删除文件或队列的清单。
+原生接口不返回精确候选集合、删除数量或回收字节数。
+
+## 两种操作
+
+| 操作 | 原生依据 |
+| --- | --- |
+| `Remove queues for unconfigured topics` | 依据 Broker 当前 Topic 配置保留集合，清理不再配置的 Topic 队列存储；默认存储实现排除系统 Topic 和 LMQ |
+| `Remove expired ConsumeQueues` | 依据当前 CommitLog 最小物理位点，清理其最后物理位点早于保留起点的队列；默认文件队列实现排除系统 Topic |
+
+过期队列可能仍属于已配置的 Topic；配置列表不是该操作的排除列表。
+操作由实际 Broker 存储实现决定，扩展存储或插件的具体删除行为应先在对应环境验证。
+清理不等同于删除 Broker Topic 配置；也不主动调用手工删除 CommitLog 的命令。
+
+## 执行步骤
+
+1. 选择目标 Broker 节点，打开维护窗口并选择所需操作。
+2. 点击 `Review node scope`，核对 Broker 名称、地址和当前已配置 Topic。
+3. 评估对应存储实现的删除规则，确认备份和恢复方案。
+4. 输入界面显示的完整节点地址，再点击 `Run cleanup`。
+5. 查看回执，检查 Broker 日志、队列存储和业务消费状态。
+
+选择另一种操作会清除旧范围和确认文本，需重新审阅。
+提交前服务端重新检查实例登记信息和 Topic 名称集合；地址不再登记或 Topic 集合变化，
+会阻止执行并要求重新审阅。这不是分布式锁，检查之后仍可能发生并发变化。
+CommitLog 保留起点也可能推进，实际删除范围以 Broker 执行时的状态为准。
+
+## 回执与中断
+
+`BROKER_REPORTED_COMPLETION` 仅表示 SDK 收到 Broker 成功响应。
+不要据此推算删除数量、磁盘释放量或每个文件的删除成功率，应以实际日志与存储检查为准。
+
+调用异常、超时或没有成功确认时，返回 `UNKNOWN`。操作可能已部分完成，
+不能认定没有删除，也不能直接自动重试。本功能保留审计记录并要求人工核实。
+浏览器断网、关闭或切换实例无法停止已经发送到 Broker 的清理。
+审计持久化失败不会覆盖已取得的 Broker 回执。
+
+操作后的数据恢复依赖维护前验证过的备份与 Broker 恢复流程。
+撤销 Dashboard 的代码提交不会恢复已删除数据；重新创建 Topic 也不能替代存储恢复。
+无法接受该恢复条件时，应在实际清理前停止操作。
+
+## 验证与代码回滚
+
+POST 沿用管理员权限拦截，GET 只读取范围。没有增加配置表或依赖。
+本地测试覆盖节点与实例绑定、两种原生命令、确认文本、范围变化、权限、
+超时不确定性、中断标记、审计失败和前端生命周期。
+浏览器验证使用明确的本地 GET/POST 拦截，没有删除真实 Broker 文件。
+真实存储清理、备份恢复演练、压力、容量和网络分区验证未执行。
+
+无数据结构迁移。代码回滚可撤销本提交；实际数据恢复按前述备份方案执行。
+最后核验日期：2026-09-08。
+
+协议依据为 RocketMQ 5.5.0 的
+[AdminBrokerProcessor](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java#L2350)、
+[DefaultMessageStore.cleanUnusedTopic](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java#L1608)
+与 [ConsumeQueueStore.cleanExpired](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java#L558)。

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerQueueCleanupController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerQueueCleanupController.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.Result;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/brokers/queue-cleanup")
+public class BrokerQueueCleanupController {
+    private final BrokerQueueCleanupService service;
+
+    @GetMapping
+    public Result<BrokerQueueCleanupService.Preview> preview(@RequestParam String instanceId,
+            @RequestParam String brokerName, @RequestParam String address) {
+        return Result.ok(service.preview(instanceId, brokerName, address));
+    }
+
+    @PostMapping
+    public Result<BrokerQueueCleanupService.Receipt> apply(@RequestBody BrokerQueueCleanupService.Request request) {
+        return Result.ok(service.apply(request));
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerQueueCleanupService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerQueueCleanupService.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class BrokerQueueCleanupService {
+    private final RuntimeAdminClientResolver resolver;
+    private final OperationAuditService audit;
+
+    public enum Operation { UNUSED_TOPIC_QUEUES, EXPIRED_CONSUME_QUEUES }
+    public record Preview(String brokerName, String address, Instant sampledAt, List<String> configuredTopics) { }
+    public record Request(String instanceId, String brokerName, String address, Operation operation,
+            List<String> expectedConfiguredTopics, String confirmation) { }
+    public record Receipt(Operation operation, String brokerName, String address, String status, Instant finishedAt) { }
+
+    public Preview preview(String instanceId, String brokerName, String address) {
+        validate(brokerName, address);
+        return resolver.execute(instanceId, admin -> {
+            try {
+                return inspect(admin, brokerName, address);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new BusinessException(502, "Queue cleanup preview was interrupted");
+            }
+        });
+    }
+
+    public Receipt apply(Request request) {
+        validate(request.brokerName(), request.address());
+        if (request.operation() == null || request.expectedConfiguredTopics() == null
+                || !request.address().equals(request.confirmation())) {
+            throw new BusinessException(400, "Review the node, select an operation and confirm its address");
+        }
+        return resolver.execute(request.instanceId(), admin -> {
+            Preview current;
+            try {
+                current = inspect(admin, request.brokerName(), request.address());
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new BusinessException(502, "Queue cleanup preflight was interrupted");
+            }
+            if (!current.configuredTopics().equals(request.expectedConfiguredTopics())) {
+                throw new BusinessException(409, "Configured topics changed; review cleanup scope again");
+            }
+            boolean acknowledged = false;
+            try {
+                acknowledged = switch (request.operation()) {
+                    case UNUSED_TOPIC_QUEUES -> admin.cleanUnusedTopicByAddr(request.address());
+                    case EXPIRED_CONSUME_QUEUES -> admin.cleanExpiredConsumerQueueByAddr(request.address());
+                };
+            } catch (Exception exception) {
+                // Cleanup may have removed some files before a response is lost. Never retry here.
+                if (exception instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            String result = acknowledged ? "BROKER_REPORTED_COMPLETION" : "UNKNOWN";
+            audit.record("CLEAN_BROKER_QUEUES", "BROKER", request.brokerName(), request.instanceId(),
+                    "address=" + request.address() + ", operation=" + request.operation()
+                            + ", configuredTopicCount=" + current.configuredTopics().size(),
+                    result, acknowledged ? null : "Check broker logs and storage before another cleanup");
+            return new Receipt(request.operation(), request.brokerName(), request.address(), result, Instant.now());
+        });
+    }
+
+    private Preview inspect(MQAdminExt admin, String brokerName, String address) throws Exception {
+        var cluster = admin.examineBrokerClusterInfo();
+        if (cluster == null || cluster.getBrokerAddrTable() == null) {
+            throw new BusinessException(502, "Broker registry is unavailable");
+        }
+        var broker = cluster.getBrokerAddrTable().get(brokerName);
+        if (broker == null || broker.getBrokerAddrs() == null || !broker.getBrokerAddrs().containsValue(address)) {
+            throw new BusinessException(404, "Broker address is not registered in the selected instance");
+        }
+        var topics = admin.getAllTopicConfig(address, 5000);
+        if (topics == null || topics.getTopicConfigTable() == null) {
+            throw new BusinessException(502, "Configured topics are unavailable; cleanup cannot be reviewed");
+        }
+        List<String> names = topics.getTopicConfigTable().keySet().stream().sorted().toList();
+        return new Preview(brokerName, address, Instant.now(), names);
+    }
+
+    private void validate(String brokerName, String address) {
+        if (!StringUtils.hasText(brokerName) || !StringUtils.hasText(address)) {
+            throw new BusinessException(400, "Broker name and registered address are required");
+        }
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
@@ -366,6 +366,24 @@ class AuthInterceptorTest {
     }
 
     @Test
+    void shouldRejectQueueCleanupForNonAdmin() throws Exception {
+        TestSession session = login(false);
+        var response = new MockHttpServletResponse();
+        boolean allowed = session.interceptor().preHandle(authenticatedRequest(
+                "POST", "/api/brokers/queue-cleanup", session.token()), response, new Object());
+        assertThat(allowed).isFalse();
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void shouldAllowQueueCleanupForAdmin() throws Exception {
+        TestSession session = login(true);
+        boolean allowed = session.interceptor().preHandle(authenticatedRequest(
+                "POST", "/api/brokers/queue-cleanup", session.token()), new MockHttpServletResponse(), new Object());
+        assertThat(allowed).isTrue();
+    }
+
+    @Test
     void shouldRejectMutatingPostForNonAdminUser() throws Exception {
         TestSession session = login(false);
         MockHttpServletRequest request = authenticatedRequest(

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/BrokerQueueCleanupServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/BrokerQueueCleanupServiceTest.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.rocketmq.common.TopicConfig;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.body.TopicConfigSerializeWrapper;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.studio.persistence.entity.RmqOperationAudit;
+import org.apache.rocketmq.studio.persistence.mapper.RmqOperationAuditMapper;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.apache.rocketmq.studio.cluster.broker.BrokerQueueCleanupService.Operation;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class BrokerQueueCleanupServiceTest {
+    private final DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+    private final InstanceRepository repository = mock(InstanceRepository.class);
+    private final RmqOperationAuditMapper audits = mock(RmqOperationAuditMapper.class);
+    private final ClusterInfo cluster = new ClusterInfo();
+    private final TopicConfigSerializeWrapper topics = new TopicConfigSerializeWrapper();
+    private BrokerQueueCleanupService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        var factory = new MqAdminExtFactory() {
+            @Override
+            protected DefaultMQAdminExt newAdmin(RPCHook hook) { return admin; }
+        };
+        service = new BrokerQueueCleanupService(new RuntimeAdminClientResolver(repository, factory,
+                new MqAdminProperties(), mock(MqClientPool.class)), new OperationAuditService(audits));
+        when(repository.findByIdentifier("instance-a")).thenReturn(Optional.of(
+                InstanceVO.builder().endpoint("ns-a:9876").vendor(InstanceVendor.APACHE).build()));
+        cluster.setBrokerAddrTable(new HashMap<>());
+        cluster.getBrokerAddrTable().put("broker-a", new BrokerData("cluster-a", "broker-a",
+                new HashMap<>(Map.of(0L, "master:10911", 1L, "replica:10911"))));
+        when(admin.examineBrokerClusterInfo()).thenReturn(cluster);
+        topics.getTopicConfigTable().put("orders", new TopicConfig("orders"));
+        topics.getTopicConfigTable().put("payments", new TopicConfig("payments"));
+        when(admin.getAllTopicConfig("master:10911", 5000)).thenReturn(topics);
+        when(admin.cleanUnusedTopicByAddr("master:10911")).thenReturn(true);
+        when(admin.cleanExpiredConsumerQueueByAddr("master:10911")).thenReturn(true);
+    }
+
+    private BrokerQueueCleanupService.Preview preview() {
+        return service.preview("instance-a", "broker-a", "master:10911");
+    }
+    private BrokerQueueCleanupService.Request request(Operation operation) {
+        return new BrokerQueueCleanupService.Request("instance-a", "broker-a", "master:10911", operation,
+                preview().configuredTopics(), "master:10911");
+    }
+
+    @Test
+    void previewListsConfiguredTopicsWithoutCallingEitherCleanup() throws Exception {
+        assertThat(preview().configuredTopics()).containsExactly("orders", "payments");
+        verify(admin, never()).cleanUnusedTopicByAddr(anyString());
+        verify(admin, never()).cleanExpiredConsumerQueueByAddr(anyString());
+    }
+
+    @Test
+    void unusedCleanupTargetsOnlyTheReviewedNodeAndRecordsBrokerCompletion() throws Exception {
+        var result = service.apply(request(Operation.UNUSED_TOPIC_QUEUES));
+        assertThat(result.status()).isEqualTo("BROKER_REPORTED_COMPLETION");
+        assertThat(result.address()).isEqualTo("master:10911");
+        assertThat(result.operation()).isEqualTo(Operation.UNUSED_TOPIC_QUEUES);
+        verify(admin).cleanUnusedTopicByAddr("master:10911");
+        verify(admin, never()).cleanExpiredConsumerQueueByAddr(anyString());
+        verify(audits).insert(any(RmqOperationAudit.class));
+    }
+
+    @Test
+    void expiredCleanupUsesTheSeparateNativeCommand() throws Exception {
+        assertThat(service.apply(request(Operation.EXPIRED_CONSUME_QUEUES)).status()).isEqualTo("BROKER_REPORTED_COMPLETION");
+        verify(admin).cleanExpiredConsumerQueueByAddr("master:10911");
+        verify(admin, never()).cleanUnusedTopicByAddr(anyString());
+    }
+
+    @Test
+    void changedConfiguredTopicsRequireAWholeNewReview() throws Exception {
+        var request = request(Operation.UNUSED_TOPIC_QUEUES);
+        topics.getTopicConfigTable().remove("payments");
+        assertThatThrownBy(() -> service.apply(request)).hasMessageContaining("Configured topics changed");
+        verify(admin, never()).cleanUnusedTopicByAddr(anyString());
+    }
+
+    @Test
+    void wrongConfirmationOrMissingOperationCannotExecuteCleanup() throws Exception {
+        assertThatThrownBy(() -> service.apply(new BrokerQueueCleanupService.Request("instance-a", "broker-a",
+                "master:10911", Operation.UNUSED_TOPIC_QUEUES, List.of("orders"), "other:10911")))
+                .hasMessageContaining("confirm its address");
+        assertThatThrownBy(() -> service.apply(new BrokerQueueCleanupService.Request("instance-a", "broker-a",
+                "master:10911", null, List.of("orders"), "master:10911")))
+                .hasMessageContaining("select an operation");
+        assertThatThrownBy(() -> service.apply(new BrokerQueueCleanupService.Request("instance-a", "broker-a",
+                "master:10911", Operation.UNUSED_TOPIC_QUEUES, null, "master:10911")))
+                .hasMessageContaining("Review the node");
+        verify(admin, never()).cleanUnusedTopicByAddr(anyString());
+    }
+
+    @Test
+    void removedOrMismatchedBrokerAddressCannotBeRetargeted() throws Exception {
+        var request = request(Operation.EXPIRED_CONSUME_QUEUES);
+        cluster.getBrokerAddrTable().get("broker-a").getBrokerAddrs().remove(0L);
+        assertThatThrownBy(() -> service.apply(request)).hasMessageContaining("not registered");
+        assertThatThrownBy(() -> service.preview("instance-a", "other-broker", "replica:10911"))
+                .hasMessageContaining("not registered");
+        verify(admin, never()).cleanExpiredConsumerQueueByAddr(anyString());
+    }
+
+    @Test
+    void missingTopicMetadataIsNotAnEmptySafeRetentionSet() throws Exception {
+        when(admin.getAllTopicConfig("master:10911", 5000)).thenReturn(null);
+        assertThatThrownBy(this::preview).hasMessageContaining("cleanup cannot be reviewed");
+        when(admin.examineBrokerClusterInfo()).thenReturn(null);
+        assertThatThrownBy(this::preview).hasMessageContaining("registry is unavailable");
+        assertThatThrownBy(() -> service.preview("instance-a", "", "master:10911"))
+                .hasMessageContaining("required");
+    }
+
+    @Test
+    void timeoutAndNegativeAcknowledgementAreUncertainWithoutAutomaticRetry() throws Exception {
+        doThrow(new org.apache.rocketmq.remoting.exception.RemotingTimeoutException("master:10911", 5000))
+                .when(admin).cleanUnusedTopicByAddr("master:10911");
+        assertThat(service.apply(request(Operation.UNUSED_TOPIC_QUEUES)).status()).isEqualTo("UNKNOWN");
+        verify(admin).cleanUnusedTopicByAddr("master:10911");
+        when(admin.cleanExpiredConsumerQueueByAddr("master:10911")).thenReturn(false);
+        assertThat(service.apply(request(Operation.EXPIRED_CONSUME_QUEUES)).status()).isEqualTo("UNKNOWN");
+    }
+
+    @Test
+    void auditFailureCannotChangeACompletedCleanupReceipt() {
+        doThrow(new IllegalStateException("audit unavailable")).when(audits).insert(any(RmqOperationAudit.class));
+        assertThat(service.apply(request(Operation.UNUSED_TOPIC_QUEUES)).status()).isEqualTo("BROKER_REPORTED_COMPLETION");
+    }
+
+    @Test
+    void previewAndPreflightInterruptionsRestoreFlagAndDoNotDelete() throws Exception {
+        var request = request(Operation.UNUSED_TOPIC_QUEUES);
+        doThrow(new InterruptedException()).when(admin).examineBrokerClusterInfo();
+        try {
+            assertThatThrownBy(this::preview).hasMessageContaining("preview was interrupted");
+            assertThat(Thread.interrupted()).isTrue();
+            assertThatThrownBy(() -> service.apply(request)).hasMessageContaining("preflight was interrupted");
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+            verify(admin, never()).cleanUnusedTopicByAddr(anyString());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void interruptedCleanupPreservesTheUnknownResultAndThreadFlag() throws Exception {
+        doThrow(new InterruptedException()).when(admin).cleanUnusedTopicByAddr(anyString());
+        try {
+            assertThat(service.apply(request(Operation.UNUSED_TOPIC_QUEUES)).status()).isEqualTo("UNKNOWN");
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void controllerExposesReadOnlyScopeAndExplicitCleanupCommand() throws Exception {
+        var mvc = MockMvcBuilders.standaloneSetup(new BrokerQueueCleanupController(service)).build();
+        mvc.perform(get("/api/brokers/queue-cleanup").param("instanceId", "instance-a")
+                        .param("brokerName", "broker-a").param("address", "master:10911"))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.data.configuredTopics[0]").value("orders"));
+        mvc.perform(post("/api/brokers/queue-cleanup").contentType("application/json")
+                        .content(new ObjectMapper().writeValueAsString(request(Operation.EXPIRED_CONSUME_QUEUES))))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.data.status").value("BROKER_REPORTED_COMPLETION"));
+    }
+}

--- a/web/src/api/brokerQueueCleanup.test.ts
+++ b/web/src/api/brokerQueueCleanup.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, describe, expect, it } from 'vitest';
+import client from './client';
+import { applyBrokerQueueCleanup, previewBrokerQueueCleanup } from './brokerQueueCleanup';
+const mock = new MockAdapter(client);
+const target = { instanceId: 'instance-a', brokerName: 'broker-a', address: 'master:10911' };
+afterEach(() => mock.reset());
+describe('Queue cleanup API', () => {
+  it('reads a configured-topic snapshot without invoking deletion', async () => {
+    mock.onGet('/brokers/queue-cleanup').reply((config) => {
+      expect(config.params).toEqual(target);
+      return [200, { code: 0, data: { configuredTopics: ['orders'] } }];
+    });
+    expect((await previewBrokerQueueCleanup(target)).configuredTopics).toEqual(['orders']);
+    expect(mock.history.post).toHaveLength(0);
+  });
+  it('sends exact operation scope, retained-topic snapshot and typed confirmation', async () => {
+    const signal = new AbortController().signal;
+    mock.onPost('/brokers/queue-cleanup').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({
+        ...target,
+        operation: 'EXPIRED_CONSUME_QUEUES',
+        expectedConfiguredTopics: ['orders'],
+        confirmation: target.address,
+      });
+      expect(config.signal).toBe(signal);
+      return [200, { code: 0, data: { status: 'UNKNOWN' } }];
+    });
+    expect(
+      (
+        await applyBrokerQueueCleanup(
+          target,
+          'EXPIRED_CONSUME_QUEUES',
+          ['orders'],
+          target.address,
+          signal,
+        )
+      ).status,
+    ).toBe('UNKNOWN');
+    expect(mock.history.post).toHaveLength(1);
+  });
+});

--- a/web/src/api/brokerQueueCleanup.ts
+++ b/web/src/api/brokerQueueCleanup.ts
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import client from './client';
+export type QueueCleanupOperation = 'UNUSED_TOPIC_QUEUES' | 'EXPIRED_CONSUME_QUEUES';
+export interface QueueCleanupTarget {
+  instanceId: string;
+  brokerName: string;
+  address: string;
+}
+export interface QueueCleanupPreview {
+  brokerName: string;
+  address: string;
+  sampledAt: string;
+  configuredTopics: string[];
+}
+export interface QueueCleanupReceipt {
+  operation: QueueCleanupOperation;
+  brokerName: string;
+  address: string;
+  status: 'BROKER_REPORTED_COMPLETION' | 'UNKNOWN';
+  finishedAt: string;
+}
+export async function previewBrokerQueueCleanup(params: QueueCleanupTarget, signal?: AbortSignal) {
+  const response = await client.get<{ data: QueueCleanupPreview }>('/brokers/queue-cleanup', {
+    params,
+    signal,
+  });
+  return response.data.data;
+}
+export async function applyBrokerQueueCleanup(
+  target: QueueCleanupTarget,
+  operation: QueueCleanupOperation,
+  expectedConfiguredTopics: string[],
+  confirmation: string,
+  signal?: AbortSignal,
+) {
+  const response = await client.post<{ data: QueueCleanupReceipt }>(
+    '/brokers/queue-cleanup',
+    { ...target, operation, expectedConfiguredTopics, confirmation },
+    { signal, timeout: 0 },
+  );
+  return response.data.data;
+}

--- a/web/src/components/BrokerQueueCleanupDialog.tsx
+++ b/web/src/components/BrokerQueueCleanupDialog.tsx
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { Alert, Button, Input, Modal, Radio, Space, Tag, Typography } from 'antd';
+import {
+  applyBrokerQueueCleanup,
+  previewBrokerQueueCleanup,
+  type QueueCleanupOperation,
+  type QueueCleanupPreview,
+  type QueueCleanupReceipt,
+  type QueueCleanupTarget,
+} from '../api/brokerQueueCleanup';
+
+export function BrokerQueueCleanupDialog({
+  target,
+  onClose,
+}: {
+  target: QueueCleanupTarget;
+  onClose: () => void;
+}) {
+  const [operation, setOperation] = useState<QueueCleanupOperation>('UNUSED_TOPIC_QUEUES');
+  const [preview, setPreview] = useState<QueueCleanupPreview>();
+  const [receipt, setReceipt] = useState<QueueCleanupReceipt>();
+  const [confirmation, setConfirmation] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const active = useRef(true);
+  const locked = useRef(false);
+  const request = useRef<AbortController>();
+  useEffect(() => {
+    active.current = true;
+    return () => {
+      active.current = false;
+      request.current?.abort();
+    };
+  }, []);
+  const run = async (apply: boolean) => {
+    if (locked.current || (apply && (!preview || confirmation !== target.address))) return;
+    locked.current = true;
+    setBusy(true);
+    setError('');
+    const controller = new AbortController();
+    request.current = controller;
+    try {
+      if (apply && preview) {
+        setPreview(undefined);
+        setConfirmation('');
+        const result = await applyBrokerQueueCleanup(
+          target,
+          operation,
+          preview.configuredTopics,
+          confirmation,
+          controller.signal,
+        );
+        if (active.current) setReceipt(result);
+      } else {
+        setPreview(undefined);
+        setReceipt(undefined);
+        setConfirmation('');
+        const result = await previewBrokerQueueCleanup(target, controller.signal);
+        if (active.current) setPreview(result);
+      }
+    } catch (failure) {
+      if (active.current)
+        setError(
+          apply
+            ? 'Cleanup was not confirmed. Check broker logs and storage; some files may already have been removed.'
+            : failure instanceof Error
+              ? failure.message
+              : 'Cleanup scope could not be read',
+        );
+    } finally {
+      locked.current = false;
+      if (active.current) setBusy(false);
+    }
+  };
+  return (
+    <Modal
+      open
+      title="Broker queue cleanup"
+      width={800}
+      style={{ top: 24 }}
+      closable={!busy}
+      maskClosable={!busy}
+      onCancel={() => {
+        if (!locked.current) onClose();
+      }}
+      footer={
+        <Space>
+          <Button disabled={busy} onClick={onClose}>
+            Close
+          </Button>
+          <Button loading={busy} onClick={() => void run(false)}>
+            Review node scope
+          </Button>
+          <Button
+            danger
+            type="primary"
+            loading={busy}
+            disabled={!preview || confirmation !== target.address}
+            onClick={() => void run(true)}
+          >
+            Run cleanup
+          </Button>
+        </Space>
+      }
+    >
+      <Space
+        direction="vertical"
+        size={16}
+        style={{ width: '100%', maxHeight: 'calc(100vh - 210px)', overflow: 'auto' }}
+      >
+        <Alert
+          type="warning"
+          showIcon
+          message="This permanently removes broker-selected queue storage. There is no automatic undo."
+          description="Use a maintenance window with verified backups and recovery procedures. The native API has no dry run or deleted-file inventory. Reviewing configured topics is not a list of deletion candidates."
+        />
+        <Typography.Text>
+          Broker: <strong>{target.brokerName}</strong> · Node:{' '}
+          <Typography.Text code>{target.address}</Typography.Text>
+        </Typography.Text>
+        <Radio.Group
+          value={operation}
+          disabled={busy}
+          onChange={(event) => {
+            setOperation(event.target.value);
+            setPreview(undefined);
+            setReceipt(undefined);
+            setConfirmation('');
+            setError('');
+          }}
+        >
+          <Space direction="vertical">
+            <Radio value="UNUSED_TOPIC_QUEUES">Remove queues for unconfigured topics</Radio>
+            <Radio value="EXPIRED_CONSUME_QUEUES">Remove expired ConsumeQueues</Radio>
+          </Space>
+        </Radio.Group>
+        <Typography.Paragraph style={{ margin: 0 }}>
+          {operation === 'UNUSED_TOPIC_QUEUES'
+            ? 'The broker keeps configured topics and native exclusions, then removes remaining unused queue stores.'
+            : 'The broker uses the current minimum CommitLog offset to remove fully expired queues. This may include queues belonging to still-configured topics.'}
+        </Typography.Paragraph>
+        {error && <Alert type="error" showIcon message={error} />}
+        {preview && (
+          <>
+            <Typography.Text strong>
+              Currently configured topics ({preview.configuredTopics.length})
+            </Typography.Text>
+            <div
+              style={{
+                maxHeight: 160,
+                overflow: 'auto',
+                border: '1px solid #d9d9d9',
+                borderRadius: 8,
+                padding: 12,
+              }}
+            >
+              {preview.configuredTopics.length
+                ? preview.configuredTopics.map((topic) => (
+                    <div key={topic}>
+                      <Typography.Text code>{topic}</Typography.Text>
+                    </div>
+                  ))
+                : 'No configured topics were returned'}
+            </div>
+            <label>
+              Type the node address to confirm irreversible cleanup
+              <Input
+                aria-label="Node address confirmation"
+                value={confirmation}
+                disabled={busy}
+                onChange={(event) => setConfirmation(event.target.value)}
+                autoComplete="off"
+              />
+            </label>
+          </>
+        )}
+        {receipt && (
+          <Alert
+            type={receipt.status === 'UNKNOWN' ? 'warning' : 'info'}
+            showIcon
+            message={<Tag>{receipt.status}</Tag>}
+            description={
+              receipt.status === 'UNKNOWN'
+                ? 'Check broker logs and storage before another attempt. Cleanup may be partially complete.'
+                : 'The broker reported completion. No deleted-file count or reclaimed-byte measurement is available; verify storage and broker logs.'
+            }
+          />
+        )}
+        <Typography.Text type="secondary">
+          This targets one registered node and does not trigger manual CommitLog deletion. Closing
+          the browser or switching instances cannot stop a cleanup already sent to the broker.
+        </Typography.Text>
+      </Space>
+    </Modal>
+  );
+}

--- a/web/src/components/__tests__/BrokerQueueCleanupDialog.test.tsx
+++ b/web/src/components/__tests__/BrokerQueueCleanupDialog.test.tsx
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { ConfigProvider } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BrokerQueueCleanupDialog } from '../BrokerQueueCleanupDialog';
+import {
+  applyBrokerQueueCleanup,
+  previewBrokerQueueCleanup,
+  type QueueCleanupPreview,
+} from '../../api/brokerQueueCleanup';
+
+vi.mock('../../api/brokerQueueCleanup', () => ({
+  applyBrokerQueueCleanup: vi.fn(),
+  previewBrokerQueueCleanup: vi.fn(),
+}));
+const target = { instanceId: 'instance-a', brokerName: 'broker-a', address: 'master:10911' };
+const sample: QueueCleanupPreview = {
+  brokerName: target.brokerName,
+  address: target.address,
+  sampledAt: '2026-09-08T00:00:00Z',
+  configuredTopics: ['orders', 'payments'],
+};
+const result = {
+  operation: 'UNUSED_TOPIC_QUEUES' as const,
+  brokerName: target.brokerName,
+  address: target.address,
+  status: 'BROKER_REPORTED_COMPLETION' as const,
+  finishedAt: '2026-09-08T00:01:00Z',
+};
+const open = (onClose = vi.fn()) =>
+  render(
+    <ConfigProvider theme={{ token: { motion: false } }}>
+      <BrokerQueueCleanupDialog target={target} onClose={onClose} />
+    </ConfigProvider>,
+  );
+const preview = async () => {
+  fireEvent.click(screen.getByRole('button', { name: /Review node scope/ }));
+  await screen.findByText('orders');
+};
+const confirm = () =>
+  fireEvent.change(screen.getByLabelText('Node address confirmation'), {
+    target: { value: target.address },
+  });
+const apply = () => fireEvent.click(screen.getByRole('button', { name: /Run cleanup/ }));
+
+describe('Broker queue cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(previewBrokerQueueCleanup).mockResolvedValue(sample);
+    vi.mocked(applyBrokerQueueCleanup).mockResolvedValue(result);
+  });
+
+  it('requires scope review and exact node confirmation before sending cleanup', async () => {
+    open();
+    expect(previewBrokerQueueCleanup).not.toHaveBeenCalled();
+    await preview();
+    expect(screen.getByText(/not a list of deletion candidates/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Run cleanup/ })).toBeDisabled();
+    fireEvent.change(screen.getByLabelText('Node address confirmation'), {
+      target: { value: 'other:10911' },
+    });
+    expect(screen.getByRole('button', { name: /Run cleanup/ })).toBeDisabled();
+    confirm();
+    apply();
+    await screen.findByText('BROKER_REPORTED_COMPLETION');
+    expect(applyBrokerQueueCleanup).toHaveBeenCalledWith(
+      target,
+      'UNUSED_TOPIC_QUEUES',
+      ['orders', 'payments'],
+      target.address,
+      expect.any(AbortSignal),
+    );
+    expect(
+      screen.getByText(/No deleted-file count or reclaimed-byte measurement/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Run cleanup/ })).toBeDisabled();
+  });
+
+  it('changing cleanup type consumes both scope review and confirmation', async () => {
+    open();
+    await preview();
+    confirm();
+    fireEvent.click(screen.getByRole('radio', { name: 'Remove expired ConsumeQueues' }));
+    expect(screen.queryByText('orders')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Node address confirmation')).not.toBeInTheDocument();
+    expect(screen.getByText(/still-configured topics/)).toBeInTheDocument();
+    await preview();
+    confirm();
+    apply();
+    await screen.findByText('BROKER_REPORTED_COMPLETION');
+    expect(applyBrokerQueueCleanup).toHaveBeenCalledWith(
+      target,
+      'EXPIRED_CONSUME_QUEUES',
+      ['orders', 'payments'],
+      target.address,
+      expect.any(AbortSignal),
+    );
+  });
+
+  it('locks close and form changes and prevents duplicate cleanup while pending', async () => {
+    let resolve!: (value: typeof result) => void;
+    vi.mocked(applyBrokerQueueCleanup).mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    const close = vi.fn();
+    open(close);
+    await preview();
+    confirm();
+    apply();
+    apply();
+    expect(applyBrokerQueueCleanup).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('radio', { name: 'Remove expired ConsumeQueues' })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(close).not.toHaveBeenCalled();
+    await act(async () => resolve(result));
+  });
+
+  it('does not claim rollback or zero deletions after a lost response', async () => {
+    vi.mocked(applyBrokerQueueCleanup).mockRejectedValue(new Error('timeout'));
+    open();
+    await preview();
+    confirm();
+    apply();
+    await screen.findByText(/some files may already have been removed/);
+    expect(screen.getByRole('button', { name: /Run cleanup/ })).toBeDisabled();
+    expect(screen.queryByLabelText('Node address confirmation')).not.toBeInTheDocument();
+  });
+
+  it('shows an uncertain broker response and requires manual verification', async () => {
+    vi.mocked(applyBrokerQueueCleanup).mockResolvedValue({ ...result, status: 'UNKNOWN' });
+    open();
+    await preview();
+    confirm();
+    apply();
+    await screen.findByText('UNKNOWN');
+    expect(screen.getByText(/Cleanup may be partially complete/)).toBeInTheDocument();
+  });
+
+  it('aborts a pending preview on unmount and ignores late results', async () => {
+    let resolve!: (value: QueueCleanupPreview) => void;
+    vi.mocked(previewBrokerQueueCleanup).mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    const view = open();
+    fireEvent.click(screen.getByRole('button', { name: /Review node scope/ }));
+    const signal = vi.mocked(previewBrokerQueueCleanup).mock.calls[0][1];
+    view.unmount();
+    expect(signal?.aborted).toBe(true);
+    await act(async () => resolve(sample));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -31,6 +31,8 @@ import type { ClusterInfo } from '../../api/cluster';
 import { supportsApacheRuntime, type Instance } from '../../api/instance';
 import { listInstances } from '../../services/instanceService';
 import { useVisiblePolling } from '../../hooks/useVisiblePolling';
+import { BrokerQueueCleanupDialog } from '../../components/BrokerQueueCleanupDialog';
+import type { QueueCleanupTarget } from '../../api/brokerQueueCleanup';
 import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 
 // ─── Types ──────────────────────────────────────────────────────
@@ -190,6 +192,7 @@ const BrokerClusterPage = () => {
   const [proxyData, setProxyData] = useState<ProxyRecord[]>([]);
   const [instances, setInstances] = useState<Instance[]>([]);
   const [selectedInstanceId, setSelectedInstanceId] = useState<string | undefined>(undefined);
+  const [cleanupTarget, setCleanupTarget] = useState<QueueCleanupTarget>();
   const mountedRef = useRef(true);
   const loadRequestId = useRef(0);
   const { t } = useLang();
@@ -325,6 +328,26 @@ const BrokerClusterPage = () => {
     (activeTab === 'broker' && brokerData.length === 0);
 
   const brokerColumns = [
+    {
+      title: 'Maintenance',
+      key: 'queue-cleanup',
+      render: (_: unknown, row: BrokerRecord) => (
+        <Button
+          size="small"
+          disabled={!selectedInstanceId || isMockMode()}
+          onClick={() => {
+            if (selectedInstanceId)
+              setCleanupTarget({
+                instanceId: selectedInstanceId,
+                brokerName: row.brokerName,
+                address: row.address,
+              });
+          }}
+        >
+          Queue cleanup
+        </Button>
+      ),
+    },
     {
       title: t('brokerCluster.k8sCluster'),
       dataIndex: 'k8sCluster',
@@ -521,7 +544,10 @@ const BrokerClusterPage = () => {
           <Select
             aria-label="选择实例"
             value={selectedInstanceId}
-            onChange={setSelectedInstanceId}
+            onChange={(value) => {
+              setCleanupTarget(undefined);
+              setSelectedInstanceId(value);
+            }}
             placeholder="选择实例"
             style={{ minWidth: 180 }}
             options={instances.map((instance) => ({ value: instance.name, label: instance.name }))}
@@ -614,6 +640,13 @@ const BrokerClusterPage = () => {
           />
         </Card>
       </Spin>
+      {cleanupTarget && cleanupTarget.instanceId === selectedInstanceId && (
+        <BrokerQueueCleanupDialog
+          key={cleanupTarget.instanceId + cleanupTarget.address}
+          target={cleanupTarget}
+          onClose={() => setCleanupTarget(undefined)}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
<!-- Make sure the base branch is `master`: that is the RocketMQ Studio trunk. -->

### Which Issue(s) This PR Fixes

- Fixes #4449
- Replaces #4149, closed by the branch switch in #4379.

### Brief Description

This is a resubmission of #4149 against `master`, following the branch switch notice in #4379. The fork branch is unchanged; `master` is now the RocketMQ Studio trunk.

Topic 删除或 CommitLog 保留清理后，Broker 可能仍有需要维护的队列存储。现有界面缺少原生队列清理入口，本 PR 把无用 Topic 队列与过期 ConsumeQueue 清理整合为单节点维护流程，包含范围审阅、明确确认、审计和不确定结果处理。

## 改动说明

- GET 读取所选实例中已登记节点的当前 Topic 配置列表；POST 要求操作类型、已审阅的 Topic 集合和完整节点地址确认。提交前重新核对节点登记和 Topic 名称集合，变化时阻止执行。
- 两种操作分别调用 cleanUnusedTopicByAddr 与 cleanExpiredConsumerQueueByAddr，只针对一个登记节点，不使用集群级遍历接口。
- 原生 API 没有 dry run、删除清单或回收字节数。UI 明确区分配置保留集合与删除候选，不伪造清理收益；成功响应显示 BROKER_REPORTED_COMPLETION，超时或异常显示 UNKNOWN，不自动重试。
- 切换清理类型清除范围与确认；执行期间锁定关闭和编辑，实例切换后丢弃迟到结果。中文文档说明备份、维护窗口、并发变化、不可撤销删除及恢复边界。

协议依据：[DefaultMessageStore.cleanUnusedTopic](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java#L1608) 按配置保留集合删除无用队列，默认实现排除系统 Topic/LMQ；[ConsumeQueueStore.cleanExpired](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java#L558) 按 CommitLog 最小物理位点清理完全过期队列，可能涉及仍配置的 Topic。没有手工删除 CommitLog 的调用。

### How Did You Test This Change?

## 原提交验证记录

本地后端 63 项、前端 23 项测试通过；新增服务 46/46 行、30/34 分支覆盖。Checkstyle、TypeScript/Vite 构建、后端打包通过，ESLint 0 错误、10 条现有告警。浏览器同一脚本明确拦截本地 GET/POST，验证节点、配置列表、确认文本、操作类型及完成回执，没有删除真实 Broker 文件。一次前端测试运行出现异常长耗时和超时，未改超时阈值，单独复跑 6 项弹窗测试通过。

## 兼容性与回滚

无新增依赖或数据库迁移，撤销代码提交可移除入口与接口；已删除数据必须依靠事先验证的备份恢复，撤销代码或重建 Topic 都不能恢复数据。真实存储清理、备份恢复演练、压力、容量和网络分区测试未执行。既有全量测试与依赖审计缺口继续记录。提交含 [skip ci]，未运行远端工作流。核验日期：2026-09-08。

### Checklist

- [x] One coherent change; unrelated modifications are not bundled in
- [x] Commit subject follows Conventional Commits (`feat:` / `fix:` / `refactor:` / `chore:` / `docs:` / `perf:`)
- [x] Tests added or updated for non-trivial changes, test methods named `...Test`
- [x] New UI text has both Chinese and English entries under `web/src/i18n/`, or the change does not add UI text
- [x] Architecture constraints stay green (`mvn test` runs the ArchUnit checks), or the original verification scope is stated above
- [x] New source files carry the ASF license header, or no new source files were added
- [x] Documentation touched where behaviour changed (README / `docs/` / in-app help), or no documentation change was required
