### PR TITLE
feat: inspect and start RocksDB queue write checks

### DIFF
--- a/docs/zh/rocksdb-queue-check.md
+++ b/docs/zh/rocksdb-queue-check.md
@@ -1,0 +1,64 @@
+# RocksDB 双写队列检查
+
+## 使用场景
+
+在文件 ConsumeQueue 与 RocksDB ConsumeQueue 双写迁移期间，管理员需要检查
+两种存储的索引写入进度。Broker 集群页的 `RocksDB check` 为单个已登记节点
+提供配置审阅、单 Topic 检查提交和日志定位信息。
+
+该功能不切换存储、不修复索引，也不修改双写配置。检查本身会访问存储、占用异步工作线程，
+可能创建比较存储的队列对象，因此启动检查使用管理员 POST，预览使用 GET。
+
+## 操作流程
+
+1. 选择 Apache 实例，在目标 Broker 地址行打开检查窗口。
+2. 点击 `Read storage scope`，读取该节点登记、双写配置和已配置 Topic。
+3. 选择一个 Topic，输入正整数 Unix 毫秒时间。默认值为打开窗口前十分钟。
+4. 确认节点、Topic、检查时间及扫描负载后点击 `Start check`。
+5. 保存回执中的节点、Topic、检查时间、提交及响应时间，到该 Broker 日志查看结果。
+
+预览只接受明确的 `rocksdbCQDoubleWriteEnable` 布尔值及可读取的
+`combineCQLoadingCQTypes`。只有双写启用且包含 `default`、`defaultRocksDB`
+两种存储才允许提交；提交前重新读取配置，变化时要求重新审阅。
+配置反映当前属性，不能证明正在运行的具体存储实现，应同时核对版本与启动日志。
+
+Topic 必须仍在所选节点配置中；不支持空 Topic 代表全集群或全部 Topic 的隐式扫描。
+接口使用实例既有认证客户端，不接受未登记节点地址，不自动转向其它副本。
+
+## 检查时间的含义
+
+官方实现以 RocksDB 存储时间查找队列位点，并取它与最小保留位点的较大值，
+向文件 ConsumeQueue 的当前末尾逐条比较物理位点、大小、标签及批次信息。
+时间查找异常可能回退到最小保留位点；早于检查时间的队尾可能直接跳过。
+因此时间参数既不是精确工作量上限，也不代表完整历史审计或原子快照。
+
+时间越早可能扫描越多数据。应先在测试集群测量负载，在维护窗口选择适当时间，
+避免并发启动多个检查。界面没有调度、后台轮询、取消或自动重试。
+关闭页面只能中止浏览器等待，不能取消已经受理的 Broker 任务。
+
+## 回执与结果
+
+| 回执 | 含义与下一步 |
+| --- | --- |
+| `ACCEPTED` | Broker 原始状态为 2，异步检查已受理；尚无一致性结论 |
+| `BROKER_RESPONSE` | 返回其它原始状态及详情；保留协议值，不据此宣称索引健康 |
+| `UNKNOWN` | 无响应或通信异常；检查可能已启动，先查日志再决定是否重提 |
+
+在提交时间附近搜索 `checkRocksdbCqWriteProgress result:` 以及
+`checkRocksdbCqWriteProgress error`。原生 API 不返回任务 ID，也没有查询最终结果接口；
+并发任务日志可能重叠，不能用时间戳伪造唯一关联。
+原生日志中的 0、1、2、3 分别表示检查通过、不通过、检查中和错误。
+非组合存储、缺少比较存储也可能产生“无需检查”的状态 0，应读取详情而非仅看数字。
+
+## 验证与回滚
+
+本地测试覆盖节点登记、配置变化、Topic 删除、时间边界、超时与中断、审计失败、
+管理员权限、HTTP 契约、确认失效及组件卸载。浏览器通过本地拦截验证请求，未对真实 Broker 扫描。
+真实双写集群的索引差异、日志关联、插件兼容性、性能、容量及故障注入尚未验证。
+
+无新增依赖、数据库迁移或配置迁移。撤销提交即可移除入口；已经启动的原生检查
+没有取消接口，撤销代码不能停止它。检查不提供修复操作，发现差异后需按存储迁移方案处理。
+
+核验日期：2026-09-08。依据 RocketMQ 5.5.0 的
+[AdminBrokerProcessor](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java#L482)
+与 [CombineConsumeQueueStore](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/store/src/main/java/org/apache/rocketmq/store/queue/CombineConsumeQueueStore.java#L456)。

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerRocksdbCheckController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerRocksdbCheckController.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.Result;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/brokers/rocksdb-check")
+public class BrokerRocksdbCheckController {
+    private final BrokerRocksdbCheckService service;
+
+    @GetMapping
+    public Result<BrokerRocksdbCheckService.Preview> preview(@RequestParam String instanceId,
+            @RequestParam String brokerName, @RequestParam String address) {
+        return Result.ok(service.preview(instanceId, brokerName, address));
+    }
+
+    @PostMapping
+    public Result<BrokerRocksdbCheckService.Receipt> submit(@RequestBody BrokerRocksdbCheckService.Request request) {
+        return Result.ok(service.submit(request));
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerRocksdbCheckService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerRocksdbCheckService.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class BrokerRocksdbCheckService {
+    private final RuntimeAdminClientResolver resolver;
+    private final OperationAuditService audit;
+
+    public record Settings(boolean doubleWriteEnabled, List<String> loadingStores) { }
+    public record Preview(String brokerName, String address, Instant sampledAt, Settings settings,
+            boolean eligible, List<String> topics) { }
+    public record Request(String instanceId, String brokerName, String address, String topic,
+            String checkFromMillis, Settings expectedSettings, boolean confirmed) { }
+    public record Receipt(String brokerName, String address, String topic, String checkFromMillis,
+            String status, Integer brokerStatus, String brokerRemark, Instant submittedAt, Instant receivedAt) { }
+
+    public Preview preview(String instanceId, String brokerName, String address) {
+        validate(brokerName, address);
+        return resolver.execute(instanceId, admin -> {
+            try {
+                return inspect(admin, brokerName, address);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new BusinessException(502, "RocksDB check preview was interrupted");
+            }
+        });
+    }
+
+    public Receipt submit(Request request) {
+        validate(request.brokerName(), request.address());
+        if (!StringUtils.hasText(request.topic()) || !request.confirmed() || request.expectedSettings() == null) {
+            throw new BusinessException(400, "Select one topic, review storage settings and confirm the scan");
+        }
+        long checkpoint;
+        try {
+            if (request.checkFromMillis() == null || !request.checkFromMillis().matches("[0-9]+")) {
+                throw new NumberFormatException();
+            }
+            checkpoint = Long.parseLong(request.checkFromMillis());
+            if (checkpoint <= 0 || checkpoint > System.currentTimeMillis()) {
+                throw new NumberFormatException();
+            }
+        } catch (NumberFormatException exception) {
+            throw new BusinessException(400, "Check start must be positive epoch milliseconds in the past");
+        }
+        return resolver.execute(request.instanceId(), admin -> {
+            Preview current;
+            try {
+                current = inspect(admin, request.brokerName(), request.address());
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new BusinessException(502, "RocksDB check preflight was interrupted");
+            }
+            if (!current.eligible() || !current.settings().equals(request.expectedSettings())) {
+                throw new BusinessException(409, "Double-write storage settings are unsupported or changed; review again");
+            }
+            if (!current.topics().contains(request.topic())) {
+                throw new BusinessException(409, "Selected topic is no longer configured on this broker");
+            }
+            Instant submittedAt = Instant.now();
+            Integer brokerStatus = null;
+            String remark = null;
+            try {
+                var response = admin.checkRocksdbCqWriteProgress(request.address(), request.topic(), checkpoint);
+                if (response != null) {
+                    brokerStatus = response.getCheckStatus();
+                    remark = response.getCheckResult();
+                }
+            } catch (Exception exception) {
+                // A lost response does not prove the broker's asynchronous worker was not started.
+                if (exception instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            String status = brokerStatus == null ? "UNKNOWN" : brokerStatus == 2 ? "ACCEPTED" : "BROKER_RESPONSE";
+            audit.record("CHECK_ROCKSDB_QUEUE_PROGRESS", "BROKER", request.brokerName(), request.instanceId(),
+                    "address=" + request.address() + ", topic=" + request.topic() + ", checkFromMillis=" + checkpoint,
+                    status, brokerStatus == null ? "Check broker logs before submitting another scan" : null);
+            return new Receipt(request.brokerName(), request.address(), request.topic(), Long.toString(checkpoint),
+                    status, brokerStatus, remark, submittedAt, Instant.now());
+        });
+    }
+
+    private Preview inspect(MQAdminExt admin, String brokerName, String address) throws Exception {
+        var cluster = admin.examineBrokerClusterInfo();
+        if (cluster == null || cluster.getBrokerAddrTable() == null) {
+            throw new BusinessException(502, "Broker registry is unavailable");
+        }
+        var broker = cluster.getBrokerAddrTable().get(brokerName);
+        if (broker == null || broker.getBrokerAddrs() == null || !broker.getBrokerAddrs().containsValue(address)) {
+            throw new BusinessException(404, "Broker address is not registered in the selected instance");
+        }
+        var config = admin.getBrokerConfig(address);
+        String enabled = config == null ? null : config.getProperty("rocksdbCQDoubleWriteEnable");
+        String stores = config == null ? null : config.getProperty("combineCQLoadingCQTypes");
+        if (!("true".equalsIgnoreCase(enabled) || "false".equalsIgnoreCase(enabled)) || stores == null) {
+            throw new BusinessException(502, "RocksDB double-write configuration is unavailable");
+        }
+        var settings = new Settings(Boolean.parseBoolean(enabled), Arrays.stream(stores.split(";"))
+                .map(String::trim).filter(StringUtils::hasText).distinct().sorted().toList());
+        var topics = admin.getAllTopicConfig(address, 5000);
+        if (topics == null || topics.getTopicConfigTable() == null) {
+            throw new BusinessException(502, "Configured topics are unavailable");
+        }
+        boolean eligible = settings.doubleWriteEnabled()
+                && settings.loadingStores().containsAll(List.of("default", "defaultRocksDB"));
+        return new Preview(brokerName, address, Instant.now(), settings, eligible,
+                topics.getTopicConfigTable().keySet().stream().sorted().toList());
+    }
+
+    private void validate(String brokerName, String address) {
+        if (!StringUtils.hasText(brokerName) || !StringUtils.hasText(address)) {
+            throw new BusinessException(400, "Broker name and registered address are required");
+        }
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
@@ -573,6 +573,22 @@ class AuthInterceptorTest {
         assertThat(allowed).isTrue();
     }
 
+    @Test
+    void rocksdbCheckRequiresAdmin() throws Exception {
+        var session = login(false);
+        var response = new MockHttpServletResponse();
+        assertThat(session.interceptor().preHandle(authenticatedRequest("POST", "/api/brokers/rocksdb-check",
+                session.token()), response, new Object())).isFalse();
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void rocksdbCheckAllowsAdmin() throws Exception {
+        var session = login(true);
+        assertThat(session.interceptor().preHandle(authenticatedRequest("POST", "/api/brokers/rocksdb-check",
+                session.token()), new MockHttpServletResponse(), new Object())).isTrue();
+    }
+
     private TestSession login(boolean admin) {
         AuthProperties properties = new AuthProperties();
         properties.setLoginRequired(true);

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/BrokerRocksdbCheckServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/BrokerRocksdbCheckServiceTest.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import org.apache.rocketmq.common.CheckRocksdbCqWriteResult;
+import org.apache.rocketmq.common.TopicConfig;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.body.TopicConfigSerializeWrapper;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.studio.persistence.entity.RmqOperationAudit;
+import org.apache.rocketmq.studio.persistence.mapper.RmqOperationAuditMapper;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class BrokerRocksdbCheckServiceTest {
+    private final DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+    private final InstanceRepository repository = mock(InstanceRepository.class);
+    private final RmqOperationAuditMapper audits = mock(RmqOperationAuditMapper.class);
+    private final ClusterInfo cluster = new ClusterInfo();
+    private final TopicConfigSerializeWrapper topics = new TopicConfigSerializeWrapper();
+    private final Properties config = new Properties();
+    private BrokerRocksdbCheckService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        var factory = new MqAdminExtFactory() {
+            @Override
+            protected DefaultMQAdminExt newAdmin(RPCHook hook) { return admin; }
+        };
+        service = new BrokerRocksdbCheckService(new RuntimeAdminClientResolver(repository, factory,
+                new MqAdminProperties(), mock(MqClientPool.class)), new OperationAuditService(audits));
+        when(repository.findByIdentifier("instance-a")).thenReturn(Optional.of(
+                InstanceVO.builder().endpoint("ns-a:9876").vendor(InstanceVendor.APACHE).build()));
+        cluster.setBrokerAddrTable(new HashMap<>());
+        cluster.getBrokerAddrTable().put("broker-a", new BrokerData("cluster-a", "broker-a",
+                new HashMap<>(Map.of(0L, "master:10911", 1L, "replica:10911"))));
+        when(admin.examineBrokerClusterInfo()).thenReturn(cluster);
+        topics.getTopicConfigTable().put("orders", new TopicConfig("orders"));
+        topics.getTopicConfigTable().put("payments", new TopicConfig("payments"));
+        when(admin.getAllTopicConfig("master:10911", 5000)).thenReturn(topics);
+        config.setProperty("rocksdbCQDoubleWriteEnable", "true");
+        config.setProperty("combineCQLoadingCQTypes", "default;defaultRocksDB");
+        when(admin.getBrokerConfig("master:10911")).thenReturn(config);
+        var result = new CheckRocksdbCqWriteResult();
+        result.setCheckStatus(2);
+        when(admin.checkRocksdbCqWriteProgress("master:10911", "orders", 1000L)).thenReturn(result);
+    }
+
+    private BrokerRocksdbCheckService.Preview preview() {
+        return service.preview("instance-a", "broker-a", "master:10911");
+    }
+
+    private BrokerRocksdbCheckService.Request request() {
+        return new BrokerRocksdbCheckService.Request("instance-a", "broker-a", "master:10911", "orders",
+                "1000", preview().settings(), true);
+    }
+
+    @Test
+    void readsOnlySelectedNodeConfigurationWithoutStartingScan() throws Exception {
+        assertThat(preview().topics()).containsExactly("orders", "payments");
+        assertThat(preview().eligible()).isTrue();
+        verify(admin, never()).checkRocksdbCqWriteProgress(anyString(), anyString(), org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    void acceptedIsOnlyAnAsyncReceiptWithExactScopeAndAudit() throws Exception {
+        var result = service.submit(request());
+        assertThat(result.status()).isEqualTo("ACCEPTED");
+        assertThat(result.brokerStatus()).isEqualTo(2);
+        assertThat(result.checkFromMillis()).isEqualTo("1000");
+        assertThat(result.submittedAt()).isBeforeOrEqualTo(result.receivedAt());
+        verify(admin).checkRocksdbCqWriteProgress("master:10911", "orders", 1000L);
+        verify(audits).insert(any(RmqOperationAudit.class));
+    }
+
+    @Test
+    void disabledOrIncompleteStoreConfigurationCannotStart() {
+        var request = request();
+        config.setProperty("rocksdbCQDoubleWriteEnable", "false");
+        assertThat(preview().eligible()).isFalse();
+        assertThatThrownBy(() -> service.submit(request)).hasMessageContaining("unsupported or changed");
+        config.setProperty("rocksdbCQDoubleWriteEnable", "true");
+        config.setProperty("combineCQLoadingCQTypes", "default");
+        assertThat(preview().eligible()).isFalse();
+        assertThatThrownBy(() -> service.submit(request)).hasMessageContaining("unsupported or changed");
+    }
+
+    @Test
+    void settingsAndTopicAreRecheckedBeforeSubmission() throws Exception {
+        var request = request();
+        config.setProperty("combineCQLoadingCQTypes", "default;defaultRocksDB;futureStore");
+        assertThatThrownBy(() -> service.submit(request)).hasMessageContaining("changed");
+        config.setProperty("combineCQLoadingCQTypes", "default;defaultRocksDB");
+        topics.getTopicConfigTable().remove("orders");
+        assertThatThrownBy(() -> service.submit(request)).hasMessageContaining("no longer configured");
+        verify(admin, never()).checkRocksdbCqWriteProgress(anyString(), anyString(), org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    void missingMetadataIsNotHealthyOrEligible() throws Exception {
+        config.remove("rocksdbCQDoubleWriteEnable");
+        assertThatThrownBy(this::preview).hasMessageContaining("configuration is unavailable");
+        config.setProperty("rocksdbCQDoubleWriteEnable", "invalid");
+        assertThatThrownBy(this::preview).hasMessageContaining("configuration is unavailable");
+        config.setProperty("rocksdbCQDoubleWriteEnable", "true");
+        when(admin.getAllTopicConfig("master:10911", 5000)).thenReturn(null);
+        assertThatThrownBy(this::preview).hasMessageContaining("topics are unavailable");
+        when(admin.getBrokerConfig("master:10911")).thenReturn(null);
+        assertThatThrownBy(this::preview).hasMessageContaining("configuration is unavailable");
+    }
+
+    @Test
+    void validatesExplicitConfirmationAndOneTopic() {
+        var settings = preview().settings();
+        assertThatThrownBy(() -> service.submit(new BrokerRocksdbCheckService.Request("instance-a", "broker-a",
+                "master:10911", "", "1000", settings, true))).hasMessageContaining("Select one topic");
+        assertThatThrownBy(() -> service.submit(new BrokerRocksdbCheckService.Request("instance-a", "broker-a",
+                "master:10911", "orders", "1000", settings, false))).hasMessageContaining("confirm");
+        assertThatThrownBy(() -> service.submit(new BrokerRocksdbCheckService.Request("instance-a", "broker-a",
+                "master:10911", "orders", "1000", null, true))).hasMessageContaining("review");
+    }
+
+    @Test
+    void rejectsInvalidFutureOrOverflowingCheckpointWithoutTruncation() {
+        var settings = preview().settings();
+        for (String time : new String[] {null, "", "1.5", "-1", "0", "9223372036854775808", "9223372036854775807"}) {
+            assertThatThrownBy(() -> service.submit(new BrokerRocksdbCheckService.Request("instance-a", "broker-a",
+                    "master:10911", "orders", time, settings, true))).hasMessageContaining("epoch milliseconds");
+        }
+    }
+
+    @Test
+    void removedRegistrationCannotRetargetAScan() throws Exception {
+        var request = request();
+        cluster.getBrokerAddrTable().clear();
+        assertThatThrownBy(() -> service.submit(request)).hasMessageContaining("not registered");
+        when(admin.examineBrokerClusterInfo()).thenReturn(null);
+        assertThatThrownBy(this::preview).hasMessageContaining("registry is unavailable");
+        assertThatThrownBy(() -> service.preview("instance-a", "", "master:10911")).hasMessageContaining("required");
+    }
+
+    @Test
+    void unexpectedNativeStatusIsPreservedWithoutClaimingConsistency() throws Exception {
+        var response = new CheckRocksdbCqWriteResult();
+        response.setCheckStatus(0);
+        response.setCheckResult("No store to compare");
+        when(admin.checkRocksdbCqWriteProgress("master:10911", "orders", 1000L)).thenReturn(response);
+        var receipt = service.submit(request());
+        assertThat(receipt.status()).isEqualTo("BROKER_RESPONSE");
+        assertThat(receipt.brokerStatus()).isZero();
+        assertThat(receipt.brokerRemark()).isEqualTo("No store to compare");
+    }
+
+    @Test
+    void lostOrMissingResponseIsUnknownAndNeverRetried() throws Exception {
+        when(admin.checkRocksdbCqWriteProgress("master:10911", "orders", 1000L)).thenReturn(null);
+        assertThat(service.submit(request()).status()).isEqualTo("UNKNOWN");
+        doThrow(new org.apache.rocketmq.remoting.exception.RemotingTimeoutException("master:10911", 5000))
+                .when(admin).checkRocksdbCqWriteProgress("master:10911", "orders", 1000L);
+        assertThat(service.submit(request()).status()).isEqualTo("UNKNOWN");
+        verify(admin, org.mockito.Mockito.times(2)).checkRocksdbCqWriteProgress("master:10911", "orders", 1000L);
+    }
+
+    @Test
+    void auditFailureDoesNotLoseAnAcceptedResponse() {
+        doThrow(new IllegalStateException("audit unavailable")).when(audits).insert(any(RmqOperationAudit.class));
+        assertThat(service.submit(request()).status()).isEqualTo("ACCEPTED");
+    }
+
+    @Test
+    void interruptedReadsAndSubmissionRestoreFlag() throws Exception {
+        var request = request();
+        doThrow(new InterruptedException()).when(admin).examineBrokerClusterInfo();
+        try {
+            assertThatThrownBy(this::preview).hasMessageContaining("preview was interrupted");
+            assertThat(Thread.interrupted()).isTrue();
+            assertThatThrownBy(() -> service.submit(request)).hasMessageContaining("preflight was interrupted");
+            assertThat(Thread.interrupted()).isTrue();
+            org.mockito.Mockito.doReturn(cluster).when(admin).examineBrokerClusterInfo();
+            doThrow(new InterruptedException()).when(admin).checkRocksdbCqWriteProgress("master:10911", "orders", 1000L);
+            assertThat(service.submit(request).status()).isEqualTo("UNKNOWN");
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void httpContractSeparatesPreviewAndSubmission() throws Exception {
+        var mvc = MockMvcBuilders.standaloneSetup(new BrokerRocksdbCheckController(service)).build();
+        mvc.perform(get("/api/brokers/rocksdb-check").param("instanceId", "instance-a")
+                        .param("brokerName", "broker-a").param("address", "master:10911"))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.data.eligible").value(true));
+        mvc.perform(post("/api/brokers/rocksdb-check").contentType("application/json")
+                        .content(new ObjectMapper().writeValueAsString(request())))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.data.status").value("ACCEPTED"));
+    }
+}

--- a/web/src/api/brokerRocksdbCheck.test.ts
+++ b/web/src/api/brokerRocksdbCheck.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import { beforeEach, expect, it, vi } from 'vitest';
+import client from './client';
+import { previewRocksdbCheck, submitRocksdbCheck } from './brokerRocksdbCheck';
+vi.mock('./client', () => ({ default: { get: vi.fn(), post: vi.fn() } }));
+beforeEach(() => vi.clearAllMocks());
+const target = { instanceId: 'a', brokerName: 'broker-a', address: 'master:10911' };
+it('uses GET only for scope inspection', async () => {
+  vi.mocked(client.get).mockResolvedValue({ data: { data: { eligible: true } } });
+  const signal = new AbortController().signal;
+  expect(await previewRocksdbCheck(target, signal)).toEqual({ eligible: true });
+  expect(client.get).toHaveBeenCalledWith('/brokers/rocksdb-check', { params: target, signal });
+  expect(client.post).not.toHaveBeenCalled();
+});
+it('posts an explicit single-topic request with the original checkpoint text', async () => {
+  vi.mocked(client.post).mockResolvedValue({ data: { data: { status: 'ACCEPTED' } } });
+  const settings = { doubleWriteEnabled: true, loadingStores: ['default', 'defaultRocksDB'] };
+  const signal = new AbortController().signal;
+  expect(await submitRocksdbCheck(target, 'orders', '1000', settings, signal)).toEqual({
+    status: 'ACCEPTED',
+  });
+  expect(client.post).toHaveBeenCalledWith(
+    '/brokers/rocksdb-check',
+    {
+      ...target,
+      topic: 'orders',
+      checkFromMillis: '1000',
+      expectedSettings: settings,
+      confirmed: true,
+    },
+    { signal, timeout: 0 },
+  );
+});

--- a/web/src/api/brokerRocksdbCheck.ts
+++ b/web/src/api/brokerRocksdbCheck.ts
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import client from './client';
+export interface RocksdbCheckTarget {
+  instanceId: string;
+  brokerName: string;
+  address: string;
+}
+export interface RocksdbSettings {
+  doubleWriteEnabled: boolean;
+  loadingStores: string[];
+}
+export interface RocksdbCheckPreview {
+  brokerName: string;
+  address: string;
+  sampledAt: string;
+  settings: RocksdbSettings;
+  eligible: boolean;
+  topics: string[];
+}
+export interface RocksdbCheckReceipt {
+  brokerName: string;
+  address: string;
+  topic: string;
+  checkFromMillis: string;
+  status: 'ACCEPTED' | 'UNKNOWN' | 'BROKER_RESPONSE';
+  brokerStatus: number | null;
+  brokerRemark: string | null;
+  submittedAt: string;
+  receivedAt: string;
+}
+export async function previewRocksdbCheck(params: RocksdbCheckTarget, signal?: AbortSignal) {
+  const response = await client.get<{ data: RocksdbCheckPreview }>('/brokers/rocksdb-check', {
+    params,
+    signal,
+  });
+  return response.data.data;
+}
+export async function submitRocksdbCheck(
+  target: RocksdbCheckTarget,
+  topic: string,
+  checkFromMillis: string,
+  expectedSettings: RocksdbSettings,
+  signal?: AbortSignal,
+) {
+  const response = await client.post<{ data: RocksdbCheckReceipt }>(
+    '/brokers/rocksdb-check',
+    { ...target, topic, checkFromMillis, expectedSettings, confirmed: true },
+    { signal, timeout: 0 },
+  );
+  return response.data.data;
+}

--- a/web/src/components/BrokerRocksdbCheckDialog.tsx
+++ b/web/src/components/BrokerRocksdbCheckDialog.tsx
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import { useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Descriptions,
+  Input,
+  Modal,
+  Select,
+  Space,
+  Typography,
+} from 'antd';
+import {
+  previewRocksdbCheck,
+  submitRocksdbCheck,
+  type RocksdbCheckPreview,
+  type RocksdbCheckReceipt,
+  type RocksdbCheckTarget,
+} from '../api/brokerRocksdbCheck';
+
+export default function BrokerRocksdbCheckDialog({
+  target,
+  onClose,
+}: {
+  target: RocksdbCheckTarget;
+  onClose: () => void;
+}) {
+  const [preview, setPreview] = useState<RocksdbCheckPreview>();
+  const [receipt, setReceipt] = useState<RocksdbCheckReceipt>();
+  const [topic, setTopic] = useState<string>();
+  const [checkpoint, setCheckpoint] = useState(() => String(Date.now() - 600000));
+  const [validationTime, setValidationTime] = useState(() => Date.now());
+  const [confirmed, setConfirmed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string>();
+  const busyRef = useRef(false);
+  const active = useRef(true);
+  const abort = useRef<AbortController>();
+  useEffect(() => {
+    active.current = true;
+    return () => {
+      active.current = false;
+      abort.current?.abort();
+    };
+  }, []);
+  const run = async (submit: boolean) => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setBusy(true);
+    setError(undefined);
+    setReceipt(undefined);
+    abort.current = new AbortController();
+    try {
+      if (submit && preview && topic && confirmed) {
+        const settings = preview.settings;
+        setPreview(undefined);
+        setConfirmed(false);
+        const value = await submitRocksdbCheck(
+          target,
+          topic,
+          checkpoint,
+          settings,
+          abort.current.signal,
+        );
+        if (active.current) setReceipt(value);
+      } else if (!submit) {
+        setPreview(undefined);
+        setConfirmed(false);
+        const value = await previewRocksdbCheck(target, abort.current.signal);
+        if (active.current) {
+          setPreview(value);
+          setTopic(undefined);
+        }
+      }
+    } catch (failure) {
+      if (active.current)
+        setError(
+          submit
+            ? 'Submission outcome is unknown. Check broker logs before starting another scan.'
+            : failure instanceof Error
+              ? failure.message
+              : 'Storage preview failed',
+        );
+    } finally {
+      if (active.current) {
+        busyRef.current = false;
+        setBusy(false);
+      }
+    }
+  };
+  const validTime =
+    /^[0-9]+$/.test(checkpoint) &&
+    Number.isSafeInteger(Number(checkpoint)) &&
+    Number(checkpoint) > 0 &&
+    Number(checkpoint) <= validationTime;
+  return (
+    <Modal
+      open
+      title="RocksDB queue write check"
+      width={780}
+      style={{ top: 24 }}
+      onCancel={() => {
+        if (!busyRef.current) onClose();
+      }}
+      closable={!busy}
+      maskClosable={!busy}
+      keyboard={!busy}
+      footer={
+        <Space>
+          <Button disabled={busy} onClick={onClose}>
+            Close
+          </Button>
+          <Button loading={busy} disabled={busy} onClick={() => void run(false)}>
+            Read storage scope
+          </Button>
+          <Button
+            type="primary"
+            loading={busy}
+            disabled={busy || !preview?.eligible || !topic || !validTime || !confirmed}
+            onClick={() => void run(true)}
+          >
+            Start check
+          </Button>
+        </Space>
+      }
+    >
+      <Space
+        direction="vertical"
+        style={{ width: '100%', maxHeight: 'calc(100vh - 210px)', overflowY: 'auto' }}
+        size="middle"
+      >
+        <Typography.Text code>
+          {target.brokerName} / {target.address}
+        </Typography.Text>
+        <Alert
+          type="info"
+          showIcon
+          message="Results are written to broker logs"
+          description="This command starts an asynchronous scan. The native API provides no task ID, result polling or cancellation. An accepted response does not mean the indexes match."
+        />
+        {error && <Alert type="error" message={error} />}
+        {preview && (
+          <>
+            <Descriptions
+              size="small"
+              column={1}
+              bordered
+              items={[
+                {
+                  key: 'enabled',
+                  label: 'Double write',
+                  children: String(preview.settings.doubleWriteEnabled),
+                },
+                {
+                  key: 'stores',
+                  label: 'Configured stores',
+                  children: preview.settings.loadingStores.join(', '),
+                },
+                { key: 'time', label: 'Sampled at', children: preview.sampledAt },
+              ]}
+            />
+            {!preview.eligible && (
+              <Alert
+                type="warning"
+                message="Requires double write with default and defaultRocksDB stores"
+                description="Configuration alone cannot prove the running store implementation. Verify the broker version and startup logs."
+              />
+            )}
+            <label htmlFor="rocksdb-check-topic">Topic on this node</label>
+            <Select
+              id="rocksdb-check-topic"
+              aria-label="Topic on this node"
+              showSearch
+              style={{ width: '100%' }}
+              value={topic}
+              disabled={busy || !preview.eligible}
+              options={preview.topics.map((value) => ({ value, label: value }))}
+              onChange={(value) => {
+                setTopic(value);
+                setConfirmed(false);
+                setReceipt(undefined);
+              }}
+            />
+            <label htmlFor="rocksdb-check-time">Check from store time (epoch milliseconds)</label>
+            <Input
+              id="rocksdb-check-time"
+              value={checkpoint}
+              disabled={busy}
+              onChange={(event) => {
+                setCheckpoint(event.target.value);
+                setValidationTime(Date.now());
+                setConfirmed(false);
+                setReceipt(undefined);
+              }}
+            />
+            {!validTime && (
+              <Typography.Text type="danger">
+                Enter positive epoch milliseconds in the past.
+              </Typography.Text>
+            )}
+            <Alert
+              type="warning"
+              message="Plan for storage I/O"
+              description="The broker compares retained queue entries from the checkpoint toward its current end. An older time can scan more data. The checkpoint is not an exact bound or an atomic snapshot; time lookup may fall back to the retained start."
+            />
+            <Checkbox
+              checked={confirmed}
+              disabled={busy || !preview.eligible || !topic || !validTime}
+              onChange={(event) => setConfirmed(event.target.checked)}
+            >
+              I reviewed this node, topic, checkpoint and scan load.
+            </Checkbox>
+          </>
+        )}
+        {receipt && (
+          <>
+            <Alert
+              type={receipt.status === 'ACCEPTED' ? 'info' : 'warning'}
+              message={receipt.status}
+              description="This is the command response, not a verified consistency result. Check the selected broker's logs before another submission."
+            />
+            <Descriptions
+              bordered
+              size="small"
+              column={1}
+              items={[
+                { key: 'topic', label: 'Topic', children: receipt.topic },
+                {
+                  key: 'checkpoint',
+                  label: 'Store-time checkpoint',
+                  children: receipt.checkFromMillis,
+                },
+                {
+                  key: 'status',
+                  label: 'Raw broker status',
+                  children: receipt.brokerStatus ?? 'Unavailable',
+                },
+                { key: 'submitted', label: 'Submitted at', children: receipt.submittedAt },
+                { key: 'received', label: 'Response received at', children: receipt.receivedAt },
+                {
+                  key: 'remark',
+                  label: 'Broker response detail',
+                  children: receipt.brokerRemark || 'No synchronous detail',
+                },
+              ]}
+            />
+            <Typography.Paragraph copyable code>
+              checkRocksdbCqWriteProgress result:
+            </Typography.Paragraph>
+            <Typography.Text>
+              Search this marker and checkRocksdbCqWriteProgress error on the selected node around
+              the submission time. There is no unique task identifier; concurrent scans may have
+              overlapping log entries.
+            </Typography.Text>
+          </>
+        )}
+      </Space>
+    </Modal>
+  );
+}

--- a/web/src/components/__tests__/BrokerRocksdbCheckDialog.test.tsx
+++ b/web/src/components/__tests__/BrokerRocksdbCheckDialog.test.tsx
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { ConfigProvider } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BrokerRocksdbCheckDialog from '../BrokerRocksdbCheckDialog';
+import {
+  previewRocksdbCheck,
+  submitRocksdbCheck,
+  type RocksdbCheckPreview,
+} from '../../api/brokerRocksdbCheck';
+
+vi.mock('../../api/brokerRocksdbCheck', () => ({
+  previewRocksdbCheck: vi.fn(),
+  submitRocksdbCheck: vi.fn(),
+}));
+const target = { instanceId: 'instance-a', brokerName: 'broker-a', address: 'master:10911' };
+const sample: RocksdbCheckPreview = {
+  brokerName: target.brokerName,
+  address: target.address,
+  sampledAt: '2026-09-08T00:00:00Z',
+  eligible: true,
+  topics: ['orders'],
+  settings: { doubleWriteEnabled: true, loadingStores: ['default', 'defaultRocksDB'] },
+};
+const result = {
+  brokerName: target.brokerName,
+  address: target.address,
+  topic: 'orders',
+  checkFromMillis: '1000',
+  status: 'ACCEPTED' as const,
+  brokerStatus: 2,
+  brokerRemark: null,
+  submittedAt: '2026-09-08T00:00:00Z',
+  receivedAt: '2026-09-08T00:00:01Z',
+};
+const open = (onClose = vi.fn()) =>
+  render(
+    <ConfigProvider theme={{ token: { motion: false } }}>
+      <BrokerRocksdbCheckDialog target={target} onClose={onClose} />
+    </ConfigProvider>,
+  );
+async function review() {
+  fireEvent.click(screen.getByRole('button', { name: /Read storage scope/ }));
+  await screen.findByText('Double write');
+  fireEvent.mouseDown(screen.getByRole('combobox'));
+  fireEvent.click(document.querySelector('.ant-select-item-option-content')!);
+  fireEvent.change(screen.getByLabelText('Check from store time (epoch milliseconds)'), {
+    target: { value: '1000' },
+  });
+}
+const confirm = () => fireEvent.click(screen.getByRole('checkbox'));
+const submit = () => fireEvent.click(screen.getByRole('button', { name: /Start check/ }));
+
+describe('RocksDB queue check', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    vi.mocked(previewRocksdbCheck).mockResolvedValue(sample);
+    vi.mocked(submitRocksdbCheck).mockResolvedValue(result);
+  });
+  it('requires explicit review and returns an accepted receipt without claiming a match', async () => {
+    open();
+    expect(previewRocksdbCheck).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /Start check/ })).toBeDisabled();
+    await review();
+    confirm();
+    submit();
+    await screen.findByText('ACCEPTED');
+    expect(submitRocksdbCheck).toHaveBeenCalledWith(
+      target,
+      'orders',
+      '1000',
+      sample.settings,
+      expect.any(AbortSignal),
+    );
+    expect(screen.getByText(/not a verified consistency result/)).toBeInTheDocument();
+    expect(screen.getByText('checkRocksdbCqWriteProgress result:')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Start check/ })).toBeDisabled();
+  });
+  it('clears confirmation when the checkpoint changes and rejects invalid time', async () => {
+    open();
+    await review();
+    confirm();
+    fireEvent.change(screen.getByLabelText('Check from store time (epoch milliseconds)'), {
+      target: { value: '9223372036854775807' },
+    });
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+    expect(screen.getByRole('button', { name: /Start check/ })).toBeDisabled();
+    expect(screen.getByText('Enter positive epoch milliseconds in the past.')).toBeInTheDocument();
+  });
+  it('blocks unsupported storage instead of interpreting a no-op check as healthy', async () => {
+    vi.mocked(previewRocksdbCheck).mockResolvedValue({ ...sample, eligible: false });
+    open();
+    fireEvent.click(screen.getByRole('button', { name: /Read storage scope/ }));
+    await screen.findByText(/Requires double write/);
+    expect(screen.getByRole('button', { name: /Start check/ })).toBeDisabled();
+    expect(submitRocksdbCheck).not.toHaveBeenCalled();
+  });
+  it('locks submission and close while the command is pending', async () => {
+    let resolve!: (value: typeof result) => void;
+    vi.mocked(submitRocksdbCheck).mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    const close = vi.fn();
+    open(close);
+    await review();
+    confirm();
+    submit();
+    submit();
+    expect(submitRocksdbCheck).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(close).not.toHaveBeenCalled();
+    await act(async () => resolve(result));
+  });
+  it('keeps a lost response uncertain and consumes the review to prevent immediate retry', async () => {
+    vi.mocked(submitRocksdbCheck).mockRejectedValue(new Error('timeout'));
+    open();
+    await review();
+    confirm();
+    submit();
+    await screen.findByText(/Submission outcome is unknown/);
+    expect(screen.getByRole('button', { name: /Start check/ })).toBeDisabled();
+    expect(submitRocksdbCheck).toHaveBeenCalledTimes(1);
+  });
+  it('aborts pending reads when leaving the selected instance', async () => {
+    let resolve!: (value: RocksdbCheckPreview) => void;
+    vi.mocked(previewRocksdbCheck).mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    const view = open();
+    fireEvent.click(screen.getByRole('button', { name: /Read storage scope/ }));
+    const signal = vi.mocked(previewRocksdbCheck).mock.calls[0][1];
+    view.unmount();
+    expect(signal?.aborted).toBe(true);
+    await act(async () => resolve(sample));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -24,6 +24,9 @@ import {
   DownloadSimple,
   PlugsConnected,
 } from '@phosphor-icons/react';
+import BrokerRocksdbCheckDialog from '../../components/BrokerRocksdbCheckDialog';
+import type { RocksdbCheckTarget } from '../../api/brokerRocksdbCheck';
+import type { ColumnsType } from 'antd/es/table';
 import { useLang } from '../../i18n/LangContext';
 import { listClusters } from '../../services/clusterService';
 import { isMockMode } from '../../services/dataMode';
@@ -189,6 +192,7 @@ const BrokerClusterPage = () => {
   const [nameServerData, setNameServerData] = useState<NameServerRecord[]>([]);
   const [proxyData, setProxyData] = useState<ProxyRecord[]>([]);
   const [instances, setInstances] = useState<Instance[]>([]);
+  const [rocksdbTarget, setRocksdbTarget] = useState<RocksdbCheckTarget>();
   const [selectedInstanceId, setSelectedInstanceId] = useState<string | undefined>(undefined);
   const mountedRef = useRef(true);
   const loadRequestId = useRef(0);
@@ -324,7 +328,7 @@ const BrokerClusterPage = () => {
     (activeTab === 'proxy' && proxyData.length === 0) ||
     (activeTab === 'broker' && brokerData.length === 0);
 
-  const brokerColumns = [
+  const brokerColumns: ColumnsType<BrokerRecord> = [
     {
       title: t('brokerCluster.k8sCluster'),
       dataIndex: 'k8sCluster',
@@ -387,6 +391,26 @@ const BrokerClusterPage = () => {
       sorter: (a: BrokerRecord, b: BrokerRecord) => (a.tpsOut ?? -1) - (b.tpsOut ?? -1),
     },
   ];
+
+  brokerColumns.push({
+    title: 'Storage diagnostics',
+    key: 'rocksdbCheck',
+    render: (_: unknown, record: BrokerRecord) =>
+      !isMockMode() && selectedInstanceId ? (
+        <Button
+          size="small"
+          onClick={() =>
+            setRocksdbTarget({
+              instanceId: selectedInstanceId,
+              brokerName: record.brokerName,
+              address: record.address,
+            })
+          }
+        >
+          RocksDB check
+        </Button>
+      ) : null,
+  });
 
   const nsColumns = [
     {
@@ -521,7 +545,10 @@ const BrokerClusterPage = () => {
           <Select
             aria-label="选择实例"
             value={selectedInstanceId}
-            onChange={setSelectedInstanceId}
+            onChange={(value) => {
+              setRocksdbTarget(undefined);
+              setSelectedInstanceId(value);
+            }}
             placeholder="选择实例"
             style={{ minWidth: 180 }}
             options={instances.map((instance) => ({ value: instance.name, label: instance.name }))}
@@ -614,6 +641,13 @@ const BrokerClusterPage = () => {
           />
         </Card>
       </Spin>
+      {rocksdbTarget && rocksdbTarget.instanceId === selectedInstanceId && (
+        <BrokerRocksdbCheckDialog
+          key={`${rocksdbTarget.instanceId}/${rocksdbTarget.address}`}
+          target={rocksdbTarget}
+          onClose={() => setRocksdbTarget(undefined)}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
<!-- Make sure the base branch is `master`: that is the RocketMQ Studio trunk. -->

### Which Issue(s) This PR Fixes

- Fixes #4451
- Replaces #4150, closed by the branch switch in #4379.

### Brief Description

This is a resubmission of #4150 against `master`, following the branch switch notice in #4379. The fork branch is unchanged; `master` is now the RocketMQ Studio trunk.

文件与 RocksDB ConsumeQueue 双写迁移期间需要检查索引写入进度。新增单节点、单 Topic 的原生检查入口，整合存储配置审阅、时间范围选择、管理员确认、异步回执和日志定位。

## 改动说明

GET 只读已登记节点的双写配置与 Topic；POST 重新校验节点、配置及 Topic，调用 checkRocksdbCqWriteProgress。只允许双写开启且两种存储均配置的节点；检查时间保持毫秒字符串，拒绝未来时间与溢出。操作经过管理员权限与安全审计，通信中断保留 UNKNOWN，不自动重试。

官方接口立即返回状态 2，最终结果只写 Broker 日志，没有任务 ID、轮询或取消接口。UI 的 ACCEPTED 仅表示受理，其它原始状态原样保留，不把“无需检查”误报为索引一致。提交消耗预览，修改检查条件清除确认，实例切换中止等待并丢弃迟到响应。中文文档解释时间查找回退、扫描负载、非原子采样与日志关联限制。

协议依据：[AdminBrokerProcessor](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java#L482) 的异步工作线程与 [CombineConsumeQueueStore](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/store/src/main/java/org/apache/rocketmq/store/queue/CombineConsumeQueueStore.java#L456) 的逐条比较行为。

### How Did You Test This Change?

## 原提交验证记录

本地后端 64、前端 23 项测试通过；服务行覆盖率 67/67、分支 56/62。Checkstyle、TypeScript/Vite 构建、后端打包通过，ESLint 0 错误、10 条现有告警。浏览器同一脚本校验 localhost 并精确拦截 GET/POST，验证单 Topic、时间参数、已审阅配置和 ACCEPTED 回执，未启动真实 Broker 扫描。

## 兼容性与回滚

无新增依赖或数据库迁移；撤销代码提交可移除入口，无法取消已受理的原生任务。真实双写差异、日志关联、插件、性能、容量和故障注入未验证。既有全量测试与依赖审计缺口继续披露，按用户授权逐项增量验证提交，不宣称全量门槛通过。提交含 [skip ci]，未运行远端工作流。核验日期：2026-09-08。

### Checklist

- [x] One coherent change; unrelated modifications are not bundled in
- [x] Commit subject follows Conventional Commits (`feat:` / `fix:` / `refactor:` / `chore:` / `docs:` / `perf:`)
- [x] Tests added or updated for non-trivial changes, test methods named `...Test`
- [x] New UI text has both Chinese and English entries under `web/src/i18n/`, or the change does not add UI text
- [x] Architecture constraints stay green (`mvn test` runs the ArchUnit checks), or the original verification scope is stated above
- [x] New source files carry the ASF license header, or no new source files were added
- [x] Documentation touched where behaviour changed (README / `docs/` / in-app help), or no documentation change was required
